### PR TITLE
Implement hackathon project detail page

### DIFF
--- a/src/app/modules/hackathons/config/routes.ts
+++ b/src/app/modules/hackathons/config/routes.ts
@@ -24,6 +24,14 @@ export default [
     }
   },
   {
+    path: 'hackathon/:id/projects/:symbol',
+    loadComponent: () => import('@hackathons/ui/pages/hackathon-project/hackathon-project.page').then(m => m.HackathonProjectPage),
+    data: { title: 'Projects.Project' },
+    resolve: {
+      hackathon: hackathonResolver,
+    }
+  },
+  {
     path: 'hackathon/:id/attempts',
     loadComponent: () => import('@hackathons/ui/pages/hackathon-attempts/hackathon-attempts.page').then(m => m.HackathonAttemptsPage),
     data: { title: 'Hackathons.HackathonAttempts' },

--- a/src/app/modules/hackathons/ui/pages/hackathon-project/hackathon-project.page.html
+++ b/src/app/modules/hackathons/ui/pages/hackathon-project/hackathon-project.page.html
@@ -1,0 +1,27 @@
+<div class="content-wrapper container-xxl p-0">
+  <div class="content-body">
+    @if (isLoading) {
+      <div class="card" [style.height.px]="400">
+        <spinner></spinner>
+      </div>
+    } @else {
+      <app-content-header [contentHeader]="contentHeader" />
+
+      <section class="mt-2">
+        <div class="row">
+          <div class="col-lg-9 col-md-12 col-sm-12">
+            <project-description [project]="data.project" />
+
+            <div class="mt-2">
+              <project-attempts [project]="data.project" [hackathonId]="hackathonId" />
+            </div>
+          </div>
+
+          <div class="col-lg-3 col-md-12 col-sm-12">
+            <project-sidebar [project]="data.project" [hackathonId]="hackathonId" [projectSymbol]="data.symbol" (submitEvent)="reloadAttempts()" />
+          </div>
+        </div>
+      </section>
+    }
+  </div>
+</div>

--- a/src/app/modules/hackathons/ui/pages/hackathon-project/hackathon-project.page.scss
+++ b/src/app/modules/hackathons/ui/pages/hackathon-project/hackathon-project.page.scss
@@ -1,0 +1,3 @@
+.card-header {
+  padding-bottom: 0 !important;
+}

--- a/src/app/modules/hackathons/ui/pages/hackathon-project/hackathon-project.page.ts
+++ b/src/app/modules/hackathons/ui/pages/hackathon-project/hackathon-project.page.ts
@@ -1,0 +1,72 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { Observable } from 'rxjs';
+import { BaseLoadComponent } from '@app/common';
+import { ContentHeader } from '@shared/ui/components/content-header/content-header.component';
+import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
+import { CoreCommonModule } from '@core/common.module';
+import { TranslateModule } from '@ngx-translate/core';
+import { HackathonsApiService } from '@hackathons/data-access/hackathons-api.service';
+import { HackathonProject } from '@hackathons/domain';
+import { ProjectDescriptionComponent } from '@projects/ui/components/project-description/project-description.component';
+import { ProjectSidebarComponent } from '@projects/ui/components/project-sidebar/project-sidebar.component';
+import { ProjectAttemptsComponent } from '@projects/ui/components/project-attempts/project-attempts.component';
+
+@Component({
+  selector: 'hackathon-project',
+  templateUrl: './hackathon-project.page.html',
+  styleUrls: ['./hackathon-project.page.scss'],
+  standalone: true,
+  imports: [
+    CoreCommonModule,
+    ContentHeaderModule,
+    TranslateModule,
+    ProjectDescriptionComponent,
+    ProjectSidebarComponent,
+    ProjectAttemptsComponent
+  ]
+})
+export class HackathonProjectPage extends BaseLoadComponent<HackathonProject> implements OnInit {
+  public hackathonId: number;
+  public symbol: string;
+
+  @ViewChild(ProjectAttemptsComponent) attemptsComponent: ProjectAttemptsComponent;
+
+  constructor(private hackathonsApiService: HackathonsApiService) {
+    super();
+  }
+
+  override ngOnInit(): void {
+    this.route.params.subscribe(params => {
+      this.hackathonId = +params['id'];
+      this.symbol = params['symbol'];
+      this.loadData();
+      this.loadContentHeader();
+    });
+  }
+
+  getData(): Observable<HackathonProject> {
+    return this.hackathonsApiService.getHackathonProject(this.hackathonId, this.symbol);
+  }
+
+  override afterLoadData(data: HackathonProject) {
+    this.titleService.updateTitle(this.route, { projectTitle: data.project.title });
+  }
+
+  protected getContentHeader(): ContentHeader {
+    return {
+      headerTitle: this.data?.project.title ?? 'Project',
+      breadcrumb: {
+        type: '',
+        links: [
+          { name: 'Hackathons', isLink: true, link: '../../..' },
+          { name: this.hackathonId + '', isLink: true, link: '..' },
+          { name: this.symbol, isLink: false }
+        ]
+      }
+    };
+  }
+
+  reloadAttempts() {
+    this.attemptsComponent?.reloadPage();
+  }
+}

--- a/src/app/modules/projects/data-access/api/projects-api.service.ts
+++ b/src/app/modules/projects/data-access/api/projects-api.service.ts
@@ -36,4 +36,16 @@ export class ProjectsApiService {
     formData.append('technology', technology);
     return this.api.post(`projects/${projectSlug}/submit`, formData);
   }
+
+  submitHackathonAttempt(
+    hackathonId: number | string,
+    projectSymbol: string,
+    technology: string,
+    file: File
+  ): Observable<any> {
+    const formData = new FormData();
+    formData.append('file', file, file.name);
+    formData.append('technology', technology);
+    return this.api.post(`hackathons/${hackathonId}/projects/${projectSymbol}/submit`, formData);
+  }
 }

