### PR TITLE
Refactor kepcoin module

### DIFF
--- a/src/app/modules/kepcoin/components/earns-list/earns-list.component.html
+++ b/src/app/modules/kepcoin/components/earns-list/earns-list.component.html
@@ -1,0 +1,81 @@
+<div>
+  <ul class="timeline">
+    @for (earn of earns; track earn) {
+      <li class="timeline-item">
+        <span class="timeline-point timeline-point-warning timeline-point-indicator"></span>
+        <div class="timeline-event">
+          <div class="d-flex justify-content-between flex-sm-row flex-column mb-sm-0 mb-1">
+            <h6>
+              <img height="19" src="assets/images/icons/kepcoin.png">{{ earn.kepcoin }}
+            </h6>
+            <span class="timeline-event-time">{{ earn.datetime }}</span>
+          </div>
+          <p>
+            <span class="text-dark">
+              @switch (earn.earnType) {
+                @case (EarnType.WroteBlog) {
+                  <span>{{ 'WroteBlog' | translate }}</span>
+                }
+                @case (EarnType.WroteProblemSolution) {
+                  <span>{{ 'WroteProblemSolution' | translate }}</span>
+                }
+                @case (EarnType.LoyaltyBonus) {
+                  <span>{{ 'LoyaltyBonus' | translate }}</span>
+                }
+                @case (EarnType.BonusFromAdmin) {
+                  <span>{{ 'BonusFromAdmin' | translate }}</span>
+                }
+                @case (EarnType.DailyActivity) {
+                  <span>
+                    {{ 'DailyActivity' | translate }}: <u class="text-primary">{{ earn.detail.date }}</u>
+                  </span>
+                }
+                @case (EarnType.DailyTaskCompletion) {
+                  <span>
+                    {{ 'DailyTaskCompleted' | translate }}: <u class="text-primary">{{ earn.detail.description }}</u>
+                  </span>
+                }
+                @case (EarnType.DailyProblemsRatingWin) {
+                  <span>
+                    {{ 'DailyRatingWinner' | translate }}: <u class="text-primary">{{ earn.detail.date }}</u>
+                  </span>
+                }
+                @case (EarnType.WeeklyProblemsRatingWin) {
+                  <span>
+                    {{ 'WeeklyRatingWinner' | translate }}: <u class="text-primary">{{ earn.detail.date }}</u>
+                  </span>
+                }
+                @case (EarnType.MonthlyProblemsRatingWin) {
+                  <span>
+                    {{ 'MonthlyRatingWinner' | translate }}: <u class="text-primary">{{ earn.detail.date }}</u>
+                  </span>
+                }
+                @case (EarnType.ContestParticipated) {
+                  <span>
+                    {{ 'ContestParticipant' | translate }}: <a [routerLink]="['/competitions', 'contests', 'contest', earn.detail.contest.id]">
+                    <u class="text-primary">{{ earn.detail.contest.title }}</u>
+                  </a>
+                  </span>
+                }
+                @case (EarnType.ArenaParticipated) {
+                  <span>
+                    {{ 'ArenaParticipant' | translate }}: <a [routerLink]="['/competitions', 'arena', 'tournament', earn.detail.arena.id]">
+                    <u class="text-primary">{{ earn.detail.arena.title }}</u>
+                  </a>
+                  </span>
+                }
+                @case (EarnType.TournamentParticipated) {
+                  <span>{{ 'TournamentParticipant' | translate }}</span>
+                }
+                @case (EarnType.ProjectTaskComplete) {
+                  <span>{{ 'ProjectTaskComplete' | translate }}</span>
+                }
+              }
+            </span>
+          </p>
+          <div class="d-flex align-items-center"></div>
+        </div>
+      </li>
+    }
+  </ul>
+</div>

--- a/src/app/modules/kepcoin/components/earns-list/earns-list.component.ts
+++ b/src/app/modules/kepcoin/components/earns-list/earns-list.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { CoreCommonModule } from '@core/common.module';
+import { CoreDirectivesModule } from '@shared/directives/directives.module';
+import { EarnType } from '../../enums';
+
+@Component({
+  selector: 'kepcoin-earns-list',
+  standalone: true,
+  imports: [CoreCommonModule, RouterLink, CoreDirectivesModule],
+  templateUrl: './earns-list.component.html'
+})
+export class EarnsListComponent {
+  @Input() earns: any[] = [];
+  EarnType = EarnType;
+}

