### PR TITLE
Update problems search placeholder translation

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -52,6 +52,7 @@ export const localeEn = {
   ADVANCED: 'Advanced',
   EXTREMAL: 'Extremal',
   TITLE: 'Title',
+  PROBLEMS_SEARCH_PLACEHOLDER: 'Search by problem number or title',
   TAGS: 'Tags',
   VERDICT: 'Verdict',
   DIFFICULTY: 'Difficulty',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -43,6 +43,7 @@ export const localeRu = {
   ADVANCED: 'Продвинутый',
   EXTREMAL: 'Сложнейший',
   TITLE: 'Название',
+  PROBLEMS_SEARCH_PLACEHOLDER: 'Поиск по номеру или названию задачи',
   TAGS: 'Теги',
   DIFFICULTY: 'Сложность',
   RATING: 'Рейтинг',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -43,6 +43,7 @@ export const localeUz = {
   ADVANCED: 'Ilgʻor',
   EXTREMAL: 'Juda qiyin',
   TITLE: 'Nomi',
+  PROBLEMS_SEARCH_PLACEHOLDER: 'Masala raqami yoki nomi bo‘yicha qidirish',
   TAGS: 'Teglar',
   DIFFICULTY: 'Qiyinchligi',
   RATING: 'Reyting',

--- a/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.html
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.html
@@ -15,7 +15,7 @@
               class="form-control"
               formControlName="search"
               name="title"
-              placeholder="{{ 'TITLE' | translate }}"
+              placeholder="{{ 'PROBLEMS_SEARCH_PLACEHOLDER' | translate }}"
               type="text"
             />
           </div>


### PR DESCRIPTION
## Summary
- replace the problems filter search placeholder with a dedicated translation key
- add localized values for the new placeholder text in English, Russian, and Uzbek

## Testing
- npm run lint *(fails: ng not found in environment)*
- npx ng lint *(fails: Angular CLI executable unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe787c160832fb85694778762638a