### PR TITLE
Refine user popover rating cards

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -30,6 +30,9 @@ export const localeEn = {
   Reset: 'Reset',
   Problemset: 'Problemset',
   Profile: 'Profile',
+  UserPopover: {
+    ViewDetails: 'View user details',
+  },
   CustomTest: 'Custom test',
   HasChecker: 'Has checker',
   FilterProblems: 'Filtering problems',
@@ -297,6 +300,7 @@ export const localeEn = {
   Facts: 'Facts',
   NumberOfAttempts: 'Number of attempts',
   Rank: 'Rank',
+  Percentile: 'Percentile',
   Monday: 'Monday',
   Tuesday: 'Tuesday',
   Wednesday: 'Wednesday',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -29,6 +29,9 @@ export const localeRu = {
   Reset: 'Сброс',
   Problemset: 'Набор задач',
   Profile: 'Профиль',
+  UserPopover: {
+    ViewDetails: 'Подробнее о пользователе',
+  },
   CustomTest: 'Тестировать',
   HasChecker: 'Чекер',
   FilterProblems: 'Фильтрация задач',
@@ -294,6 +297,7 @@ export const localeRu = {
   Facts: 'Факты',
   NumberOfAttempts: 'Количество попыток',
   Rank: 'Место',
+  Percentile: 'Процентиль',
   Monday: 'Понедельник',
   Tuesday: 'Вторник',
   Wednesday: 'Среда',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -29,6 +29,9 @@ export const localeUz = {
   Reset: 'Reset',
   Problemset: 'Masalalar toʻplami',
   Profile: 'Profil',
+  UserPopover: {
+    ViewDetails: 'Profilni koʻrish',
+  },
   CustomTest: 'Ishlatib koʻrish',
   HasChecker: 'Cheker',
   FilterProblems: 'Masalalarni filterlash',
@@ -293,6 +296,7 @@ export const localeUz = {
   Facts: 'Faktlar',
   NumberOfAttempts: 'Urinishlar soni',
   Rank: 'Oʻrin',
+  Percentile: 'Foizlik koʻrsatkich',
   Monday: 'Dushanba',
   Tuesday: 'Seshanba',
   Wednesday: 'Chorshanba',

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.html
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.html
@@ -1,25 +1,75 @@
 <ng-template #popContent>
   @if (user && userRatings) {
-    <kep-card >
+    <kep-card>
       <img
         [src]="user.coverPhoto"
         class="img-fluid card-img-top"
         alt="Profile Cover Photo"/>
-      <div class="card-body d-flex justify-content-start gap-2">
-        <div class="avatar avatar-rounded" [class]="{
-          'online': user.isOnline,
-          'offline': !user.isOnline
-        }">
-          <img [src]="user.avatar" alt="Profile Picture"/>
+      <div class="card-body">
+        <div class="user-popover__header d-flex gap-2 align-items-center">
+          <div class="avatar avatar-rounded" [class]="{
+            'online': user.isOnline,
+            'offline': !user.isOnline
+          }">
+            <img [src]="user.avatar" alt="Profile Picture"/>
+          </div>
+
+          <div class="name">
+            <div class="full-name">
+              {{ user.firstName }} {{ user.lastName }}
+            </div>
+            <small class="text-muted">@{{ user.username }}</small>
+          </div>
         </div>
 
-        <div class="name">
-          <div class="full-name">
-            {{ user.firstName }} {{ user.lastName }}
+        @if (ratingStats.length) {
+          <div class="rating-cards row g-2 mt-3">
+            @for (stat of ratingStats; track stat.key) {
+              <div class="col-12 col-sm-6">
+                <kep-card [customClass]="'rating-card border-0 shadow-none h-100'">
+                  <div class="card-header">
+                    <div class="d-flex align-items-center gap-2">
+                      <span class="rating-card__icon">
+                        <kep-icon
+                          color="primary"
+                          [name]="stat.icon"
+                          type="duotone"/>
+                      </span>
+                      <span class="rating-card__title">{{ stat.translationKey | translate }}</span>
+                    </div>
+                    @if (stat.title) {
+                      <span class="badge rounded-pill bg-primary-subtle text-primary">
+                        {{ stat.title }}
+                      </span>
+                    }
+                  </div>
+                  <div class="card-body">
+                    <div class="rating-card__value">
+                      {{ stat.value | number: stat.format }}
+                    </div>
+                    <div class="rating-card__meta">
+                      <div>
+                        {{ 'Rank' | translate }}
+                        @if (stat.rank !== undefined && stat.rank !== null) {
+                          <span class="rating-card__meta-value">#{{ stat.rank | number: '1.0-0' }}</span>
+                        } @else {
+                          <span class="rating-card__meta-value">—</span>
+                        }
+                      </div>
+                      <div>
+                        {{ 'Percentile' | translate }}
+                        @if (stat.percentile !== undefined && stat.percentile !== null) {
+                          <span class="rating-card__meta-value">{{ stat.percentile | number: '1.0-1' }}%</span>
+                        } @else {
+                          <span class="rating-card__meta-value">—</span>
+                        }
+                      </div>
+                    </div>
+                  </div>
+                </kep-card>
+              </div>
+            }
           </div>
-          <small>{{ user.username }}</small>
-        </div>
-        @if (userRatings) {
         }
       </div>
       <div class="card-footer border-0 bg-transparent pt-0">
@@ -27,7 +77,7 @@
           [routerLink]="['/users', 'user', username]"
           class="btn btn-outline-primary btn-sm w-100"
         >
-          View user details
+          {{ 'UserPopover.ViewDetails' | translate }}
         </a>
       </div>
     </kep-card>

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.scss
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.scss
@@ -5,19 +5,11 @@
 
   .card {
     margin-bottom: 0;
-
-    .card-body {
-      background: white;
-
-      @include dark-layout {
-        background: color-mix(in srgb, black 90%, var(--primary) 10%);
-      }
-    }
   }
 
   .popover-body {
     padding: 0 !important;
-    width: 400px !important;
+    width: 360px !important;
     box-shadow: none !important;
     border: none !important;
   }
@@ -29,4 +21,71 @@
   padding: 0;
   cursor: pointer;
   text-align: left;
+}
+
+.user-popover__header {
+  flex-wrap: wrap;
+}
+
+.rating-card {
+  border: none;
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem;
+    background: linear-gradient(to bottom, rgba(var(--primary-rgb), 0.08), transparent);
+
+    @include dark-layout {
+      background: linear-gradient(to bottom, rgba(255, 255, 255, 0.05), transparent);
+    }
+  }
+
+  .card-body {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 0.5rem;
+    padding: 0.75rem 1rem 1rem;
+  }
+}
+
+.rating-card__icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(var(--primary-rgb), 0.4);
+  background: white;
+
+  @include dark-layout {
+    background: transparent;
+  }
+}
+
+.rating-card__title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.rating-card__value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.rating-card__meta {
+  font-size: 0.75rem;
+  text-align: right;
+  color: var(--bs-secondary-color);
+}
+
+.rating-card__meta-value {
+  color: var(--bs-body-color);
+  font-weight: 600;
 }

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.ts
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.ts
@@ -2,6 +2,33 @@ import { ChangeDetectorRef, Component, inject, Input, OnInit, ViewEncapsulation 
 import { ApiService } from '@core/data-access/api.service';
 import { User } from "@users/domain";
 
+type RatingKey = 'skillsRating' | 'activityRating' | 'contestsRating' | 'challengesRating';
+
+interface RatingInfo {
+  value: number;
+  rank?: number;
+  percentile?: number;
+  title?: string;
+}
+
+interface UserRatingsResponse {
+  skillsRating?: RatingInfo;
+  activityRating?: RatingInfo;
+  contestsRating?: RatingInfo;
+  challengesRating?: RatingInfo;
+}
+
+interface RatingStat {
+  key: RatingKey;
+  translationKey: string;
+  icon: string;
+  value: number;
+  rank?: number;
+  percentile?: number;
+  title?: string;
+  format: string;
+}
+
 @Component({
   selector: 'user-popover',
   templateUrl: './user-popover.component.html',
@@ -19,8 +46,16 @@ export class UserPopoverComponent implements OnInit {
   @Input() customContent = false;
 
   public user: User;
-  public userRatings: any;
+  public userRatings: UserRatingsResponse;
+  public ratingStats: RatingStat[] = [];
   protected cdr = inject(ChangeDetectorRef);
+
+  private readonly ratingConfig: Array<{ key: RatingKey; translationKey: string; icon: string }> = [
+    { key: 'skillsRating', translationKey: 'SkillsRating', icon: 'rating' },
+    { key: 'activityRating', translationKey: 'ActivityRating', icon: 'rating' },
+    { key: 'contestsRating', translationKey: 'Contests.ContestsRating', icon: 'contests' },
+    { key: 'challengesRating', translationKey: 'PageTitle.Challenges.ChallengesRating', icon: 'challenges' },
+  ];
 
   constructor(
     public api: ApiService,
@@ -35,11 +70,40 @@ export class UserPopoverComponent implements OnInit {
         this.user = user;
         this.cdr.detectChanges();
       });
-      this.api.get(`users/${this.username}/ratings`).subscribe((userRatings: any) => {
+      this.api.get(`users/${this.username}/ratings`).subscribe((userRatings: UserRatingsResponse) => {
         this.userRatings = userRatings;
+        this.ratingStats = this.buildRatingStats(userRatings);
         this.cdr.detectChanges();
       });
     }
+  }
+
+  private buildRatingStats(userRatings: UserRatingsResponse): RatingStat[] {
+    if (!userRatings) {
+      return [];
+    }
+
+    return this.ratingConfig
+      .map(({ key, translationKey, icon }) => {
+        const rating = userRatings[key];
+        if (!rating || typeof rating.value !== 'number') {
+          return null;
+        }
+
+        const format = Number.isInteger(rating.value) ? '1.0-0' : '1.0-1';
+
+        return {
+          key,
+          translationKey,
+          icon,
+          value: rating.value,
+          rank: rating.rank,
+          percentile: rating.percentile,
+          title: rating.title,
+          format,
+        } as RatingStat;
+      })
+      .filter((stat): stat is RatingStat => !!stat);
   }
 
 }


### PR DESCRIPTION
## Summary
- reshape the user popover rating stats into compact cards that mirror the home ranks layout with icons, badges, and responsive columns
- extend the rating stat mapping to carry icon metadata while still relying on the existing translation keys for labels
- simplify the popover styling so the refreshed cards fit the smaller overlay without introducing excess custom rules

## Testing
- npm run lint *(fails: `ng` CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d058930890832f8682a9d34d438cbf