--- a/src/app/modules/kepcoin/components/how-to-earn-kepcoin/how-to-earn-kepcoin.component.html
+++ b/src/app/modules/kepcoin/components/how-to-earn-kepcoin/how-to-earn-kepcoin.component.html
@@ -1,0 +1,42 @@
+<kep-card>
+  <div class="card-header">
+    <div class="card-title">
+      <i data-feather="dollar-sign"></i>
+      {{ 'HowToEarnKepcoin' | translate }}
+    </div>
+  </div>
+
+  <div class="card-body text-dark">
+    {{ 'EarnDescription' | translate }}
+
+    <div class="earn">
+      <kepcoin [value]="1"></kepcoin>
+      : {{ 'EarnItem1' | translate }}
+    </div>
+
+    <div class="earn">
+      <kepcoin [value]="'1-10'"></kepcoin>
+      : {{ 'EarnItem2' | translate }}
+    </div>
+
+    <div class="earn">
+      <kepcoin [value]="'3, 10, 50'"></kepcoin>
+      : {{ 'EarnItem3' | translate }}
+    </div>
+
+    <div class="earn">
+      <kepcoin [value]="'5+'"></kepcoin>
+      : {{ 'EarnItem4' | translate }}
+    </div>
+
+    <div class="earn">
+      <kepcoin [value]="'10-100'"></kepcoin>
+      : {{ 'EarnItem5' | translate }}
+    </div>
+
+    <div class="earn">
+      <kepcoin [value]="'1-50'"></kepcoin>
+      : {{ 'EarnItem6' | translate }}
+    </div>
+  </div>
+</kep-card>

--- a/src/app/modules/kepcoin/components/how-to-earn-kepcoin/how-to-earn-kepcoin.component.ts
+++ b/src/app/modules/kepcoin/components/how-to-earn-kepcoin/how-to-earn-kepcoin.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CoreCommonModule } from '@core/common.module';
+import { KepcoinViewModule } from '@shared/components/kepcoin-view/kepcoin-view.module';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+
+@Component({
+  selector: 'how-to-earn-kepcoin',
+  standalone: true,
+  imports: [CoreCommonModule, KepcoinViewModule, KepCardComponent],
+  templateUrl: './how-to-earn-kepcoin.component.html'
+})
+export class HowToEarnKepcoinComponent {}

--- a/src/app/modules/kepcoin/components/how-to-spend-kepcoin/how-to-spend-kepcoin.component.html
+++ b/src/app/modules/kepcoin/components/how-to-spend-kepcoin/how-to-spend-kepcoin.component.html
@@ -1,0 +1,55 @@
+<kep-card>
+  <div class="card-header">
+    <div class="card-title">
+      <i data-feather="coffee"></i>
+      {{ 'HowToSpendKepcoin' | translate }}
+    </div>
+  </div>
+
+  <div class="card-body text-dark">
+    <div class="spend">
+      <kepcoin [value]="'0-14'"></kepcoin>
+      : {{ 'SpendItem1' | translate }}
+    </div>
+
+    <div class="spend">
+      <kepcoin [value]="1"></kepcoin>
+      : {{ 'SpendItem2' | translate }}
+    </div>
+
+    <div class="spend">
+      <kepcoin [value]="'2-50'"></kepcoin>
+      : {{ 'SpendItem3' | translate }}
+    </div>
+
+    <div class="spend">
+      <kepcoin [value]="5"></kepcoin>
+      : {{ 'SpendItem4' | translate }}
+    </div>
+
+    <div class="spend">
+      <kepcoin [value]="1"></kepcoin>
+      : {{ 'SpendItem5' | translate }}
+    </div>
+
+    <div class="spend">
+      <kepcoin [value]="'1-1000'"></kepcoin>
+      : {{ 'SpendItem6' | translate }}
+    </div>
+
+    <div class="spend">
+      <kepcoin [value]="'50'"></kepcoin>
+      : {{ 'SpendItem7' | translate }}
+    </div>
+
+    <div class="spend">
+      <kepcoin [value]="25"></kepcoin>
+      : {{ 'SpendItem8' | translate }}
+    </div>
+
+    <div class="spend">
+      <kepcoin [value]="25"></kepcoin>
+      : {{ 'SpendItem9' | translate }}
+    </div>
+  </div>
+</kep-card>

