### PR TITLE
Reuse existing rating translations in user popover

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -30,6 +30,9 @@ export const localeEn = {
   Reset: 'Reset',
   Problemset: 'Problemset',
   Profile: 'Profile',
+  UserPopover: {
+    ViewDetails: 'View user details',
+  },
   CustomTest: 'Custom test',
   HasChecker: 'Has checker',
   FilterProblems: 'Filtering problems',
@@ -297,6 +300,7 @@ export const localeEn = {
   Facts: 'Facts',
   NumberOfAttempts: 'Number of attempts',
   Rank: 'Rank',
+  Percentile: 'Percentile',
   Monday: 'Monday',
   Tuesday: 'Tuesday',
   Wednesday: 'Wednesday',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -29,6 +29,9 @@ export const localeRu = {
   Reset: 'Сброс',
   Problemset: 'Набор задач',
   Profile: 'Профиль',
+  UserPopover: {
+    ViewDetails: 'Подробнее о пользователе',
+  },
   CustomTest: 'Тестировать',
   HasChecker: 'Чекер',
   FilterProblems: 'Фильтрация задач',
@@ -294,6 +297,7 @@ export const localeRu = {
   Facts: 'Факты',
   NumberOfAttempts: 'Количество попыток',
   Rank: 'Место',
+  Percentile: 'Процентиль',
   Monday: 'Понедельник',
   Tuesday: 'Вторник',
   Wednesday: 'Среда',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -29,6 +29,9 @@ export const localeUz = {
   Reset: 'Reset',
   Problemset: 'Masalalar toʻplami',
   Profile: 'Profil',
+  UserPopover: {
+    ViewDetails: 'Profilni koʻrish',
+  },
   CustomTest: 'Ishlatib koʻrish',
   HasChecker: 'Cheker',
   FilterProblems: 'Masalalarni filterlash',
@@ -293,6 +296,7 @@ export const localeUz = {
   Facts: 'Faktlar',
   NumberOfAttempts: 'Urinishlar soni',
   Rank: 'Oʻrin',
+  Percentile: 'Foizlik koʻrsatkich',
   Monday: 'Dushanba',
   Tuesday: 'Seshanba',
   Wednesday: 'Chorshanba',

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.html
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.html
@@ -1,25 +1,65 @@
 <ng-template #popContent>
   @if (user && userRatings) {
-    <kep-card >
+    <kep-card>
       <img
         [src]="user.coverPhoto"
         class="img-fluid card-img-top"
         alt="Profile Cover Photo"/>
-      <div class="card-body d-flex justify-content-start gap-2">
-        <div class="avatar avatar-rounded" [class]="{
-          'online': user.isOnline,
-          'offline': !user.isOnline
-        }">
-          <img [src]="user.avatar" alt="Profile Picture"/>
+      <div class="card-body">
+        <div class="user-popover__header d-flex gap-2 align-items-center">
+          <div class="avatar avatar-rounded" [class]="{
+            'online': user.isOnline,
+            'offline': !user.isOnline
+          }">
+            <img [src]="user.avatar" alt="Profile Picture"/>
+          </div>
+
+          <div class="name">
+            <div class="full-name">
+              {{ user.firstName }} {{ user.lastName }}
+            </div>
+            <small class="text-muted">@{{ user.username }}</small>
+          </div>
         </div>
 
-        <div class="name">
-          <div class="full-name">
-            {{ user.firstName }} {{ user.lastName }}
+        @if (ratingStats.length) {
+          <div class="ratings mt-3">
+            @for (stat of ratingStats; track stat.key) {
+              <div class="rating-item">
+                <div class="d-flex align-items-center justify-content-between gap-2 mb-1">
+                  <span class="text-uppercase text-muted fw-semibold small">
+                    {{ stat.translationKey | translate }}
+                  </span>
+                  @if (stat.title) {
+                    <span class="rating-item__title">{{ stat.title }}</span>
+                  }
+                </div>
+                <div class="d-flex align-items-baseline gap-2">
+                  <span class="rating-item__value fw-semibold">
+                    {{ stat.value | number: stat.format }}
+                  </span>
+                </div>
+                <div class="d-flex flex-wrap gap-2 justify-content-between small text-muted mt-2">
+                  <span>
+                    {{ 'Rank' | translate }}
+                    @if (stat.rank !== undefined && stat.rank !== null) {
+                      <span class="text-body fw-semibold">#{{ stat.rank | number: '1.0-0' }}</span>
+                    } @else {
+                      <span class="text-body fw-semibold">—</span>
+                    }
+                  </span>
+                  <span>
+                    {{ 'Percentile' | translate }}
+                    @if (stat.percentile !== undefined && stat.percentile !== null) {
+                      <span class="text-body fw-semibold">{{ stat.percentile | number: '1.0-1' }}%</span>
+                    } @else {
+                      <span class="text-body fw-semibold">—</span>
+                    }
+                  </span>
+                </div>
+              </div>
+            }
           </div>
-          <small>{{ user.username }}</small>
-        </div>
-        @if (userRatings) {
         }
       </div>
       <div class="card-footer border-0 bg-transparent pt-0">
@@ -27,7 +67,7 @@
           [routerLink]="['/users', 'user', username]"
           class="btn btn-outline-primary btn-sm w-100"
         >
-          View user details
+          {{ 'UserPopover.ViewDetails' | translate }}
         </a>
       </div>
     </kep-card>

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.scss
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.scss
@@ -30,3 +30,45 @@
   cursor: pointer;
   text-align: left;
 }
+
+.user-popover__header {
+  flex-wrap: wrap;
+}
+
+.ratings {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.rating-item {
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(var(--bs-primary-rgb), 0.06);
+  border: 1px solid rgba(var(--bs-body-color-rgb), 0.08);
+
+  @include dark-layout {
+    background: rgba(var(--bs-primary-rgb), 0.2);
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.rating-item__value {
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.rating-item__title {
+  border-radius: 999px;
+  padding: 0.125rem 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  background: rgba(var(--bs-primary-rgb), 0.16);
+  color: var(--bs-primary);
+
+  @include dark-layout {
+    background: rgba(255, 255, 255, 0.15);
+    color: white;
+  }
+}

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.ts
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.ts
@@ -2,6 +2,32 @@ import { ChangeDetectorRef, Component, inject, Input, OnInit, ViewEncapsulation 
 import { ApiService } from '@core/data-access/api.service';
 import { User } from "@users/domain";
 
+type RatingKey = 'skillsRating' | 'activityRating' | 'contestsRating' | 'challengesRating';
+
+interface RatingInfo {
+  value: number;
+  rank?: number;
+  percentile?: number;
+  title?: string;
+}
+
+interface UserRatingsResponse {
+  skillsRating?: RatingInfo;
+  activityRating?: RatingInfo;
+  contestsRating?: RatingInfo;
+  challengesRating?: RatingInfo;
+}
+
+interface RatingStat {
+  key: RatingKey;
+  translationKey: string;
+  value: number;
+  rank?: number;
+  percentile?: number;
+  title?: string;
+  format: string;
+}
+
 @Component({
   selector: 'user-popover',
   templateUrl: './user-popover.component.html',
@@ -19,8 +45,16 @@ export class UserPopoverComponent implements OnInit {
   @Input() customContent = false;
 
   public user: User;
-  public userRatings: any;
+  public userRatings: UserRatingsResponse;
+  public ratingStats: RatingStat[] = [];
   protected cdr = inject(ChangeDetectorRef);
+
+  private readonly ratingConfig: Array<{ key: RatingKey; translationKey: string }> = [
+    { key: 'skillsRating', translationKey: 'SkillsRating' },
+    { key: 'activityRating', translationKey: 'ActivityRating' },
+    { key: 'contestsRating', translationKey: 'Contests.ContestsRating' },
+    { key: 'challengesRating', translationKey: 'PageTitle.Challenges.ChallengesRating' },
+  ];
 
   constructor(
     public api: ApiService,
@@ -35,11 +69,39 @@ export class UserPopoverComponent implements OnInit {
         this.user = user;
         this.cdr.detectChanges();
       });
-      this.api.get(`users/${this.username}/ratings`).subscribe((userRatings: any) => {
+      this.api.get(`users/${this.username}/ratings`).subscribe((userRatings: UserRatingsResponse) => {
         this.userRatings = userRatings;
+        this.ratingStats = this.buildRatingStats(userRatings);
         this.cdr.detectChanges();
       });
     }
+  }
+
+  private buildRatingStats(userRatings: UserRatingsResponse): RatingStat[] {
+    if (!userRatings) {
+      return [];
+    }
+
+    return this.ratingConfig
+      .map(({ key, translationKey }) => {
+        const rating = userRatings[key];
+        if (!rating || typeof rating.value !== 'number') {
+          return null;
+        }
+
+        const format = Number.isInteger(rating.value) ? '1.0-0' : '1.0-1';
+
+        return {
+          key,
+          translationKey,
+          value: rating.value,
+          rank: rating.rank,
+          percentile: rating.percentile,
+          title: rating.title,
+          format,
+        } as RatingStat;
+      })
+      .filter((stat): stat is RatingStat => !!stat);
   }
 
 }


### PR DESCRIPTION
## Summary
- reuse previously defined translation keys for rating labels in the user popover instead of introducing a new Ratings group
- remove the redundant Ratings translation block from the locale files and add a shared Percentile key alongside the existing Rank key
- keep the refreshed popover layout while sourcing localized contest and challenge labels from their existing namespaces

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d058930890832f8682a9d34d438cbf