### PR TITLE
Fix file input reset on project submission

### DIFF
--- a/src/app/modules/projects/ui/components/project-sidebar/project-sidebar.component.html
+++ b/src/app/modules/projects/ui/components/project-sidebar/project-sidebar.component.html
@@ -20,7 +20,7 @@
     <div class="mb-1">
       <label><strong>{{ 'File' | translate }}:</strong></label>
       <div class="custom-file">
-        <input (change)="handleFileInput($event.target.files)" accept=".txt" class="form-control" id="customFile"
+        <input #fileInput (change)="handleFileInput($event.target.files)" accept=".txt" class="form-control" id="customFile"
                type="file"/>
         <label class="form-label" for="customFile">
           {{ this.fileToUpload?.name || 'Max size 1mb' }}

--- a/src/app/modules/projects/ui/components/project-sidebar/project-sidebar.component.ts
+++ b/src/app/modules/projects/ui/components/project-sidebar/project-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, inject, Input, OnInit, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, ViewChild, inject, Input, OnInit, Output } from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
 import { CoreCommonModule } from '@core/common.module';
 import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
@@ -28,6 +28,7 @@ export class ProjectSidebarComponent implements OnInit {
 
   public selectedTechnology: string;
   public fileToUpload: File | null = null;
+  @ViewChild('fileInput') fileInputRef: ElementRef<HTMLInputElement>;
 
   protected readonly toastr = inject(ToastrService);
   protected readonly projectsRepository = inject(ProjectsRepository);
@@ -61,6 +62,7 @@ export class ProjectSidebarComponent implements OnInit {
     submit$.subscribe(() => {
       this.submitEvent.emit();
       this.toastr.success('Submitted');
+      this.fileInputRef.nativeElement.value = '';
     });
   }
 }


### PR DESCRIPTION
## Summary
- clear file input after submitting in `ProjectSidebarComponent`

## Testing
- `npm install --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_688365b30188832f8b5894324ebe040d