### PR TITLE
Add user-specific attempts route and enhance filters

### DIFF
--- a/src/app/modules/problems/components/attempts-filter/attempts-filter.component.html
+++ b/src/app/modules/problems/components/attempts-filter/attempts-filter.component.html
@@ -5,8 +5,26 @@
       {{ 'Filter' | translate }}
     </div>
 
-    <div class="filter-clear">
-      <button (click)="filterClear()" class="btn btn-primary btn-sm" ngbTooltip="{{ 'Clear' | translate }}">
+    <div class="filter-actions">
+      <button
+        (click)="myAttemptsClick()"
+        class="btn btn-outline-primary btn-sm"
+        type="button">
+        {{ 'MY_ATTEMPTS' | translate }}
+      </button>
+
+      <button
+        (click)="refresh.emit()"
+        class="btn btn-outline-primary btn-sm"
+        type="button">
+        {{ 'Reload' | translate }}
+      </button>
+
+      <button
+        (click)="filterClear()"
+        class="btn btn-primary btn-sm"
+        ngbTooltip="{{ 'Clear' | translate }}"
+        type="button">
         <kep-icon name="cross" size="small-4"/>
       </button>
     </div>
@@ -38,19 +56,34 @@
       <div class="col-6 col-lg-3">
         <div class="mb-1">
           <label class="text-primary">
+            <kep-icon name="lang" size="small-4"/>
+            {{ 'Language' | translate }}
+          </label>
+
+          <ng-select
+            appendTo="body"
+            [placeholder]="'Language' | translate"
+            [searchable]="false"
+            formControlName="lang">
+            <ng-option></ng-option>
+            @for (item of langOptions; track item.lang) {
+              <ng-option [value]="item.lang">
+                <attempt-language [size]="24" [lang]="item.lang"/>
+                {{ item.langFull }}
+              </ng-option>
+            }
+          </ng-select>
+        </div>
+      </div>
+
+      <div class="col-6 col-lg-3">
+        <div class="mb-1">
+          <label class="text-primary">
             <kep-icon name="verdict" size="small-4"/>
             {{ 'Verdict' | translate }}
           </label>
           <verdicts-select formControlName="verdict"/>
         </div>
-      </div>
-
-      <div class="col-6 col-lg-3 d-flex align-items-center">
-        <button
-          (click)="myAttemptsClick()"
-          class="btn full-width mt-2 py-75 btn-sm btn-primary">
-          {{ 'MY_ATTEMPTS' | translate }}
-        </button>
       </div>
     </div>
   </div>

--- a/src/app/modules/problems/components/attempts-filter/attempts-filter.component.scss
+++ b/src/app/modules/problems/components/attempts-filter/attempts-filter.component.scss
@@ -1,0 +1,17 @@
+:host ::ng-deep kep-card .card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+:host ::ng-deep .filter-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+:host ::ng-deep .filter-actions .btn {
+  white-space: nowrap;
+}

--- a/src/app/modules/problems/components/attempts-filter/attempts-filter.component.ts
+++ b/src/app/modules/problems/components/attempts-filter/attempts-filter.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
 import { TranslateModule } from '@ngx-translate/core';
 import {
@@ -14,6 +14,9 @@ import { UsersAutocompleteComponent } from "@shared/components/users-autocomplet
 import {
   ProblemsAutocompleteComponent
 } from "@shared/components/problems-autocomplete/problems-autocomplete.component";
+import { NgSelectModule } from "@shared/third-part-modules/ng-select/ng-select.module";
+import { AttemptLanguageComponent } from "@shared/components/attempt-language/attempt-language.component";
+import { ProblemsApiService } from "@problems/services/problems-api.service";
 
 @Component({
   selector: 'attempts-filter',
@@ -26,19 +29,45 @@ import {
     NgbTooltipModule,
     KepCardComponent,
     UsersAutocompleteComponent,
-    ProblemsAutocompleteComponent
+    ProblemsAutocompleteComponent,
+    NgSelectModule,
+    AttemptLanguageComponent
   ],
   templateUrl: './attempts-filter.component.html',
   styleUrl: './attempts-filter.component.scss'
 })
 export class AttemptsFilterComponent extends BaseUserComponent implements OnInit {
   @Output() filterChange = new EventEmitter<AttemptsFilter>;
+  @Output() refresh = new EventEmitter<void>;
+
+  @Input()
+  set initialFilter(filter: Partial<AttemptsFilter> | null) {
+    if (!filter) {
+      return;
+    }
+
+    const problemId = filter.problemId !== undefined && filter.problemId !== null ? Number(filter.problemId) : null;
+
+    this.form.patchValue({
+      username: filter.username ?? null,
+      problemId: problemId !== null && !Number.isNaN(problemId) ? problemId : null,
+      verdict: filter.verdict ?? null,
+      lang: filter.lang ?? null,
+    }, {emitEvent: false});
+  }
 
   public form = new FormGroup({
     username: new FormControl(),
     problemId: new FormControl(),
     verdict: new FormControl(),
+    lang: new FormControl(),
   });
+
+  public langOptions: Array<{ lang: string; langFull: string }> = [];
+
+  constructor(private problemsService: ProblemsApiService) {
+    super();
+  }
 
   ngOnInit() {
     this.form.valueChanges.pipe(
@@ -47,6 +76,12 @@ export class AttemptsFilterComponent extends BaseUserComponent implements OnInit
     ).subscribe(
       (value) => {
         this.filterChange.next(value as AttemptsFilter);
+      }
+    );
+    this.problemsService.getLangs().subscribe(
+      langs => {
+        this.langOptions = langs || [];
+        this.cdr.markForCheck();
       }
     );
   }
@@ -60,6 +95,7 @@ export class AttemptsFilterComponent extends BaseUserComponent implements OnInit
       username: null,
       problemId: null,
       verdict: null,
+      lang: null,
     });
   }
 }