--- a/src/app/modules/kepcoin/components/how-to-spend-kepcoin/how-to-spend-kepcoin.component.ts
+++ b/src/app/modules/kepcoin/components/how-to-spend-kepcoin/how-to-spend-kepcoin.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CoreCommonModule } from '@core/common.module';
+import { KepcoinViewModule } from '@shared/components/kepcoin-view/kepcoin-view.module';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+
+@Component({
+  selector: 'how-to-spend-kepcoin',
+  standalone: true,
+  imports: [CoreCommonModule, KepcoinViewModule, KepCardComponent],
+  templateUrl: './how-to-spend-kepcoin.component.html'
+})
+export class HowToSpendKepcoinComponent {}

--- a/src/app/modules/kepcoin/components/spends-list/spends-list.component.html
+++ b/src/app/modules/kepcoin/components/spends-list/spends-list.component.html
@@ -1,0 +1,97 @@
+<div>
+  <ul class="timeline">
+    @for (spend of spends; track spend) {
+      <li class="timeline-item">
+        <span class="timeline-point timeline-point-warning timeline-point-indicator"></span>
+        <div class="timeline-event">
+          <div class="d-flex justify-content-between flex-sm-row flex-column mb-sm-0 mb-1">
+            <h6>
+              <img height="19" src="assets/images/icons/kepcoin.png">{{ spend.kepcoin }}
+            </h6>
+            <span class="timeline-event-time">{{ spend.datetime }}</span>
+          </div>
+          <p>
+            <span class="text-dark">
+              @switch (spend.type) {
+                @case (SpendType.AttemptView) {
+                  <span>
+                    {{ 'ViewAttempt' | translate }} <a class="text-primary" routerLink="/practice/problems/attempts/{{ spend.detail.attemptId }}">
+                    <u>{{ spend.detail.attemptId }}</u>
+                  </a>
+                  </span>
+                }
+                @case (SpendType.AttemptTestView) {
+                  <span>
+                    {{ 'ViewTestAttempt' | translate }} <a class="text-primary" routerLink="/practice/problems/attempts/{{ spend.detail.attemptId }}">
+                    <u>{{ spend.detail.attemptId }}</u>
+                  </a>
+                  </span>
+                }
+                @case (SpendType.ProblemSolution) {
+                  <span>
+                    {{ 'ViewProblemSolution' | translate }} <a class="text-primary" routerLink="/practice/problems/problem/{{ spend.detail.problemId }}">
+                    <u>{{ spend.detail.problemId }}. {{ spend.detail.problemTitle }}</u>
+                  </a>
+                  </span>
+                }
+                @case (SpendType.DoubleRating) {
+                  <span>{{ 'DoubleRating' | translate }}</span>
+                }
+                @case (SpendType.CoverPhotoChange) {
+                  <span>
+                    {{ 'ChangeImage' | translate }}
+                    <img src="{{ spend.detail.coverPhoto }}" style="width: 100%;">
+                  </span>
+                }
+                @case (SpendType.Course) {
+                  <span>{{ 'Course' | translate }}</span>
+                }
+                @case (SpendType.StudyPlan) {
+                  <span>{{ 'StudyPlan' | translate }}</span>
+                }
+                @case (SpendType.CodeEditorTesting) {
+                  <span>{{ 'CodeEditorTesting' | translate }}</span>
+                }
+                @case (SpendType.SaveRating) {
+                  <span>{{ 'SaveRating' | translate }}</span>
+                }
+                @case (SpendType.TestPass) {
+                  <span>
+                    {{ 'PassTest' | translate }} <a class="text-primary" routerLink="/practice/tests/test/{{ spend.detail.test.id }}">
+                    <u>{{ spend.detail.test.title }}</u>
+                  </a>
+                  </span>
+                }
+                @case (SpendType.UserContestCreate) {
+                  <span>{{ 'CreateContest' | translate }}</span>
+                }
+                @case (SpendType.Project) {
+                  <span>{{ 'Project' | translate }}</span>
+                }
+                @case (SpendType.StreakFreeze) {
+                  <span>{{ 'StreakFreeze' | translate }}</span>
+                }
+                @case (SpendType.VirtualContest) {
+                  <span>{{ 'VirtualContest' | translate }}</span>
+                }
+                @case (SpendType.UnratedContest) {
+                  <span>{{ 'UnratedContest' | translate }}</span>
+                }
+                @case (SpendType.AnswerForInput) {
+                  <span>{{ 'AnswerForInput' | translate }}</span>
+                }
+                @case (SpendType.CheckSamples) {
+                  <span>{{ 'CheckSamples' | translate }}</span>
+                }
+                @case (SpendType.Merch) {
+                  <span>{{ 'Merch' | translate }}</span>
+                }
+              }
+            </span>
+          </p>
+          <div class="d-flex align-items-center"></div>
+        </div>
+      </li>
+    }
+  </ul>
+</div>

