### PR TITLE
Refactor problems page layout

### DIFF
--- a/src/app/modules/problems/pages/problems/problems.component.html
+++ b/src/app/modules/problems/pages/problems/problems.component.html
@@ -2,50 +2,31 @@
   <div class="content-body">
     <section-header [contentHeader]="contentHeader"/>
 
-    <ul ngbNav #navFilled="ngbNav" class="nav-tabs nav-style-1 nav-fill">
-      <li ngbNavItem>
-        <a ngbNavLink>{{ 'AllProblems' | translate }}</a>
-        <ng-template ngbNavContent>
-          <section-categories></section-categories>
-          @defer (on viewport) {
-            <section-problems-filter></section-problems-filter>
-          } @placeholder {
-            <div class="card" [style.height.px]="200">
-              <spinner></spinner>
-            </div>
-          }
-          @defer (on viewport) {
-            <section-problems-list></section-problems-list>
-          } @placeholder {
-            <div class="card" [style.height.px]="200">
-              <spinner></spinner>
-            </div>
-          }
-        </ng-template>
-      </li>
-
-      <li ngbNavItem>
-        <a ngbNavLink>{{ 'MostViewedProblems' | translate }}</a>
-        <ng-template ngbNavContent>
-          <div class="row">
-            <div class="col-12 col-lg-6">
-              <section-most-viewed></section-most-viewed>
-            </div>
-            <div class="col-12 col-lg-6">
-              <section-last-attempts></section-last-attempts>
-            </div>
+    <div class="problems-page">
+      @defer (on viewport) {
+        <div class="problems-page__layout">
+          <div class="problems-page__main">
+            <section-problems-filter/>
+            <section-problems-table class="mt-1"/>
           </div>
-        </ng-template>
-      </li>
+          <aside class="problems-page__sidebar">
+            <section-problems-summary/>
+            <section-last-attempts class="problems-page__card"/>
+          </aside>
+        </div>
+      } @placeholder {
+        <div class="card" [style.height.px]="300">
+          <spinner></spinner>
+        </div>
+      }
 
-      <li ngbNavItem>
-        <a ngbNavLink>{{ 'LastContestProblems' | translate }}</a>
-        <ng-template ngbNavContent>
-          <section-last-contest-problems></section-last-contest-problems>
-        </ng-template>
-      </li>
-    </ul>
-    <div [ngbNavOutlet]="navFilled" class="mt-2"></div>
+      <div class="problems-page__additional">
+        <section-most-viewed class="problems-page__additional-card"/>
+        <section-last-contest-problems class="problems-page__additional-card"/>
+      </div>
+
+      <section-categories class="problems-page__categories"/>
+    </div>
 
   </div>
 </div>

--- a/src/app/modules/problems/pages/problems/problems.component.scss
+++ b/src/app/modules/problems/pages/problems/problems.component.scss
@@ -1,1 +1,49 @@
 @import 'styles/kep-imports';
