### PR TITLE
Fix hackathon countdown labels

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -533,6 +533,10 @@ export const localeEn = {
     REGISTRANTS_COUNT: 'Number of registrants',
     CONTESTANT: 'Participant',
     POINTS: 'Points',
+    HACKATHON_ENDS: 'Hackathon ends in',
+    HACKATHON_STARTS: 'Hackathon starts in',
+    HACKATHON_FINISHED: 'Hackathon finished',
+    HACKATHON_STARTED: 'Hackathon started',
   },
   USER_INFO: {
     ABOUT: 'About',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -529,6 +529,10 @@ export const localeRu = {
     REGISTRANTS_COUNT: 'Количество зарегистрировавшихся',
     CONTESTANT: 'Участник',
     POINTS: 'Очки',
+    HACKATHON_ENDS: 'Хакатон завершится',
+    HACKATHON_STARTS: 'Хакатон начнется',
+    HACKATHON_FINISHED: 'Хакатон завершен',
+    HACKATHON_STARTED: 'Хакатон начался',
   },
   USER_INFO: {
     ABOUT: 'О себе',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -532,6 +532,10 @@ export const localeUz = {
     REGISTRANTS_COUNT: 'Ro\'yhatdan o\'tganlar soni',
     CONTESTANT: 'Ishtirokchi',
     POINTS: 'Ballar',
+    HACKATHON_ENDS: 'Xakaton yakunlanishiga',
+    HACKATHON_STARTS: 'Xakaton boshlanishiga',
+    HACKATHON_FINISHED: 'Xakaton yakunlandi',
+    HACKATHON_STARTED: 'Xakaton boshlandi',
   },
   USER_INFO: {
     ABOUT: 'Oʻzi haqida',

--- a/src/app/modules/hackathons/ui/components/hackathon-countdown-card/hackathon-countdown-card.component.html
+++ b/src/app/modules/hackathons/ui/components/hackathon-countdown-card/hackathon-countdown-card.component.html
@@ -1,18 +1,18 @@
 <kep-card [customClass]="'overlay-card'">
-  <img class="card-img" [src]="hackathon.logo" height="200">
+  <img class="card-img" [src]="hackathon.logo" height="200" #hackathonLogo>
 
   <div class="card-img-overlay d-flex flex-column p-0" style="justify-content: space-evenly;">
     <div class="card-header my-1 justify-content-center" style="border-block-end: none !important;">
       <h6 class="text-uppercase">
         @switch (hackathon.status) {
-          @case (ContestStatus.ALREADY) {
-            {{ 'CONTESTS.CONTEST_ENDS' | translate }}
+          @case (HackathonStatus.ALREADY) {
+            {{ 'HACKATHONS.HACKATHON_ENDS' | translate }}
           }
-          @case (ContestStatus.FINISHED) {
-            {{ 'CONTESTS.CONTEST_FINISHED' | translate }}
+          @case (HackathonStatus.FINISHED) {
+            {{ 'HACKATHONS.HACKATHON_FINISHED' | translate }}
           }
-          @case (ContestStatus.NOT_STARTED) {
-            {{ 'CONTESTS.CONTEST_STARTS' | translate }}
+          @case (HackathonStatus.NOT_STARTED) {
+            {{ 'HACKATHONS.HACKATHON_STARTS' | translate }}
           }
         }
       </h6>
@@ -22,7 +22,7 @@
         [clockColor]="'#fff'"
         [hackathon]="hackathon"
         [textColor]="'#fff'"/>
-      @if (hackathon.status == ContestStatus.FINISHED) {
+      @if (hackathon.status == HackathonStatus.FINISHED) {
         <h5
           class="text-center mt-1">
           {{ hackathon.finishTime | localizedDate:'medium' }}

--- a/src/app/modules/hackathons/ui/components/hackathon-countdown-card/hackathon-countdown-card.component.ts
+++ b/src/app/modules/hackathons/ui/components/hackathon-countdown-card/hackathon-countdown-card.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, Input, ViewChild } from '@angular/core';
-import { ContestStatus } from '@contests/constants/contest-status';
+import { HackathonStatus } from '@hackathons/domain/constants/hackathon-status';
 import { Hackathon } from "@hackathons/domain";
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
 import { HackathonCountdownComponent } from "../hackathon-countdown/hackathon-countdown.component";
@@ -21,15 +21,15 @@ import { TranslatePipe } from "@ngx-translate/core";
 export class HackathonCountdownCardComponent {
   @Input() hackathon: Hackathon;
 
-  @ViewChild('contestLogo') contestLogoRef: ElementRef<HTMLImageElement>;
+  @ViewChild('hackathonLogo') hackathonLogoRef: ElementRef<HTMLImageElement>;
 
   public logoWidth: number;
   public logoHeight: number;
 
-  protected readonly ContestStatus = ContestStatus;
+  protected readonly HackathonStatus = HackathonStatus;
 
   onLoad(event: any) {
-    this.logoHeight = this.contestLogoRef.nativeElement.naturalHeight;
-    this.logoWidth = this.contestLogoRef.nativeElement.naturalWidth;
+    this.logoHeight = this.hackathonLogoRef.nativeElement.naturalHeight;
+    this.logoWidth = this.hackathonLogoRef.nativeElement.naturalWidth;
   }
 }


### PR DESCRIPTION
## Summary
- update hackathon countdown card to use `HackathonStatus`
- show hackathon-specific countdown texts
- localize hackathon countdown messages in all languages

## Testing
- `npm run lint` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e0c1d2eb8832f82cc6b2295a09efe