### PR TITLE
feat: localize ng-select not found text

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,8 @@ import { localeEn } from "./i18n/en";
 import { localeRu } from "./i18n/ru";
 import { localeUz } from "./i18n/uz";
 import { CoreLoadingScreenService } from "@core/services/loading-screen.service";
+import { NgSelectConfig } from '@ng-select/ng-select';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-root',
@@ -17,16 +19,27 @@ import { CoreLoadingScreenService } from "@core/services/loading-screen.service"
 export class AppComponent {
   protected translateService = inject(TranslateService);
   protected coreLoadingService = inject(CoreLoadingScreenService);
+  private ngSelectConfig = inject(NgSelectConfig);
 
   constructor(private appStateService: AppStateService) {
     this.translateService.setTranslation('en', localeEn);
     this.translateService.setTranslation('ru', localeRu);
     this.translateService.setTranslation('uz', localeUz);
 
-    this.appStateService.state$.subscribe(
-      (state) => {
+    this.appStateService.state$
+      .pipe(takeUntilDestroyed())
+      .subscribe((state) => {
         this.translateService.setDefaultLang(state.language);
-      }
-    )
+        this.setNgSelectGlobalTexts();
+      });
+
+    this.translateService.onDefaultLangChange
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => this.setNgSelectGlobalTexts());
+  }
+
+  private setNgSelectGlobalTexts(): void {
+    this.ngSelectConfig.notFoundText = this.translateService.instant('NG_SELECT.NOT_FOUND');
+    this.ngSelectConfig.loadingText = this.translateService.instant('NG_SELECT.LOADING');
   }
 }

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -66,6 +66,10 @@ export const localeEn = {
   SOLVED: 'Solved',
   NOT_SOLVED: 'Not solved',
   SELECT: 'Select',
+  NG_SELECT: {
+    NOT_FOUND: 'No options found',
+    LOADING: 'Loading...',
+  },
   NEWS: 'News',
   LAST_COMMENTS: 'Last comments',
   LAST_POSTS: 'Last posts',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -56,6 +56,10 @@ export const localeRu = {
   SOLVED: 'Решенный',
   NOT_SOLVED: 'Нерешенный',
   SELECT: 'Выбрать',
+  NG_SELECT: {
+    NOT_FOUND: 'Ничего не найдено',
+    LOADING: 'Загрузка...',
+  },
   NEWS: 'Новости',
   LAST_COMMENTS: 'Последние комментарии',
   LAST_POSTS: 'Последние посты',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -56,6 +56,10 @@ export const localeUz = {
   SOLVED: 'Ishlangan',
   NOT_SOLVED: 'Ishlanmagan',
   SELECT: 'Tanlash',
+  NG_SELECT: {
+    NOT_FOUND: 'Hech narsa topilmadi',
+    LOADING: 'Yuklanmoqda...',
+  },
   NEWS: 'Yangiliklar',
   LAST_COMMENTS: 'Soʻngi izohlar',
   LAST_POSTS: 'Yangi postlar',


### PR DESCRIPTION
## Summary
- add localized NG_SELECT not found strings for English, Russian, and Uzbek
- configure the root component to update the global ng-select notFoundText whenever the active language changes
- localize the global ng-select loadingText so it updates with the active language

## Testing
- npm run lint *(fails: `ng` command not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfecbd8ba8832fbfb5ab95254cc6b1