+
+.problems-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  &__layout {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: minmax(0, 1fr);
+
+    @include media-breakpoint-up(xl) {
+      grid-template-columns: minmax(0, 1.8fr) minmax(280px, 1fr);
+      align-items: start;
+    }
+  }
+
+  &__main {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__sidebar {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__card {
+    width: 100%;
+  }
+
+  &__additional {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+
+    @include media-breakpoint-up(xl) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  &__additional-card,
+  &__categories {
+    width: 100%;
+  }
+}

--- a/src/app/modules/problems/pages/problems/problems.component.ts
+++ b/src/app/modules/problems/pages/problems/problems.component.ts
@@ -1,11 +1,9 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { SectionProblemsFilterComponent } from './sections/section-problems-filter/section-problems-filter.component';
 import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
-import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
 import { BasePageComponent } from '@core/common/classes/base-page.component';
 import { SectionHeaderComponent } from '@problems/pages/problems/sections/section-header/section-header.component';
 import { SectionCategoriesComponent } from './sections/section-categories/section-categories.component';
-import { SectionProblemsListComponent } from './sections/section-problems-list/section-problems-list.component';
 import {
   SectionMostViewedProblemsComponent
 } from './sections/section-most-viewed-problems/section-most-viewed-problems.component';
@@ -13,10 +11,11 @@ import {
   SectionLastContestProblemsComponent
 } from './sections/section-last-contest-problems/section-last-contest-problems.component';
 import { SectionLastAttemptsComponent } from './sections/section-last-attempts/section-last-attempts.component';
-import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { TranslatePipe } from "@ngx-translate/core";
 import { ContentHeader } from "@shared/ui/components/content-header/content-header.component";
 import { ContentHeaderModule } from "@shared/ui/components/content-header/content-header.module";
+import { SectionProblemsSummaryComponent } from "./sections/section-problems-summary/section-problems-summary.component";
+import { SectionProblemsTableComponent } from "./sections/section-problems-table/section-problems-table.component";
 
 @Component({
   selector: 'app-problems',
@@ -27,16 +26,15 @@ import { ContentHeaderModule } from "@shared/ui/components/content-header/conten
   imports: [
     SectionProblemsFilterComponent,
     SpinnerComponent,
-    NgSelectModule,
     SectionHeaderComponent,
     SectionCategoriesComponent,
-    SectionProblemsListComponent,
+    SectionProblemsTableComponent,
     SectionMostViewedProblemsComponent,
     SectionLastContestProblemsComponent,
     SectionLastAttemptsComponent,
-    NgbNavModule,
     TranslatePipe,
-    ContentHeaderModule
+    ContentHeaderModule,
+    SectionProblemsSummaryComponent
   ],
 })
 export class ProblemsComponent extends BasePageComponent implements OnInit {

--- a/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.html
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.html
@@ -1,235 +1,159 @@
-<kep-card>
-  <div class="card-header">
-    <div class="card-title text-dark">
-      <kep-icon name="filter"></kep-icon>
-      {{ 'Filter' | translate }}
-      <span class="ms-1 total-count">({{ problemsCount }})</span>
-    </div>
-    <button aria-label="filter-collapsed" class="btn btn-sm btn-primary" (click)="filterCollapsed=!filterCollapsed;">
-      <kep-icon [name]="filterCollapsed ? 'double-up' : 'double-down'"></kep-icon>
-    </button>
-  </div>
+<kep-card customClass="problems-filter">
   <div class="card-body">
     <form [formGroup]="filterForm">
-      <div class="row">
-        <div class="col-6 col-lg-3">
-          <div class="mb-1">
-            <label class="text-primary" aria-label="Title">
-              <kep-icon name="pencil"></kep-icon>
-              <strong>
-                {{ 'TITLE' | translate }}:
-              </strong>
-            </label>
-            <input
-              formControlName="title"
-              class="form-control"
-              name="title"
-              type="text"
-            />
-          </div>
+      <div class="problems-filter__header">
+        <div class="problems-filter__title">
+          <kep-icon name="filter"></kep-icon>
+          <span>{{ 'Filter' | translate }}</span>
+          <span class="problems-filter__count">({{ problemsCount }})</span>
         </div>
-
-        <div class="col-6 col-lg-3">
-          <label class="text-primary" aria-label="Tags">
-            <kep-icon name="tags"></kep-icon>
-            <strong>
-              {{ 'TAGS' | translate }}:
-            </strong>
-          </label>
-          <div class="mb-1">
-            <div ngbDropdown container="body" [placement]="'bottom'"
-                 class="select-tags btn-group full-width d-lg-block d-none">
-              <button type="button" class="btn btn-outline-primary" [style.width.%]="80" rippleEffect>
-                {{ selectedTagsName || ('SELECT' | translate) }}
-              </button>
-              <button
-                [style.width.%]="20"
-                ngbDropdownToggle
-                type="button"
-                class="btn btn-outline-primary dropdown-toggle-split"
-                rippleEffect>
-              </button>
-              <div ngbDropdownMenu class="tags-dropdown" [style.width.rem]="32">
-                <div ngbAccordion [closeOthers]="true" [destroyOnHide]="false">
-                  @for (category of categories; track category.id) {
-                    <div ngbAccordionItem [id]="'i' + category.id">
-                      <h2 ngbAccordionHeader>
-                        <button ngbAccordionButton>
-                          {{ category.title }}
-                        </button>
-                      </h2>
-                      <div ngbAccordionCollapse>
-                        <div ngbAccordionBody>
-                          @for (tag of category.tags; track $index) {
-                            @if (tag) {
-                              <button (click)="tagOnClick(tag?.id)" class="mx-25 mb-50 btn btn-sm" [class]="{
-                                'btn-outline-primary': filterForm.value.tags?.indexOf(tag.id) === -1,
-                                'btn-primary': filterForm.value.tags?.indexOf(tag.id) !== -1,
-                              }">
-                                {{ tag.name }}
-                              </button>
-                            }
-                          }
-                        </div>
-                      </div>
-                    </div>
-                  }
-                </div>
-              </div>
-            </div>
-
-            <ng-select
-              appendTo="body"
-              class="d-lg-none tags-select"
-              formControlName="tags"
-              [dropdownPosition]="'top'"
-              [multiple]="true"
-              [items]="tags"
-              [closeOnSelect]="false"
-              [maxSelectedItems]="3"
-              [groupBy]="'category'"
-              [bindLabel]="'name'"
-              [bindValue]="'id'"
-              placeholder="{{ 'SELECT' | translate }}:"
-              [compareWith]="compareEqual">
-              <ng-template ng-optgroup-tmp let-item="item">
-                {{ item.category }}
-              </ng-template>
-            </ng-select>
-          </div>
+        <div class="problems-filter__actions">
+          <button type="button" class="btn btn-icon btn-sm btn-outline-primary" (click)="filterCollapsed = !filterCollapsed">
+            <kep-icon [name]="filterCollapsed ? 'double-up' : 'double-down'"></kep-icon>
+          </button>
         </div>
-
-        <div class="col-6 col-lg-3">
-          <label class="text-primary" aria-label="Difficulty">
-            <kep-icon name="graph-2"></kep-icon>
-            <strong>
-              {{ 'DIFFICULTY' | translate }}:
-            </strong>
-          </label>
-          <div class="mb-1">
-            <ng-select [searchable]="false" appendTo="body" formControlName="difficulty" [compareWith]="compareEqual">
-              @for (item of difficulties; track item) {
-                <ng-option [value]="item.value">
-                  <span class="text-{{ item.value | problemDifficultyColor }}">
-                    {{ item.name }}
-                  </span>
-                </ng-option>
-              }
-            </ng-select>
-          </div>
-        </div>
-
-        <div class="col-lg-3 col-6">
-          <label class="text-primary" aria-label="Status">
-            <kep-icon name="check-square"></kep-icon>
-            <strong>
-              {{ 'STATUS' | translate }}:
-            </strong>
-          </label>
-          <div class="mb-1">
-            <ng-select [searchable]="false" appendTo="body" formControlName="status" [compareWith]="compareEqual">
-              <ng-option [value]="3">
-                <kep-icon name="minus" class="text-warning"></kep-icon>
-                {{ 'Unknown' | translate }}
-              </ng-option>
-              <ng-option [value]="1">
-                <kep-icon name="check" class="text-success"></kep-icon>
-                {{ 'Solved' | translate }}
-              </ng-option>
-              <ng-option [value]="2">
-                <kep-icon name="cross" class="text-danger"></kep-icon>
-                {{ 'Unsolved' | translate }}
-              </ng-option>
-            </ng-select>
-          </div>
-        </div>
-
       </div>
 
-      @if (filterCollapsed) {
-        <div class="row">
-          <div class="col-lg-3 col-6">
-            <label class="text-primary">
-              <kep-icon name="filter-search"></kep-icon>
-              <strong>
-                {{ 'Checker' | translate }}:
-              </strong>
-            </label>
-            <div class="mb-1">
-              <ng-select appendTo="body" formControlName="hasChecker" [compareWith]="compareEqual">
-                <ng-option [value]="true">
-                  <i [data-feather]="'exists' | iconName" class="text-success"></i>
-                  {{ 'Yes' | translate }}
-                </ng-option>
-                <ng-option [value]="false">
-                  <i [data-feather]="'not_exists' | iconName" class="text-danger"></i>
-                  {{ 'No' | translate }}
-                </ng-option>
-              </ng-select>
-            </div>
+      <div class="problems-filter__grid">
+        <div class="problems-filter__field problems-filter__field--search">
+          <kep-icon name="search"></kep-icon>
+          <input
+            type="search"
+            class="form-control"
+            formControlName="title"
+            [placeholder]="'Search' | translate"
+          />
+        </div>
+
+        <div class="problems-filter__field">
+          <ng-select
+            appendTo="body"
+            formControlName="tags"
+            [multiple]="true"
+            [closeOnSelect]="false"
+            [items]="tags"
+            [groupBy]="'category'"
+            [bindLabel]="'name'"
+            [bindValue]="'id'"
+            placeholder="{{ 'TAGS' | translate }}"
+            [compareWith]="compareEqual">
+            <ng-template ng-optgroup-tmp let-item="item">
+              {{ item.category }}
+            </ng-template>
+          </ng-select>
+        </div>
+
+        <div class="problems-filter__field">
+          <ng-select
+            appendTo="body"
+            formControlName="difficulty"
+            [searchable]="false"
+            placeholder="{{ 'DIFFICULTY' | translate }}"
+            [compareWith]="compareEqual">
+            @for (item of difficulties; track item) {
+              <ng-option [value]="item.value">
+                <span class="text-{{ item.value | problemDifficultyColor }}">
+                  {{ item.name }}
+                </span>
+              </ng-option>
+            }
+          </ng-select>
+        </div>
+
+        <div class="problems-filter__field">
+          <ng-select
+            appendTo="body"
+            formControlName="status"
+            [searchable]="false"
+            placeholder="{{ 'STATUS' | translate }}"
+            [compareWith]="compareEqual">
+            <ng-option [value]="3">
+              <kep-icon name="minus" class="text-warning"></kep-icon>
+              {{ 'Unknown' | translate }}
+            </ng-option>
+            <ng-option [value]="1">
+              <kep-icon name="check" class="text-success"></kep-icon>
+              {{ 'Solved' | translate }}
+            </ng-option>
+            <ng-option [value]="2">
+              <kep-icon name="cross" class="text-danger"></kep-icon>
+              {{ 'Unsolved' | translate }}
+            </ng-option>
+          </ng-select>
+        </div>
+      </div>
+
+      <div class="problems-filter__advanced" *ngIf="filterCollapsed">
+        <div class="problems-filter__grid problems-filter__grid--advanced">
+          <div class="problems-filter__field">
+            <ng-select
+              appendTo="body"
+              formControlName="hasChecker"
+              [compareWith]="compareEqual"
+              placeholder="{{ 'Checker' | translate }}">
+              <ng-option [value]="true">
+                <i [data-feather]="'exists' | iconName" class="text-success"></i>
+                {{ 'Yes' | translate }}
+              </ng-option>
+              <ng-option [value]="false">
+                <i [data-feather]="'not_exists' | iconName" class="text-danger"></i>
+                {{ 'No' | translate }}
+              </ng-option>
+            </ng-select>
           </div>
-          <div class="col-lg-3 col-6">
-            <label class="text-primary">
-              <kep-icon name="filter-search"></kep-icon>
-              <strong>
-                {{ 'CheckInput' | translate }}:
-              </strong>
-            </label>
-            <div class="mb-1">
-              <ng-select appendTo="body" formControlName="hasCheckInput" [compareWith]="compareEqual">
-                <ng-option [value]="true">
-                  <i [data-feather]="'exists' | iconName" class="text-success"></i>
-                  {{ 'Yes' | translate }}
-                </ng-option>
-                <ng-option [value]="false">
-                  <i [data-feather]="'not_exists' | iconName" class="text-danger"></i>
-                  {{ 'No' | translate }}
-                </ng-option>
-              </ng-select>
-            </div>
+
+          <div class="problems-filter__field">
+            <ng-select
+              appendTo="body"
+              formControlName="hasCheckInput"
+              [compareWith]="compareEqual"
+              placeholder="{{ 'CheckInput' | translate }}">
+              <ng-option [value]="true">
+                <i [data-feather]="'exists' | iconName" class="text-success"></i>
+                {{ 'Yes' | translate }}
+              </ng-option>
+              <ng-option [value]="false">
+                <i [data-feather]="'not_exists' | iconName" class="text-danger"></i>
+                {{ 'No' | translate }}
+              </ng-option>
+            </ng-select>
           </div>
-          <div class="col-lg-3 col-6">
-            <label class="text-primary">
-              <kep-icon name="filter-search"></kep-icon>
-              <strong>
-                {{ 'Solution' | translate }}:
-              </strong>
-            </label>
-            <div class="mb-1">
-              <ng-select appendTo="body" formControlName="hasSolution" [compareWith]="compareEqual">
-                <ng-option [value]="true">
-                  <i [data-feather]="'exists' | iconName" class="text-success"></i>
-                  {{ 'Yes' | translate }}
-                </ng-option>
-                <ng-option [value]="false">
-                  <i [data-feather]="'not_exists' | iconName" class="text-danger"></i>
-                  {{ 'No' | translate }}
-                </ng-option>
-              </ng-select>
-            </div>
+
+          <div class="problems-filter__field">
+            <ng-select
+              appendTo="body"
+              formControlName="hasSolution"
+              [compareWith]="compareEqual"
+              placeholder="{{ 'Solution' | translate }}">
+              <ng-option [value]="true">
+                <i [data-feather]="'exists' | iconName" class="text-success"></i>
+                {{ 'Yes' | translate }}
+              </ng-option>
+              <ng-option [value]="false">
+                <i [data-feather]="'not_exists' | iconName" class="text-danger"></i>
+                {{ 'No' | translate }}
+              </ng-option>
+            </ng-select>
           </div>
-          <div class="col-lg-3 col-6">
-            <label class="text-primary">
-              <kep-icon name="filter-search"></kep-icon>
-              <strong>
-                {{ 'PartialSolvable' | translate }}:
-              </strong>
-            </label>
-            <div class="mb-1">
-              <ng-select appendTo="body" formControlName="partialSolvable" [compareWith]="compareEqual">
-                <ng-option [value]="true">
-                  <i [data-feather]="'exists' | iconName" class="text-success"></i>
-                  {{ 'Yes' | translate }}
-                </ng-option>
-                <ng-option [value]="false">
-                  <i [data-feather]="'not_exists' | iconName" class="text-danger"></i>
-                  {{ 'No' | translate }}
-                </ng-option>
-              </ng-select>
-            </div>
+
+          <div class="problems-filter__field">
+            <ng-select
+              appendTo="body"
+              formControlName="partialSolvable"
+              [compareWith]="compareEqual"
+              placeholder="{{ 'PartialSolvable' | translate }}">
+              <ng-option [value]="true">
+                <i [data-feather]="'exists' | iconName" class="text-success"></i>
+                {{ 'Yes' | translate }}
+              </ng-option>
+              <ng-option [value]="false">
+                <i [data-feather]="'not_exists' | iconName" class="text-danger"></i>
+                {{ 'No' | translate }}
+              </ng-option>
+            </ng-select>
           </div>
         </div>
-      }
+      </div>
     </form>
   </div>
 </kep-card>

--- a/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.scss
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.scss
@@ -1,20 +1,90 @@
 @import 'styles/kep-imports';
-//
-//.tags-dropdown {
-//  --bs-dropdown-padding-x: 0;
-//  --bs-dropdown-padding-y: 0;
-//
-//  --bs-dropdown-bg: white;
-//
-//  @include dark-layout {
-//    --bs-dropdown-bg: #{$theme-dark-card-bg};
-//  }
-//}
-//
-//.select-tags {
-//  background: white;
-//
-//  @include dark-layout {
-//    background: inherit;
-//  }
-//}
+
+.problems-filter {
+  .card-body {
+    padding: 1.5rem;
+
+    @include media-breakpoint-down(sm) {
+      padding: 1rem;
+    }
+  }
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+  }
+
+  &__count {
+    color: var(--bs-body-color);
+    opacity: 0.6;
+  }
+
+  &__grid {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  &__grid--advanced {
+    margin-top: 0.75rem;
+  }
+
+  &__field {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+
+    .ng-select {
+      width: 100%;
+    }
+  }
+
+  &__field--search {
+    background-color: rgba($primary, 0.05);
+    border-radius: 0.75rem;
+    padding: 0.25rem 0.75rem;
+    border: 1px solid transparent;
+
+    input {
+      border: none;
+      background: transparent;
+      box-shadow: none;
+
+      &:focus {
+        outline: none;
+        box-shadow: none;
+      }
+    }
+
+    @include dark-layout {
+      background-color: rgba($white, 0.05);
+    }
+  }
+
+  &__advanced {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid rgba($primary, 0.1);
+  }
+}
+
+:host ::ng-deep {
+  .problems-filter {
+    .ng-select-container {
+      border-radius: 0.75rem;
+    }
+
+    .ng-select.ng-select-multiple .ng-select-container {
+      padding-left: 0.5rem;
+    }
+  }
+}

--- a/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.ts
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.ts
@@ -7,7 +7,6 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { deepCopy, equalsCheck } from '@shared/utils';
 import { CoreCommonModule } from '@core/common.module';
 import { ProblemsPipesModule } from '@problems/pipes/problems-pipes.module';
-import { NgbAccordionModule, NgbDropdownModule } from '@ng-bootstrap/ng-bootstrap';
 import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
 import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
 import { takeUntil } from 'rxjs/operators';
@@ -26,8 +25,6 @@ interface Difficulty {
   imports: [
     CoreCommonModule,
     ProblemsPipesModule,
-    NgbDropdownModule,
-    NgbAccordionModule,
     KepIconComponent,
     NgSelectModule,
     KepCardComponent,
@@ -50,7 +47,6 @@ export class SectionProblemsFilterComponent extends BaseComponent implements OnI
   public categories: Array<Category> = [];
   public difficulties: Array<Difficulty> = [];
 
-  public selectedTagsName: string;
   public filterCollapsed = false;
   public problemsCount = 0;
 
@@ -104,15 +100,6 @@ export class SectionProblemsFilterComponent extends BaseComponent implements OnI
         });
         this.tags = tags;
 
-        if (queryParams.tags) {
-          this.selectedTagsName = Array.from(new Set(this.tags.filter(tag => queryParams.tags.indexOf(tag.id) !== -1).map(tag => tag.name))).join(', ');
-        }
-      }
-    );
-
-    this.filterForm.controls.tags.valueChanges.subscribe(
-      (tags) => {
-        this.selectedTagsName = Array.from(new Set(this.tags.filter(tag => tags.indexOf(tag.id) !== -1).map(tag => tag.name))).join(', ');
       }
     );
 
