### PR TITLE
Internationalize ix-table pagination labels

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -70,6 +70,10 @@ export const localeEn = {
     NOT_FOUND: 'No options found',
     LOADING: 'Loading...',
   },
+  TABLE: {
+    SHOWING: 'Showing',
+    OF: 'of',
+  },
   NEWS: 'News',
   LAST_COMMENTS: 'Last comments',
   LAST_POSTS: 'Last posts',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -60,6 +60,10 @@ export const localeRu = {
     NOT_FOUND: 'Ничего не найдено',
     LOADING: 'Загрузка...',
   },
+  TABLE: {
+    SHOWING: 'Показано',
+    OF: 'из',
+  },
   NEWS: 'Новости',
   LAST_COMMENTS: 'Последние комментарии',
   LAST_POSTS: 'Последние посты',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -60,6 +60,10 @@ export const localeUz = {
     NOT_FOUND: 'Hech narsa topilmadi',
     LOADING: 'Yuklanmoqda...',
   },
+  TABLE: {
+    SHOWING: 'Koʻrsatilmoqda',
+    OF: 'dan',
+  },
   NEWS: 'Yangiliklar',
   LAST_COMMENTS: 'Soʻngi izohlar',
   LAST_POSTS: 'Yangi postlar',

--- a/src/app/shared/components/table/ix-table/ix-table.component.html
+++ b/src/app/shared/components/table/ix-table/ix-table.component.html
@@ -86,13 +86,13 @@
 
 <div class="d-flex justify-content-between align-items-center p-3">
   <div class="d-none d-md-block">
-    Showing
+    {{ 'TABLE.SHOWING' | translate }}
     <span class="fw-bold">
       {{ pageSize * (pageNumber - 1) + 1 }}
       -
       {{ pageSize * pageNumber }}
     </span>
-    of
+    {{ 'TABLE.OF' | translate }}
     <span class="fw-bold">
       {{ total }}
     </span>


### PR DESCRIPTION
## Summary
- localize the ix-table pagination labels using ngx-translate
- add English, Russian, and Uzbek translation entries for the pagination text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d008ddfe54832f90ba1b27108bc7aa