### PR TITLE
Use autocomplete filters on practice attempts page

### DIFF
--- a/src/app/modules/problems/components/attempts-filter/attempts-filter.component.html
+++ b/src/app/modules/problems/components/attempts-filter/attempts-filter.component.html
@@ -20,7 +20,10 @@
             {{ 'Problem' | translate }} ID
           </label>
 
-          <input class="form-control" formControlName="problemId">
+          <problem-autocomplete
+            class="w-100"
+            formControlName="problemId"
+          ></problem-autocomplete>
         </div>
       </div>
 
@@ -31,7 +34,11 @@
             {{ 'Username' | translate }}
           </label>
 
-          <input class="form-control" formControlName="username">
+          <user-autocomplete
+            class="w-100"
+            formControlName="username"
+            [showAvatar]="true"
+          ></user-autocomplete>
         </div>
       </div>
 

--- a/src/app/modules/problems/components/attempts-filter/attempts-filter.component.ts
+++ b/src/app/modules/problems/components/attempts-filter/attempts-filter.component.ts
@@ -10,6 +10,8 @@ import { debounceTime, takeUntil } from 'rxjs/operators';
 import { AttemptsFilter } from '@problems/interfaces';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
+import { ProblemAutocompleteComponent } from '@shared/components/problem-autocomplete/problem-autocomplete.component';
+import { UserAutocompleteComponent } from '@shared/components/user-autocomplete/user-autocomplete.component';
 
 @Component({
   selector: 'attempts-filter',
@@ -20,7 +22,9 @@ import { KepCardComponent } from "@shared/components/kep-card/kep-card.component
     VerdictsSelectComponent,
     ReactiveFormsModule,
     NgbTooltipModule,
-    KepCardComponent
+    KepCardComponent,
+    ProblemAutocompleteComponent,
+    UserAutocompleteComponent,
   ],
   templateUrl: './attempts-filter.component.html',
   styleUrl: './attempts-filter.component.scss'

--- a/src/app/shared/components/problem-autocomplete/problem-autocomplete.component.html
+++ b/src/app/shared/components/problem-autocomplete/problem-autocomplete.component.html
@@ -1,0 +1,23 @@
+<ng-select
+  [items]="problemOptions"
+  [bindValue]="'id'"
+  [bindLabel]="'label'"
+  [formControl]="control"
+  [loading]="loading"
+  [clearable]="clearable"
+  [placeholder]="placeholder"
+  [appendTo]="appendTo"
+  [searchable]="true"
+  (search)="handleSearch($event)"
+  (blur)="handleBlur()"
+  (open)="onOpen()"
+  [notFoundText]="notFoundText"
+>
+  <ng-template ng-option-tmp let-item="item">
+    <div class="problem-option">
+      <span class="problem-option__id">{{ item.id }}.</span>
+      <span class="problem-option__title">{{ item.title }}</span>
+    </div>
+  </ng-template>
+</ng-select>
+<ng-select-css></ng-select-css>

--- a/src/app/shared/components/problem-autocomplete/problem-autocomplete.component.scss
+++ b/src/app/shared/components/problem-autocomplete/problem-autocomplete.component.scss
@@ -1,0 +1,15 @@
+.problem-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.problem-option__id {
+  font-weight: 600;
+  color: var(--bs-primary, #7367f0);
+}
+
+.problem-option__title {
+  flex: 1;
+  min-width: 0;
+}

--- a/src/app/shared/components/problem-autocomplete/problem-autocomplete.component.ts
+++ b/src/app/shared/components/problem-autocomplete/problem-autocomplete.component.ts
@@ -1,0 +1,200 @@
+import { CommonModule } from '@angular/common';
+import { Component, forwardRef, Input, OnDestroy, OnInit } from '@angular/core';
+import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
+import { Subject, of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, finalize, map, switchMap, takeUntil, take } from 'rxjs/operators';
+import { ProblemsApiService } from '@problems/services/problems-api.service';
+import { Problem } from '@problems/models/problems.models';
+import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
+import { PageResult } from '@core/common/classes/page-result';
+
+interface ProblemOption {
+  id: number;
+  title: string;
+  label: string;
+}
+
+@Component({
+  selector: 'problem-autocomplete',
+  standalone: true,
+  templateUrl: './problem-autocomplete.component.html',
+  styleUrls: ['./problem-autocomplete.component.scss'],
+  imports: [CommonModule, ReactiveFormsModule, NgSelectModule],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => ProblemAutocompleteComponent),
+      multi: true,
+    },
+  ],
+})
+export class ProblemAutocompleteComponent implements ControlValueAccessor, OnInit, OnDestroy {
+  @Input() placeholder = 'Masala tanlang';
+  @Input() notFoundText = 'Natija topilmadi';
+  @Input() minSearchLength = 0;
+  @Input() debounceTime = 300;
+  @Input() pageSize = 10;
+  @Input() appendTo: string | null = 'body';
+  @Input() clearable = true;
+
+  readonly control = new FormControl<number | null>(null);
+  protected problemOptions: ProblemOption[] = [];
+  protected loading = false;
+  protected disabled = false;
+
+  private selectedOption: ProblemOption | null = null;
+  private readonly destroy$ = new Subject<void>();
+  private readonly search$ = new Subject<string>();
+
+  private onChange: (value: number | null) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  constructor(private readonly problemsApi: ProblemsApiService) {}
+
+  ngOnInit(): void {
+    this.control.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((value) => {
+        this.onChange(value ?? null);
+        if (value === null || value === undefined) {
+          this.selectedOption = null;
+        } else {
+          const found = this.problemOptions.find((option) => option.id === value);
+          if (found) {
+            this.selectedOption = found;
+          }
+        }
+      });
+
+    this.search$
+      .pipe(
+        takeUntil(this.destroy$),
+        debounceTime(this.debounceTime),
+        distinctUntilChanged(),
+        switchMap((term) => {
+          if (term.length < this.minSearchLength) {
+            return of<ProblemOption[]>([]);
+          }
+          this.loading = true;
+          return this.fetchProblems(term).pipe(
+            finalize(() => {
+              this.loading = false;
+            })
+          );
+        })
+      )
+      .subscribe((options) => {
+        this.problemOptions = this.mergeSelectedOption(options);
+      });
+
+    this.triggerSearch('');
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  writeValue(value: number | null): void {
+    if (value === null || value === undefined) {
+      this.control.setValue(null, { emitEvent: false });
+      this.selectedOption = null;
+      return;
+    }
+
+    const numericValue = Number(value);
+    if (Number.isNaN(numericValue)) {
+      this.control.setValue(null, { emitEvent: false });
+      this.selectedOption = null;
+      return;
+    }
+
+    this.control.setValue(numericValue, { emitEvent: false });
+    this.loadProblem(numericValue);
+  }
+
+  registerOnChange(fn: (value: number | null) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+    if (isDisabled) {
+      this.control.disable({ emitEvent: false });
+    } else {
+      this.control.enable({ emitEvent: false });
+    }
+  }
+
+  protected handleSearch({ term }: { term: string }): void {
+    this.triggerSearch(term ?? '');
+  }
+
+  protected handleBlur(): void {
+    this.onTouched();
+  }
+
+  protected onOpen(): void {
+    if (!this.problemOptions.length) {
+      this.triggerSearch('');
+    }
+  }
+
+  private triggerSearch(term: string): void {
+    this.search$.next(term);
+  }
+
+  private fetchProblems(term: string) {
+    return this.problemsApi
+      .getProblems({
+        search: term,
+        page: 1,
+        pageSize: this.pageSize,
+      })
+      .pipe(
+        map((response: PageResult<Problem>) =>
+          response.data.map((problem) => this.mapProblemToOption(problem))
+        ),
+        catchError(() => of<ProblemOption[]>([]))
+      );
+  }
+
+  private loadProblem(id: number): void {
+    this.problemsApi
+      .getProblem(id)
+      .pipe(
+        take(1),
+        map((problem: Problem) => this.mapProblemToOption(problem)),
+        catchError(() => of<ProblemOption | null>(null))
+      )
+      .subscribe((option) => {
+        if (!option) {
+          return;
+        }
+        this.selectedOption = option;
+        this.problemOptions = this.mergeSelectedOption(this.problemOptions);
+      });
+  }
+
+  private mergeSelectedOption(options: ProblemOption[]): ProblemOption[] {
+    if (this.selectedOption) {
+      const exists = options.some((option) => option.id === this.selectedOption!.id);
+      if (!exists) {
+        return [this.selectedOption, ...options];
+      }
+    }
+    return options;
+  }
+
+  private mapProblemToOption(problem: Problem): ProblemOption {
+    return {
+      id: problem.id,
+      title: problem.title,
+      label: `${problem.id}. ${problem.title}`,
+    };
+  }
+}

--- a/src/app/shared/components/user-autocomplete/user-autocomplete.component.html
+++ b/src/app/shared/components/user-autocomplete/user-autocomplete.component.html
@@ -1,0 +1,28 @@
+<ng-select
+  [items]="userOptions"
+  [bindValue]="'username'"
+  [bindLabel]="'label'"
+  [formControl]="control"
+  [loading]="loading"
+  [clearable]="clearable"
+  [placeholder]="placeholder"
+  [appendTo]="appendTo"
+  [searchable]="true"
+  (search)="handleSearch($event)"
+  (blur)="handleBlur()"
+  (open)="onOpen()"
+  [notFoundText]="notFoundText"
+>
+  <ng-template ng-option-tmp let-item="item">
+    <div class="user-option">
+      <img
+        *ngIf="showAvatar && item.avatar"
+        [src]="item.avatar"
+        [alt]="item.username"
+        class="user-option__avatar"
+      />
+      <span class="user-option__username">{{ item.username }}</span>
+    </div>
+  </ng-template>
+</ng-select>
+<ng-select-css></ng-select-css>

--- a/src/app/shared/components/user-autocomplete/user-autocomplete.component.scss
+++ b/src/app/shared/components/user-autocomplete/user-autocomplete.component.scss
@@ -1,0 +1,16 @@
+.user-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.user-option__avatar {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.user-option__username {
+  font-weight: 500;
+}

--- a/src/app/shared/components/user-autocomplete/user-autocomplete.component.ts
+++ b/src/app/shared/components/user-autocomplete/user-autocomplete.component.ts
@@ -1,0 +1,196 @@
+import { CommonModule } from '@angular/common';
+import { Component, forwardRef, Input, OnDestroy, OnInit } from '@angular/core';
+import { ControlValueAccessor, FormControl, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
+import { Subject, of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, finalize, map, switchMap, take, takeUntil } from 'rxjs/operators';
+import { UsersApiService } from '@users/data-access/api/users-api.service';
+import { User } from '@users/domain/entities/user.entity';
+import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
+import { PageResult } from '@shared/components/table';
+
+interface UserOption {
+  username: string;
+  avatar?: string;
+  label: string;
+}
+
+@Component({
+  selector: 'user-autocomplete',
+  standalone: true,
+  templateUrl: './user-autocomplete.component.html',
+  styleUrls: ['./user-autocomplete.component.scss'],
+  imports: [CommonModule, ReactiveFormsModule, NgSelectModule],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => UserAutocompleteComponent),
+      multi: true,
+    },
+  ],
+})
+export class UserAutocompleteComponent implements ControlValueAccessor, OnInit, OnDestroy {
+  @Input() placeholder = 'Foydalanuvchi tanlang';
+  @Input() notFoundText = 'Natija topilmadi';
+  @Input() minSearchLength = 0;
+  @Input() debounceTime = 300;
+  @Input() pageSize = 10;
+  @Input() appendTo: string | null = 'body';
+  @Input() clearable = true;
+  @Input() showAvatar = true;
+
+  readonly control = new FormControl<string | null>(null);
+  protected userOptions: UserOption[] = [];
+  protected loading = false;
+  protected disabled = false;
+
+  private selectedOption: UserOption | null = null;
+  private readonly destroy$ = new Subject<void>();
+  private readonly search$ = new Subject<string>();
+
+  private onChange: (value: string | null) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  constructor(private readonly usersApi: UsersApiService) {}
+
+  ngOnInit(): void {
+    this.control.valueChanges
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((value) => {
+        this.onChange(value ?? null);
+        if (!value) {
+          this.selectedOption = null;
+          return;
+        }
+        const found = this.userOptions.find((option) => option.username === value);
+        if (found) {
+          this.selectedOption = found;
+        }
+      });
+
+    this.search$
+      .pipe(
+        takeUntil(this.destroy$),
+        debounceTime(this.debounceTime),
+        distinctUntilChanged(),
+        switchMap((term) => {
+          if (term.length < this.minSearchLength) {
+            return of<UserOption[]>([]);
+          }
+          this.loading = true;
+          return this.fetchUsers(term).pipe(
+            finalize(() => {
+              this.loading = false;
+            })
+          );
+        })
+      )
+      .subscribe((options) => {
+        this.userOptions = this.mergeSelectedOption(options);
+      });
+
+    this.triggerSearch('');
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  writeValue(value: string | null): void {
+    if (!value) {
+      this.control.setValue(null, { emitEvent: false });
+      this.selectedOption = null;
+      return;
+    }
+
+    this.control.setValue(value, { emitEvent: false });
+    this.loadUser(value);
+  }
+
+  registerOnChange(fn: (value: string | null) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled = isDisabled;
+    if (isDisabled) {
+      this.control.disable({ emitEvent: false });
+    } else {
+      this.control.enable({ emitEvent: false });
+    }
+  }
+
+  protected handleSearch({ term }: { term: string }): void {
+    this.triggerSearch(term ?? '');
+  }
+
+  protected handleBlur(): void {
+    this.onTouched();
+  }
+
+  protected onOpen(): void {
+    if (!this.userOptions.length) {
+      this.triggerSearch('');
+    }
+  }
+
+  private triggerSearch(term: string): void {
+    this.search$.next(term);
+  }
+
+  private fetchUsers(term: string) {
+    return this.usersApi
+      .getUsers({
+        search: term,
+        page: 1,
+        pageSize: this.pageSize,
+      })
+      .pipe(
+        map((response: PageResult<User>) =>
+          response.data.map((user) => this.mapUserToOption(user))
+        ),
+        catchError(() => of<UserOption[]>([]))
+      );
+  }
+
+  private loadUser(username: string): void {
+    this.usersApi
+      .getUser(username)
+      .pipe(
+        take(1),
+        map((user: User) => this.mapUserToOption(user)),
+        catchError(() => of<UserOption | null>(null))
+      )
+      .subscribe((option) => {
+        if (!option) {
+          return;
+        }
+        this.selectedOption = option;
+        this.userOptions = this.mergeSelectedOption(this.userOptions);
+      });
+  }
+
+  private mergeSelectedOption(options: UserOption[]): UserOption[] {
+    if (this.selectedOption) {
+      const exists = options.some(
+        (option) => option.username === this.selectedOption!.username
+      );
+      if (!exists) {
+        return [this.selectedOption, ...options];
+      }
+    }
+    return options;
+  }
+
+  private mapUserToOption(user: User): UserOption {
+    return {
+      username: user.username,
+      avatar: user.avatar,
+      label: user.username,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- replace the attempts filter text inputs with the shared problem and user autocomplete components
- wire the attempts filter component to import the new standalone autocompletes for use in the practice attempts page

## Testing
- npm run lint *(fails: ng not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfea5fc338832f921aeb2dd6e4837b