@@ -125,16 +112,5 @@ export class SectionProblemsFilterComponent extends BaseComponent implements OnI
 
   compareEqual(a, b) {
     return equalsCheck(a, b) || a?.toString() === b?.toString();
-  }
-
-  tagOnClick(tagId: number) {
-    const tags = this.filterForm.value.tags || [];
-    const index = tags.indexOf(tagId);
-    if (index === -1) {
-      tags.push(tagId);
-    } else {
-      tags.splice(index, 1);
-    }
-    this.filterForm.patchValue({tags: tags});
   }
 }

--- a/src/app/modules/problems/pages/problems/sections/section-problems-summary/section-problems-summary.component.html
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-summary/section-problems-summary.component.html
@@ -1,0 +1,46 @@
+<kep-card class="problems-summary" *ngIf="isAuthenticated">
+  <div class="card-header problems-summary__header">
+    <div>
+      <div class="card-title problems-summary__title">
+        <kep-icon name="check-circle"></kep-icon>
+        {{ 'Solved' | translate }}
+      </div>
+      <div class="problems-summary__subtitle" *ngIf="summary?.user?.ratingTitle">
+        {{ summary?.user?.ratingTitle }}
+      </div>
+    </div>
+    <div class="problems-summary__total" *ngIf="!isLoading; else summarySkeleton">
+      {{ summary?.solved || 0 }}
+    </div>
+  </div>
+
+  <div class="card-body" *ngIf="!isLoading; else summarySkeleton">
+    <ul class="problems-summary__list">
+      <li class="problems-summary__item" *ngFor="let item of difficultySummary">
+        <span class="problems-summary__label">{{ item.label | translate }}</span>
+        <span class="badge bg-{{ item.color }} problems-summary__value">{{ summary?.[item.key] || 0 }}</span>
+      </li>
+    </ul>
+
+    <div class="problems-summary__rating" *ngIf="summary">
+      <div class="problems-summary__rating-value">
+        <kep-icon name="rating" type="duotone"></kep-icon>
+        {{ summary.rating | number }}
+      </div>
+      <div class="problems-summary__rating-caption">
+        {{ 'Rating' | translate }}
+      </div>
+    </div>
+  </div>
+</kep-card>
+
+<ng-template #summarySkeleton>
+  <div class="problems-summary__skeleton">
+    <ngx-skeleton-loader
+      count="4"
+      appearance="line"
+      animation="pulse"
+      [theme]="{height: '20px', margin: '8px 0', background: 'var(--skeleton-color)'}"
+    />
+  </div>
+</ng-template>