--- a/src/app/modules/kepcoin/components/spends-list/spends-list.component.ts
+++ b/src/app/modules/kepcoin/components/spends-list/spends-list.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { CoreCommonModule } from '@core/common.module';
+import { CoreDirectivesModule } from '@shared/directives/directives.module';
+import { SpendType } from '../../enums';
+
+@Component({
+  selector: 'kepcoin-spends-list',
+  standalone: true,
+  imports: [CoreCommonModule, RouterLink, CoreDirectivesModule],
+  templateUrl: './spends-list.component.html'
+})
+export class SpendsListComponent {
+  @Input() spends: any[] = [];
+  SpendType = SpendType;
+}

--- a/src/app/modules/kepcoin/components/you-have-card/you-have-card.component.html
+++ b/src/app/modules/kepcoin/components/you-have-card/you-have-card.component.html
@@ -1,0 +1,20 @@
+<div class="card bg-kepcoin">
+  <div class="card-header">
+    <div class="card-title">
+      <i data-feather="cloud-snow"></i>
+      {{ 'StreakFreeze' | translate }}
+    </div>
+    <div>
+      <img [src]="streak > 0 ? 'assets/images/icons/fire_red.png' : 'assets/images/icons/fire_blue.png'" height="19">
+      <strong>{{ streak }}</strong>
+      <span class="badge me-1 ms-1 bg-warning">
+        {{ 'YouHave' | translate }} <strong>{{ streakFreeze }}</strong>
+      </span>
+      <kepcoin-spend-swal [value]="10" [purchaseUrl]="'purchase-streak-freeze'" (success)="buy.emit()"></kepcoin-spend-swal>
+    </div>
+  </div>
+
+  <div class="card-body">
+    <p>{{ 'StreakFreezeText' | translate }}</p>
+  </div>
+</div>

--- a/src/app/modules/kepcoin/components/you-have-card/you-have-card.component.ts
+++ b/src/app/modules/kepcoin/components/you-have-card/you-have-card.component.ts
@@ -1,0 +1,15 @@
+import { Component, EventEmitter, Output, Input } from '@angular/core';
+import { CoreCommonModule } from '@core/common.module';
+import { KepcoinSpendSwalModule } from '@shared/components/kepcoin-spend-swal/kepcoin-spend-swal.module';
+
+@Component({
+  selector: 'you-have-card',
+  standalone: true,
+  imports: [CoreCommonModule, KepcoinSpendSwalModule],
+  templateUrl: './you-have-card.component.html'
+})
+export class YouHaveCardComponent {
+  @Input() streak = 0;
+  @Input() streakFreeze = 0;
+  @Output() buy = new EventEmitter<void>();
+}

--- a/src/app/modules/kepcoin/kepcoin.component.html
+++ b/src/app/modules/kepcoin/kepcoin.component.html
@@ -6,44 +6,18 @@
     </h1>
   </div>
   <div class="col-xl-4 offset-xl-2 col-lg-5 offset-lg-1 col-md-6 col-12 offset-0">
-    <div class="card bg-kepcoin">
-      <div class="card-header">
-        <div class="card-title">
-          <i data-feather="cloud-snow"></i>
-          {{ 'StreakFreeze' | translate }}
-        </div>
-        <div>
-          <img [src]="streak > 0 ? 'assets/images/icons/fire_red.png' : 'assets/images/icons/fire_blue.png'"
-               height="19">
-          <strong>
-            {{ streak }}
-          </strong>
-          <span class="badge me-1 ms-1 bg-warning">
-            {{ 'YouHave' | translate }} <strong>{{ streakFreeze }}</strong>
-          </span>
-          <kepcoin-spend-swal
-            [value]="10"
-            [purchaseUrl]="'purchase-streak-freeze'"
-            (success)="success()"
-          ></kepcoin-spend-swal>
-        </div>
-      </div>
-
-      <div class="card-body">
-        <p>{{ 'StreakFreezeText' | translate }}</p>
-      </div>
-    </div>
+    <you-have-card [streak]="streak" [streakFreeze]="streakFreeze" (buy)="success()"></you-have-card>
 
     <kep-card>
       <div class="card-header">
         <div class="card-title">
