### PR TITLE
Revamp user popover rating cards

### DIFF
--- a/src/app/shared/components/user-popover/user-avatar-popover/user-avatar-popover.component.scss
+++ b/src/app/shared/components/user-popover/user-avatar-popover/user-avatar-popover.component.scss
@@ -1,18 +1,9 @@
 ::ng-deep .user-popover .popover-body {
-  padding: 0px !important;
-  width: 400px !important;
+  padding: 0 !important;
+  width: 360px !important;
+  max-width: 100% !important;
 }
 
 ::ng-deep .user-popover .card {
-  margin-bottom: 0px !important;
-  box-shadow: 0 4px 6px 0 rgb(85 85 85 / 9%), 0 1px 20px 0 rgb(0 0 0 / 8%), 0px 1px 11px 0px rgb(0 0 0 / 6%) !important;
-}
-
-::ng-deep .user-popover .rating-title-img {
-  width: 24px !important;
-  height: 24px !important;
-  padding: 0px !important;
-  margin: 0px !important;
-  margin-right: 2px !important;
-  margin-bottom: 3px !important;
+  margin-bottom: 0 !important;
 }

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.html
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.html
@@ -23,39 +23,48 @@
         </div>
 
         @if (ratingStats.length) {
-          <div class="ratings mt-3">
+          <div class="rating-cards mt-3">
             @for (stat of ratingStats; track stat.key) {
-              <div class="rating-item">
-                <div class="d-flex align-items-center justify-content-between gap-2 mb-1">
-                  <span class="text-uppercase text-muted fw-semibold small">
-                    {{ stat.translationKey | translate }}
-                  </span>
+              <div class="rating-card">
+                <div class="rating-card__header">
+                  <div class="rating-card__header-left">
+                    <div class="rating-card__icon">
+                      <kep-icon color="primary" [name]="stat.icon" type="duotone"></kep-icon>
+                    </div>
+                    <div class="rating-card__title">
+                      {{ stat.translationKey | translate }}
+                    </div>
+                  </div>
                   @if (stat.title) {
-                    <span class="rating-item__title">{{ stat.title }}</span>
+                    <span class="rating-card__badge">{{ stat.title }}</span>
                   }
                 </div>
-                <div class="d-flex align-items-baseline gap-2">
-                  <span class="rating-item__value fw-semibold">
+                <div class="rating-card__body">
+                  <div class="rating-card__value">
                     {{ stat.value | number: stat.format }}
-                  </span>
-                </div>
-                <div class="d-flex flex-wrap gap-2 justify-content-between small text-muted mt-2">
-                  <span>
-                    {{ 'Rank' | translate }}
-                    @if (stat.rank !== undefined && stat.rank !== null) {
-                      <span class="text-body fw-semibold">#{{ stat.rank | number: '1.0-0' }}</span>
-                    } @else {
-                      <span class="text-body fw-semibold">—</span>
-                    }
-                  </span>
-                  <span>
-                    {{ 'Percentile' | translate }}
-                    @if (stat.percentile !== undefined && stat.percentile !== null) {
-                      <span class="text-body fw-semibold">{{ stat.percentile | number: '1.0-1' }}%</span>
-                    } @else {
-                      <span class="text-body fw-semibold">—</span>
-                    }
-                  </span>
+                  </div>
+                  <div class="rating-card__meta">
+                    <div class="rating-card__meta-item">
+                      <span class="rating-card__meta-label">{{ 'Rank' | translate }}</span>
+                      <span class="rating-card__meta-value">
+                        @if (stat.rank !== undefined && stat.rank !== null) {
+                          #{{ stat.rank | number: '1.0-0' }}
+                        } @else {
+                          —
+                        }
+                      </span>
+                    </div>
+                    <div class="rating-card__meta-item">
+                      <span class="rating-card__meta-label">{{ 'Percentile' | translate }}</span>
+                      <span class="rating-card__meta-value">
+                        @if (stat.percentile !== undefined && stat.percentile !== null) {
+                          {{ stat.percentile | number: '1.0-1' }}%
+                        } @else {
+                          —
+                        }
+                      </span>
+                    </div>
+                  </div>
                 </div>
               </div>
             }

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.scss
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.scss
@@ -17,7 +17,8 @@
 
   .popover-body {
     padding: 0 !important;
-    width: 400px !important;
+    width: 360px !important;
+    max-width: 100% !important;
     box-shadow: none !important;
     border: none !important;
   }
@@ -35,40 +36,118 @@
   flex-wrap: wrap;
 }
 