--- a/src/app/modules/problems/pages/problems/sections/section-problems-summary/section-problems-summary.component.scss
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-summary/section-problems-summary.component.scss
@@ -1,0 +1,88 @@
+@import 'styles/kep-imports';
+
+.problems-summary {
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+  }
+
+  &__subtitle {
+    font-size: 0.85rem;
+    color: var(--bs-body-color);
+    opacity: 0.7;
+  }
+
+  &__total {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--bs-primary);
+    min-width: 3rem;
+    text-align: right;
+  }
+
+  &__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  &__item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.9rem;
+    background-color: rgba($primary, 0.04);
+    border-radius: 0.75rem;
+    padding: 0.5rem 0.75rem;
+
+    @include dark-layout {
+      background-color: rgba($white, 0.03);
+    }
+  }
+
+  &__label {
+    color: inherit;
+  }
+
+  &__value {
+    min-width: 2.5rem;
+    text-align: center;
+  }
+
+  &__rating {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid rgba($primary, 0.15);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  &__rating-value {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+  }
+
+  &__rating-caption {
+    font-size: 0.8rem;
+    color: var(--bs-body-color);
+    opacity: 0.6;
+  }
+
+  &__skeleton {
+    padding: 0.5rem 0;
+  }
+}

--- a/src/app/modules/problems/pages/problems/sections/section-problems-summary/section-problems-summary.component.ts
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-summary/section-problems-summary.component.ts
@@ -1,0 +1,89 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ProblemsApiService } from '@problems/services/problems-api.service';
+import { BaseComponent } from '@core/common/classes/base.component';
+import { ProblemsRating } from '@problems/models/rating.models';
+import { takeUntil } from 'rxjs/operators';
+import { NgIf, NgForOf } from '@angular/common';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { TranslatePipe } from '@ngx-translate/core';
+import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
+import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+
+interface DifficultySummary {
+  key: keyof ProblemsRating;
+  label: string;
+  color: string;
+}
+
+type ProblemsRatingSummary = Partial<ProblemsRating> & {
+  user?: {
+    username?: string;
+    ratingTitle?: string;
+  };
+};
+
+@Component({
+  selector: 'section-problems-summary',
+  standalone: true,
+  imports: [
+    NgIf,
+    NgForOf,
+    KepCardComponent,
+    TranslatePipe,
+    KepIconComponent,
+    NgxSkeletonLoaderModule
+  ],
+  templateUrl: './section-problems-summary.component.html',
+  styleUrls: ['./section-problems-summary.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SectionProblemsSummaryComponent extends BaseComponent {
+  public summary: ProblemsRatingSummary | null = null;
+  public isLoading = false;
+
+  public difficultySummary: DifficultySummary[] = [
+    {key: 'beginner', label: 'Beginner', color: 'success'},
+    {key: 'basic', label: 'Basic', color: 'info'},
+    {key: 'normal', label: 'Normal', color: 'primary'},
+    {key: 'medium', label: 'Medium', color: 'warning'},
+    {key: 'advanced', label: 'Advanced', color: 'danger'},
+    {key: 'hard', label: 'Hard', color: 'dark'},
+    {key: 'extremal', label: 'Extremal', color: 'secondary'}
+  ];
+
+  constructor(private problemsApiService: ProblemsApiService) {
+    super();
+  }
+
+  override ngOnInit(): void {
+    super.ngOnInit();
+    if (this.isAuthenticated) {
+      this.loadSummary();
+    }
+  }
+
+  override afterChangeCurrentUser(): void {
+    if (this.isAuthenticated) {
+      this.loadSummary();
+    } else {
+      this.summary = null;
+    }
+  }
+
+  private loadSummary(): void {
+    this.isLoading = true;
+    this.problemsApiService.getCurrentUserProblemsSummary()
+      .pipe(takeUntil(this._unsubscribeAll))
+      .subscribe({
+        next: (summary: ProblemsRatingSummary) => {
+          this.summary = summary;
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        }
+      });
+  }
+}

--- a/src/app/modules/problems/pages/problems/sections/section-problems-table/section-problems-table.component.scss
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-table/section-problems-table.component.scss
@@ -1,10 +1,62 @@
 @import 'styles/kep-imports';
 
 .bg-problems-table {
-  // background: mix(black, var(--primary), 10) !important;
-  color: white !important;
+  background: transparent !important;
+  color: var(--bs-body-color) !important;
 
   th {
     border: none !important;
+    font-weight: 600;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    letter-spacing: 0.05em;
+  }
+}
+
+:host ::ng-deep {
+  .kep-table {
+    .table {
+      border-collapse: separate;
+      border-spacing: 0 0.5rem;
+
+      thead th {
+        padding-bottom: 0.75rem;
+      }
+
+      tbody tr {
+        background-color: rgba($primary, 0.04);
+        border-radius: 1rem;
+        overflow: hidden;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+        @include dark-layout {
+          background-color: rgba($white, 0.04);
+        }
+
+        &:hover {
+          transform: translateY(-2px);
+          box-shadow: 0 12px 24px rgba($black, 0.08);
+
+          @include dark-layout {
+            box-shadow: 0 12px 24px rgba($black, 0.4);
+          }
+        }
+
+        td {
+          border: none;
+          padding: 1rem 1.25rem;
+          vertical-align: middle;
+        }
+      }
+
+      tbody tr.bg-success-transparent,
+      tbody tr.bg-light-danger {
+        background-color: inherit;
+
+        td {
+          background-color: transparent;
+        }
+      }
+    }
   }
 }

--- a/src/app/modules/problems/services/problems-api.service.ts
+++ b/src/app/modules/problems/services/problems-api.service.ts
@@ -79,6 +79,10 @@ export class ProblemsApiService {
     return this.api.get('problems-rating', params);
   }
 
+  getCurrentUserProblemsSummary() {
+    return this.api.get('problems-rating');
+  }
+
   getProblemVerdictStatistics(problemId: number) {
     return this.api.get(`problems/${problemId}/attempt-statistics/`);
   }


### PR DESCRIPTION
## Summary
- restructure the problems practice page to focus on a single consolidated view with sidebar content
- refresh the problems filter and list styling for a compact table-first experience
- add a solved-by-difficulty summary card backed by the problems-rating API

## Testing
- `npm run lint` *(fails: project has no lint target configured)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbc42b04c832f97d2dead9b4fe148