--- a/src/app/modules/projects/data-access/repositories/project-attempts.repository.ts
+++ b/src/app/modules/projects/data-access/repositories/project-attempts.repository.ts
@@ -33,4 +33,13 @@ export class ProjectAttemptsRepository implements BaseRepository<ProjectAttemptD
   ) {
     return this.projectsApiService.submitAttempt(projectSlug, technology, file);
   }
+
+  submitHackathonAttempt(
+    hackathonId: number | string,
+    projectSymbol: string,
+    technology: string,
+    file: File
+  ) {
+    return this.projectsApiService.submitHackathonAttempt(hackathonId, projectSymbol, technology, file);
+  }
 }

--- a/src/app/modules/projects/ui/components/project-attempts/project-attempts.component.ts
+++ b/src/app/modules/projects/ui/components/project-attempts/project-attempts.component.ts
@@ -26,6 +26,7 @@ export class ProjectAttemptsComponent extends BaseTablePageComponent<ProjectAtte
   override maxSize = 5;
 
   @Input() project: Project;
+  @Input() hackathonId?: number;
   public myAttempts = true;
 
   constructor(public repository: ProjectAttemptsRepository) {
@@ -41,16 +42,17 @@ export class ProjectAttemptsComponent extends BaseTablePageComponent<ProjectAtte
   }
 
   getPage(): Observable<PageResult<ProjectAttempt>> {
+    const params: any = {
+      page: this.pageNumber,
+      project_id: this.project.id,
+    };
+    if (this.hackathonId) {
+      params.hackathonId = this.hackathonId;
+    }
     if (this.myAttempts && this.currentUser) {
-      return this.repository.listByUsername(this.currentUser.username, {
-        page: this.pageNumber,
-        project_id: this.project.id
-      });
+      return this.repository.listByUsername(this.currentUser.username, params);
     } else {
-      return this.repository.list({
-        page: this.pageNumber,
-        project_id: this.project.id
-      });
+      return this.repository.list(params);
     }
   }
 

--- a/src/app/modules/projects/ui/components/project-sidebar/project-sidebar.component.ts
+++ b/src/app/modules/projects/ui/components/project-sidebar/project-sidebar.component.ts
@@ -22,6 +22,8 @@ import { ProjectInfoCardComponent } from "@projects/ui/components/project-info-c
 })
 export class ProjectSidebarComponent implements OnInit {
   @Input() project: Project;
+  @Input() hackathonId?: number;
+  @Input() projectSymbol?: string;
   @Output() submitEvent = new EventEmitter<any>();
 
   public selectedTechnology: string;
@@ -47,11 +49,17 @@ export class ProjectSidebarComponent implements OnInit {
     if (!this.selectedTechnology || !this.fileToUpload) {
       return;
     }
-    this.projectAttemptsRepository.submitAttempt(this.project.slug, this.selectedTechnology, this.fileToUpload).subscribe(
-      () => {
-        this.submitEvent.emit();
-        this.toastr.success('Submitted');
-      }
-    );
+    const tech = this.selectedTechnology;
+    const file = this.fileToUpload;
+    let submit$;
+    if (this.hackathonId && this.projectSymbol) {
+      submit$ = this.projectAttemptsRepository.submitHackathonAttempt(this.hackathonId, this.projectSymbol, tech, file);
+    } else {
+      submit$ = this.projectAttemptsRepository.submitAttempt(this.project.slug, tech, file);
+    }
+    submit$.subscribe(() => {
+      this.submitEvent.emit();
+      this.toastr.success('Submitted');
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add route for hackathon project details
- allow submitting attempts for hackathon projects
- add optional hackathon support in project attempts and sidebar components
- implement new HackathonProjectPage with attempts below description

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npm run lint --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cf0c89f64832fbf9f8ae1614932bb