### PR TITLE
Switch user popover to click trigger and add detail link

### DIFF
--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.html
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.html
@@ -22,20 +22,27 @@
         @if (userRatings) {
         }
       </div>
+      <div class="card-footer border-0 bg-transparent pt-0">
+        <a
+          [routerLink]="['/users', 'user', username]"
+          class="btn btn-outline-primary btn-sm w-100"
+        >
+          View user details
+        </a>
+      </div>
     </kep-card>
   }
 </ng-template>
-<a
+<button
+  type="button"
   (shown)="loadUser()"
-  [closeDelay]="2000"
+  [autoClose]="'outside'"
   [ngbPopover]="popContent"
-  [openDelay]="1000"
   [placement]="placement"
-  [routerLink]="['/users', 'user', username]"
-  class="text-{{ textColor }} {{ customClass }}"
+  class="popover-trigger text-{{ textColor }} {{ customClass }}"
   container="body"
   popoverClass="user-popover"
-  triggers="mouseenter:mouseleave"
+  triggers="click"
 >
   @if (!customContent) {
     <span class="fw-medium">
@@ -45,7 +52,7 @@
   @if (customContent) {
     <ng-content></ng-content>
   }
-</a>
+</button>
 
 @if (!customContent && streak >= 7) {
   <kep-badge [streak]="streak"></kep-badge>

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.scss
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.scss
@@ -22,3 +22,11 @@
     border: none !important;
   }
 }
+
+.popover-trigger {
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}


### PR DESCRIPTION
## Summary
- open the user popover via click instead of hover and allow loading the user data on demand
- add a button-style link inside the popover that routes to the user detail page
- style the popover trigger button to appear like the previous text link while keeping existing custom content support

## Testing
- npm run lint *(fails: ng command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d05526d5f4832fb0a4535a51be9992