--- a/src/app/modules/problems/interfaces/attempts-filter.ts
+++ b/src/app/modules/problems/interfaces/attempts-filter.ts
@@ -1,7 +1,8 @@
 import { Verdicts } from '@problems/constants';
 
 export interface AttemptsFilter {
-  username: string;
-  problemId: number;
-  verdict: Verdicts;
+  username: string | null;
+  problemId: number | null;
+  verdict: Verdicts | null;
+  lang: string | null;
 }

--- a/src/app/modules/problems/pages/attempts/attempts.component.html
+++ b/src/app/modules/problems/pages/attempts/attempts.component.html
@@ -3,7 +3,10 @@
     <app-content-header (refresh)="reloadPage()" [contentHeader]="contentHeader"></app-content-header>
 
     @if (currentUser) {
-      <attempts-filter (filterChange)="filterChange($event)"/>
+      <attempts-filter
+        (filterChange)="filterChange($event)"
+        (refresh)="reloadPage()"
+        [initialFilter]="initialFilter"/>
     }
 
     @if (!attempts && isLoading) {

--- a/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.html
+++ b/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.html
@@ -9,6 +9,11 @@
       <div class="font-medium-5 mt-1">
         {{ 'Problems' | translate }}
         <br>
+        <a
+          [routerLink]="[Resources.Attempts, username]"
+          class="btn btn-outline-primary btn-sm mt-1 attempts-link">
+          {{ 'Attempts' | translate }}
+        </a>
         <div class="font-medium-4 mt-2">
           <span ngbTooltip="{{ 'Solved' | translate }}">
             <i data-feather="check-circle"></i>

--- a/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.ts
+++ b/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.ts
@@ -5,6 +5,7 @@ import { CoreCommonModule } from '@core/common.module';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { GeneralInfo } from '@problems/models/statistics.models';
 import { getCategoryIcon } from '@problems/utils/category';
+import { Resources } from "@app/resources";
 
 interface LangInfo {
   lang: string;
@@ -38,6 +39,8 @@ interface TopicInfo {
 export class SectionProfileComponent implements OnInit {
 
   @Input() username: string;
+
+  public readonly Resources = Resources;
 
   public general: GeneralInfo = {
     solved: 0,

--- a/src/app/modules/problems/problems.routing.ts
+++ b/src/app/modules/problems/problems.routing.ts
@@ -66,6 +66,12 @@ export default [
     data: {animation: 'attempts'},
     title: 'Problems.Attempts',
   },
+  {
+    path: 'attempts/:username',
+    loadComponent: () => import('./pages/attempts/attempts.component').then(c => c.AttemptsComponent),
+    data: {animation: 'attempts'},
+    title: 'Problems.Attempts',
+  },
   // {
   //   path: 'attempts/:id',
   //   loadComponent: () => import('./pages/attempts/attempts.component').then(c => c.AttemptsComponent),

--- a/src/app/resources.ts
+++ b/src/app/resources.ts
@@ -5,6 +5,7 @@ export enum Resources {
   Problem = '/practice/problems/problem/:id',
 
   Attempts = '/practice/problems/attempts',
+  AttemptsByUser = '/practice/problems/attempts/:username',
 
   Contests = '/competitions/contests',
   Contest = '/competitions/contests/contest/:id',


### PR DESCRIPTION
## Summary
- add a dedicated /practice/problems/attempts/:username route that pre-fills the attempts filter
- enhance the attempts filter UI with language selection, refresh control, and header actions
- link the problems section of the user profile to the new attempts view

## Testing
- `npm run lint` *(fails: ng not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cff6de1804832f9ef10935e9cbed01