-.ratings {
+.rating-cards {
   display: grid;
   gap: 0.75rem;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.rating-item {
-  border-radius: 0.75rem;
+.rating-card {
+  position: relative;
+  border-radius: 1rem;
   padding: 0.75rem;
-  background: rgba(var(--bs-primary-rgb), 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
   border: 1px solid rgba(var(--bs-body-color-rgb), 0.08);
+  background: linear-gradient(180deg, rgba(var(--bs-primary-rgb), 0.14), rgba(var(--bs-primary-rgb), 0.04));
 
   @include dark-layout {
-    background: rgba(var(--bs-primary-rgb), 0.2);
-    border-color: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.12);
+    background: linear-gradient(180deg, rgba(var(--bs-primary-rgb), 0.32), rgba(var(--bs-primary-rgb), 0.18));
   }
 }
 
-.rating-item__value {
-  font-size: 1.75rem;
-  line-height: 1;
+.rating-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
 }
 
-.rating-item__title {
+.rating-card__header-left {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.rating-card__icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(var(--bs-primary-rgb), 0.5);
+  background: rgba(var(--bs-primary-rgb), 0.16);
+
+  @include dark-layout {
+    background: rgba(var(--bs-primary-rgb), 0.32);
+  }
+}
+
+.rating-card__title {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.rating-card__badge {
   border-radius: 999px;
   padding: 0.125rem 0.5rem;
   font-size: 0.7rem;
   font-weight: 600;
   text-transform: uppercase;
-  background: rgba(var(--bs-primary-rgb), 0.16);
+  background: rgba(var(--bs-primary-rgb), 0.18);
   color: var(--bs-primary);
 
   @include dark-layout {
-    background: rgba(255, 255, 255, 0.15);
+    background: rgba(255, 255, 255, 0.16);
     color: white;
+  }
+}
+
+.rating-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.rating-card__value {
+  font-size: 1.75rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.rating-card__meta {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.rating-card__meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.rating-card__meta-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  color: rgba(var(--bs-body-color-rgb), 0.6);
+
+  @include dark-layout {
+    color: rgba(255, 255, 255, 0.65);
+  }
+}
+
+.rating-card__meta-value {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+@media (max-width: 420px) {
+  .rating-cards {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.ts
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.ts
@@ -26,6 +26,7 @@ interface RatingStat {
   percentile?: number;
   title?: string;
   format: string;
+  icon: string;
 }
 
 @Component({
@@ -49,11 +50,11 @@ export class UserPopoverComponent implements OnInit {
   public ratingStats: RatingStat[] = [];
   protected cdr = inject(ChangeDetectorRef);
 
-  private readonly ratingConfig: Array<{ key: RatingKey; translationKey: string }> = [
-    { key: 'skillsRating', translationKey: 'SkillsRating' },
-    { key: 'activityRating', translationKey: 'ActivityRating' },
-    { key: 'contestsRating', translationKey: 'Contests.ContestsRating' },
-    { key: 'challengesRating', translationKey: 'PageTitle.Challenges.ChallengesRating' },
+  private readonly ratingConfig: Array<{ key: RatingKey; translationKey: string; icon: string }> = [
+    { key: 'skillsRating', translationKey: 'SkillsRating', icon: 'rating' },
+    { key: 'activityRating', translationKey: 'ActivityRating', icon: 'rating' },
+    { key: 'contestsRating', translationKey: 'Contests.ContestsRating', icon: 'contests' },
+    { key: 'challengesRating', translationKey: 'PageTitle.Challenges.ChallengesRating', icon: 'challenges' },
   ];
 
   constructor(
@@ -83,7 +84,7 @@ export class UserPopoverComponent implements OnInit {
     }
 
     return this.ratingConfig
-      .map(({ key, translationKey }) => {
+      .map(({ key, translationKey, icon }) => {
         const rating = userRatings[key];
         if (!rating || typeof rating.value !== 'number') {
           return null;
@@ -99,6 +100,7 @@ export class UserPopoverComponent implements OnInit {
           percentile: rating.percentile,
           title: rating.title,
           format,
+          icon,
         } as RatingStat;
       })
       .filter((stat): stat is RatingStat => !!stat);


### PR DESCRIPTION
## Summary
- restyle the rating stats in the user popover to mirror the home ranks cards with icons, value emphasis, and compact layout
- extend rating configuration with icon metadata so the popover can display consistent visual cues for all four ratings
- simplify popover-specific styling to use a smaller width and remove unused overrides

## Testing
- npm run lint *(fails: lint target not configured in Angular workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d05f9af748832f808573bfdbec11ad