-          @if (type == 1) {
+          @if (view === 'earns') {
             <span>
               <i data-feather="corner-right-up"></i>
               {{ 'Earns' | translate }}
             </span>
           }
-          @if (type == 2) {
+          @if (view === 'spends') {
             <span>
               <i data-feather="corner-left-down"></i>
               {{ 'Spends' | translate }}
@@ -51,152 +25,23 @@
           }
         </div>
 
-        <button (click)="type = 3 - type; currentPage=1; updatePage();" class="btn btn-warning btn-sm">
-          @if (type == 2) {
+        <button (click)="view = view === 'earns' ? 'spends' : 'earns'; currentPage=1; updatePage();" class="btn btn-warning btn-sm">
+          @if (view === 'spends') {
             <span>{{ 'Earns' | translate }}</span>
           }
-          @if (type == 1) {
+          @if (view === 'earns') {
             <span>{{ 'Spends' | translate }}</span>
           }
         </button>
       </div>
 
       <div class="card-body">
-        @if (type == 1) {
-          <div>
-            <ul class="timeline">
-              @for (earn of earns; track earn) {
-                <li class="timeline-item">
-                  <span class="timeline-point timeline-point-warning timeline-point-indicator"></span>
-                  <div class="timeline-event">
-                    <div class="d-flex justify-content-between flex-sm-row flex-column mb-sm-0 mb-1">
-                      <h6>
-                        <img height="19" src="assets/images/icons/kepcoin.png"> {{ earn.kepcoin }}
-                      </h6>
-                      <span class="timeline-event-time">{{ earn.datetime }}</span>
-                    </div>
-                    <p>
-                      <span class="text-dark">
-                        @switch (earn.earnType) {
-                          @case (4) {
-                            <span>
-                              {{ 'BonusFromAdmin' | translate }}
-                            </span>
-                          }
-                          @case (5) {
-                            <span>
-                              {{ 'DailyActivity' | translate }}: <u class="text-primary">{{ earn.detail.date }}</u>
-                            </span>
-                          }
-                          @case (6) {
-                            <span>
-                              {{ 'DailyTaskCompleted' | translate }}: <u class="text-primary">{{ earn.detail.description }}</u>
-                            </span>
-                          }
-                          @case (7) {
-                            <span>
-                              {{ 'DailyRatingWinner' | translate }}: <u class="text-primary">{{ earn.detail.date }}</u>
-                            </span>
-                          }
-                          @case (8) {
-                            <span>
-                              {{ 'WeeklyRatingWinner' | translate }}: <u class="text-primary">{{ earn.detail.date }}</u>
-                            </span>
-                          }
-                          @case (9) {
-                            <span>
-                              {{ 'MonthlyRatingWinner' | translate }}: <u class="text-primary">{{ earn.detail.date }}</u>
-                            </span>
-                          }
-                          @case (10) {
-                            <span>
-                              {{ 'ContestParticipant' | translate }}: <a [routerLink]="['/competitions', 'contests', 'contest', earn.detail.contest.id]">
-                              <u class="text-primary">{{ earn.detail.contest.title }}</u>
-                            </a>
-                            </span>
-                          }
-                          @case (11) {
-                            <span>
-                              {{ 'ArenaParticipant' | translate }}: <a [routerLink]="['/competitions', 'arena', 'tournament', earn.detail.arena.id]">
-                              <u class="text-primary">{{ earn.detail.arena.title }}</u>
-                            </a>
-                            </span>
-                          }
-                        }
-                      </span>
-                    </p>
-                    <div class="d-flex align-items-center"></div>
-                  </div>
-                </li>
-              }
-            </ul>
-          </div>
+        @if (view === 'earns') {
+          <kepcoin-earns-list [earns]="earns"></kepcoin-earns-list>
         }
 
-        @if (type == 2) {
-          <div>
-            <ul class="timeline">
-              @for (spend of spends; track spend) {
-                <li class="timeline-item">
-                  <span class="timeline-point timeline-point-warning timeline-point-indicator"></span>
-                  <div class="timeline-event">
-                    <div class="d-flex justify-content-between flex-sm-row flex-column mb-sm-0 mb-1">
-                      <h6>
-                        <img height="19" src="assets/images/icons/kepcoin.png"> {{ spend.kepcoin }}
-                      </h6>
-                      <span class="timeline-event-time">{{ spend.datetime }}</span>
-                    </div>
-                    <p>
-                      <span class="text-dark">
-                        @switch (spend.type) {
-                          @case (1) {
-                            <span>
-                              {{ 'ViewAttempt' | translate }} <a class="text-primary" routerLink="/practice/problems/attempts/{{ spend.detail.attemptId }}">
-                              <u>{{ spend.detail.attemptId }}</u>
-                            </a>
-                            </span>
-                          }
-                          @case (2) {
-                            <span>
-                              {{ 'ViewTestAttempt' | translate }} <a class="text-primary" routerLink="/practice/problems/attempts/{{ spend.detail.attemptId }}">
-                              <u>{{ spend.detail.attemptId }}</u>
-                            </a>
-                            </span>
-                          }
-                          @case (3) {
-                            <span>
-                              {{ 'ViewProblemSolution' | translate }} <a class="text-primary" routerLink="/practice/problems/problem/{{ spend.detail.problemId }}">
-                              <u>{{ spend.detail.problemId }}. {{ spend.detail.problemTitle }}</u>
-                            </a>
-                            </span>
-                          }
-                          @case (5) {
-                            <span>
-                              {{ 'ChangeImage' | translate }}
-                              <img src="{{ spend.detail.coverPhoto }}" style="width: 100%;">
-                            </span>
-                          }
-                          @case (10) {
-                            <span>
-                              {{ 'PassTest' | translate }} <a class="text-primary" routerLink="/practice/tests/test/{{ spend.detail.test.id }}">
-                              <u>{{ spend.detail.test.title }}</u>
-                            </a>
-                            </span>
-                          }
-                          @case (11) {
-                            <span>
-                              {{ 'CreateContest' | translate }}
-                            </span>
-                          }
-                        }
-                      </span>
-                    </p>
-                    <div class="d-flex align-items-center"></div>
-                  </div>
-                </li>
-              }
-            </ul>
-          </div>
+        @if (view === 'spends') {
+          <kepcoin-spends-list [spends]="spends"></kepcoin-spends-list>
         }
 
         @if (total > 0) {
@@ -214,103 +59,8 @@
     </kep-card>
   </div>
   <div class="col-lg-5 col-xl-4 col-md-6 col-12">
-    <kep-card>
-      <div class="card-header">
-        <div class="card-title">
-          <i data-feather="dollar-sign"></i>
-          {{ 'HowToEarnKepcoin' | translate }}
-        </div>
-      </div>
+    <how-to-earn-kepcoin></how-to-earn-kepcoin>
 
-      <div class="card-body text-dark">
-        {{ 'EarnDescription' | translate }}
-
-        <div class="earn">
-          <kepcoin [value]="1"></kepcoin>
-          : {{ 'EarnItem1' | translate }}
-        </div>
-
-        <div class="earn">
-          <kepcoin [value]="'1-10'"></kepcoin>
-          : {{ 'EarnItem2' | translate }}
-        </div>
-
-        <div class="earn">
-          <kepcoin [value]="'3, 10, 50'"></kepcoin>
-          : {{ 'EarnItem3' | translate }}
-        </div>
-
-        <div class="earn">
-          <kepcoin [value]="'5+'"></kepcoin>
-          : {{ 'EarnItem4' | translate }}
-        </div>
-
-        <div class="earn">
-          <kepcoin [value]="'10-100'"></kepcoin>
-          : {{ 'EarnItem5' | translate }}
-        </div>
-
-        <div class="earn">
-          <kepcoin [value]="'1-50'"></kepcoin>
-          : {{ 'EarnItem6' | translate }}
-        </div>
-      </div>
-    </kep-card>
-
-    <kep-card>
-      <div class="card-header">
-        <div class="card-title">
-          <i data-feather="coffee"></i>
-          {{ 'HowToSpendKepcoin' | translate }}
-        </div>
-      </div>
-
-      <div class="card-body text-dark">
-        <div class="spend">
-          <kepcoin [value]="'0-14'"></kepcoin>
-          : {{ 'SpendItem1' | translate }}
-        </div>
-
-        <div class="spend">
-          <kepcoin [value]="1"></kepcoin>
-          : {{ 'SpendItem2' | translate }}
-        </div>
-
-        <div class="spend">
-          <kepcoin [value]="'2-50'"></kepcoin>
-          : {{ 'SpendItem3' | translate }}
-        </div>
-
-        <div class="spend">
-          <kepcoin [value]="5"></kepcoin>
-          : {{ 'SpendItem4' | translate }}
-        </div>
-
-        <div class="spend">
-          <kepcoin [value]="1"></kepcoin>
-          : {{ 'SpendItem5' | translate }}
-        </div>
-
-        <div class="spend">
-          <kepcoin [value]="'1-1000'"></kepcoin>
-          : {{ 'SpendItem6' | translate }}
-        </div>
-
-        <div class="spend">
-          <kepcoin [value]="'50'"></kepcoin>
-          : {{ 'SpendItem7' | translate }}
-        </div>
-
-        <div class="spend">
-          <kepcoin [value]="25"></kepcoin>
-          : {{ 'SpendItem8' | translate }}
-        </div>
-
-        <div class="spend">
-          <kepcoin [value]="25"></kepcoin>
-          : {{ 'SpendItem9' | translate }}
-        </div>
-      </div>
-    </kep-card>
+    <how-to-spend-kepcoin></how-to-spend-kepcoin>
   </div>
 </div>

--- a/src/app/modules/kepcoin/kepcoin.component.ts
+++ b/src/app/modules/kepcoin/kepcoin.component.ts
@@ -11,6 +11,19 @@ import { CoreDirectivesModule } from '@shared/directives/directives.module';
 import { KepcoinSpendSwalModule } from '@shared/components/kepcoin-spend-swal/kepcoin-spend-swal.module';
 import { KepPaginationComponent } from '@shared/components/kep-pagination/kep-pagination.component';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import {
+  EarnsListComponent
+} from './components/earns-list/earns-list.component';
+import {
+  SpendsListComponent
+} from './components/spends-list/spends-list.component';
+import {
+  HowToEarnKepcoinComponent
+} from './components/how-to-earn-kepcoin/how-to-earn-kepcoin.component';
+import {
+  HowToSpendKepcoinComponent
+} from './components/how-to-spend-kepcoin/how-to-spend-kepcoin.component';
+import { YouHaveCardComponent } from './components/you-have-card/you-have-card.component';
 
 @Component({
   selector: 'app-kepcoin',
@@ -25,6 +38,11 @@ import { KepCardComponent } from '@shared/components/kep-card/kep-card.component
     KepcoinSpendSwalModule,
     KepPaginationComponent,
     KepCardComponent,
+    EarnsListComponent,
+    SpendsListComponent,
+    HowToEarnKepcoinComponent,
+    HowToSpendKepcoinComponent,
+    YouHaveCardComponent,
   ],
 })
 export class KepcoinComponent implements OnInit, OnDestroy {
@@ -34,7 +52,7 @@ export class KepcoinComponent implements OnInit, OnDestroy {
 
   public currentPage = 1;
   public total = 0;
-  public type = 1;
+  public view: 'earns' | 'spends' = 'earns';
 
   public streakFreeze = 0;
   public streak = 0;
@@ -74,7 +92,7 @@ export class KepcoinComponent implements OnInit, OnDestroy {
   }
 
   updatePage() {
-    if (this.type == 1) {
+    if (this.view === 'earns') {
       this.service.getUserKepcoinEarns({
         page: this.currentPage
       }).subscribe(


### PR DESCRIPTION
## Summary
- pull earns/spends timeline into standalone components
- create HowToEarn/HowToSpend and streak card components
- clean up `kepcoin` template to use new components
- remove magic numbers using descriptive view states

## Testing
- `npm install` *(fails: ERESOLVE could not resolve)*

------
https://chatgpt.com/codex/tasks/task_e_687f61c2bcc0832faff7554eb580544c