### PR TITLE
Add duels rating page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -56,6 +56,11 @@ export const routes: Routes = [
         loadChildren: () => import('./modules/duels/duels.routing'),
       },
       {
+        path: 'duels-rating',
+        loadComponent: () => import('./modules/duels/ui/pages/duels-rating/duels-rating.page').then(c => c.DuelsRatingPage),
+        data: { title: 'Duels.DuelsRating' },
+      },
+      {
         path: 'competitions/contests',
         loadChildren: () => import('./modules/contests/contests.routing')
       },

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -105,6 +105,7 @@ export const localeEn = {
   Problem: 'Problem',
   Rating: 'Rating',
   OverallRating: 'Overall rating',
+  DuelsRating: 'Duels Rating',
   LastAttempts: 'Last attempts',
   Verdict: 'Verdict',
   AllAttempts: 'All attempts',
@@ -816,6 +817,7 @@ export const localeEn = {
     Duels: {
       Duels: 'Duels',
       Duel: 'Duel | {{ playerFirstUsername }} vs {{ playerSecondUsername }}',
+      DuelsRating: 'Duels Rating',
     },
     Projects: {
       Projects: 'Projects',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -101,6 +101,7 @@ export const localeRu = {
   Problem: 'Задача',
   Rating: 'Рейтинг',
   OverallRating: 'Общий рейтинг',
+  DuelsRating: 'Рейтинг дуэлей',
   LastAttempts: 'Последние попытки',
   Verdict: 'Вердикт',
   AllAttempts: 'Все попытки',
@@ -810,6 +811,7 @@ export const localeRu = {
     Duels: {
       Duels: 'Дуэли',
       Duel: 'Дуэль | {{ playerFirstUsername }} vs {{ playerSecondUsername }}',
+      DuelsRating: 'Рейтинг дуэлей',
     },
     Projects: {
       Projects: 'Проекты',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -96,6 +96,7 @@ export const localeUz = {
   Problem: 'Masala',
   Rating: 'Reyting',
   OverallRating: 'Umumiy reyting',
+  DuelsRating: 'Duellar reytingi',
   LastAttempts: 'Ohirgi urinishlar',
   Verdict: 'Natija',
   ArenaWinners: 'Arena gʻoliblari',
@@ -812,6 +813,7 @@ export const localeUz = {
     Duels: {
       Duels: 'Duellar',
       Duel: 'Duel | {{ playerFirstUsername }} vs {{ playerSecondUsername }}',
+      DuelsRating: 'Duellar reytingi',
     },
     Projects: {
       Projects: 'Loyihalar',

--- a/src/app/modules/duels/data-access/api/duels-api.service.ts
+++ b/src/app/modules/duels/data-access/api/duels-api.service.ts
@@ -8,6 +8,7 @@ import {
   DuelReadyPlayer,
   DuelReadyStatus,
   DuelResults,
+  DuelsRating,
 } from '@duels/domain';
 
 @Injectable({
@@ -59,6 +60,10 @@ export class DuelsApiService {
 
   confirmDuel(duelId: number) {
     return this.api.post(`duels/${duelId}/confirm`);
+  }
+
+  getDuelsRating(params: Record<string, any>): Observable<PageResult<DuelsRating>> {
+    return this.api.get('duels-rating', params);
   }
 
 }

--- a/src/app/modules/duels/domain/entities/duels-rating.ts
+++ b/src/app/modules/duels/domain/entities/duels-rating.ts
@@ -1,0 +1,13 @@
+export interface DuelsRatingUser {
+  username: string;
+  avatar: string;
+}
+
+export interface DuelsRating {
+  rowIndex?: number;
+  user: DuelsRatingUser;
+  duels: number;
+  wins: number;
+  draws: number;
+  losses: number;
+}

--- a/src/app/modules/duels/domain/entities/index.ts
+++ b/src/app/modules/duels/domain/entities/index.ts
@@ -1,1 +1,2 @@
 export * from './duel';
+export * from './duels-rating';

--- a/src/app/modules/duels/duels.routing.ts
+++ b/src/app/modules/duels/duels.routing.ts
@@ -9,6 +9,13 @@ export default [
     },
   },
   {
+    path: 'duels-rating',
+    loadComponent: () => import('./ui/pages/duels-rating/duels-rating.page').then(c => c.DuelsRatingPage),
+    data: {
+      title: 'Duels.DuelsRating',
+    },
+  },
+  {
     path: 'duel/:id',
     loadComponent: () => import('./ui/pages/duel/duel.component').then(c => c.DuelComponent),
     data: {

--- a/src/app/modules/duels/ui/pages/duels-rating/duels-rating.page.html
+++ b/src/app/modules/duels/ui/pages/duels-rating/duels-rating.page.html
@@ -1,0 +1,97 @@
+<div class="content-wrapper container-xxl p-0">
+  <div class="content-body">
+    <app-content-header [contentHeader]="contentHeader"></app-content-header>
+
+    <section class="mt-2">
+      <kep-table [loading]="isLoading" [empty]="pageResult?.total === 0">
+        <ng-container header>
+          <tr>
+            <th>#</th>
+            <th>{{ 'User' | translate }}</th>
+            <th>
+              <table-ordering
+                [value]="ordering"
+                [justifyContent]="'start'"
+                [ordering]="'duels'"
+                [reverse]="true"
+                (change)="orderingChange($event)">
+                {{ 'Duels' | translate }}
+              </table-ordering>
+            </th>
+            <th>
+              <table-ordering
+                [value]="ordering"
+                [justifyContent]="'start'"
+                [ordering]="'wins'"
+                [reverse]="true"
+                (change)="orderingChange($event)">
+                {{ 'Wins' | translate }}
+              </table-ordering>
+            </th>
+            <th>
+              <table-ordering
+                [value]="ordering"
+                [justifyContent]="'start'"
+                [ordering]="'draws'"
+                [reverse]="true"
+                (change)="orderingChange($event)">
+                {{ 'Draws' | translate }}
+              </table-ordering>
+            </th>
+            <th>
+              <table-ordering
+                [value]="ordering"
+                [justifyContent]="'start'"
+                [ordering]="'losses'"
+                [reverse]="true"
+                (change)="orderingChange($event)">
+                {{ 'Losses' | translate }}
+              </table-ordering>
+            </th>
+          </tr>
+        </ng-container>
+        <ng-container body>
+          @for (duelsRating of duelsRatingList; track duelsRating.rowIndex) {
+            <tr>
+              <td class="fw-medium">{{ duelsRating.rowIndex }}</td>
+              <td>
+                <div class="d-flex align-items-center gap-1">
+                  <user-avatar-popover
+                    [username]="duelsRating.user.username"
+                    [avatar]="duelsRating.user.avatar">
+                  </user-avatar-popover>
+                  <a [routerLink]="['/users', 'user', duelsRating.user.username]" class="fw-medium">
+                    {{ duelsRating.user.username }}
+                  </a>
+                </div>
+              </td>
+              <td>
+                <span class="badge bg-primary-transparent">{{ duelsRating.duels }}</span>
+              </td>
+              <td>
+                <span class="badge bg-success-transparent">{{ duelsRating.wins }}</span>
+              </td>
+              <td>
+                <span class="badge bg-secondary-transparent">{{ duelsRating.draws }}</span>
+              </td>
+              <td>
+                <span class="badge bg-danger-transparent">{{ duelsRating.losses }}</span>
+              </td>
+            </tr>
+          }
+        </ng-container>
+        <ng-container pagination>
+          <kep-pagination
+            [collectionSize]="total"
+            [page]="pageNumber"
+            [pageSize]="pageSize"
+            [maxSize]="maxSize"
+            [rotate]="true"
+            [disabled]="isLoading"
+            (pageChange)="pageChange($event)">
+          </kep-pagination>
+        </ng-container>
+      </kep-table>
+    </section>
+  </div>
+</div>

--- a/src/app/modules/duels/ui/pages/duels-rating/duels-rating.page.ts
+++ b/src/app/modules/duels/ui/pages/duels-rating/duels-rating.page.ts
@@ -1,0 +1,66 @@
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+import { BaseTablePageComponent } from '@core/common/classes/base-table-page.component';
+import { PageResult } from '@core/common/classes/page-result';
+import { DuelsRating } from '@duels/domain';
+import { DuelsApiService } from '@duels/data-access';
+import { CoreCommonModule } from '@core/common.module';
+import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
+import { KepTableComponent } from '@shared/components/kep-table/kep-table.component';
+import { KepPaginationComponent } from '@shared/components/kep-pagination/kep-pagination.component';
+import { TableOrderingModule } from '@shared/components/table-ordering/table-ordering.module';
+import { UserPopoverModule } from '@shared/components/user-popover/user-popover.module';
+
+@Component({
+  selector: 'page-duels-rating',
+  standalone: true,
+  templateUrl: './duels-rating.page.html',
+  styleUrls: ['./duels-rating.page.scss'],
+  imports: [
+    CoreCommonModule,
+    ContentHeaderModule,
+    KepTableComponent,
+    KepPaginationComponent,
+    TableOrderingModule,
+    UserPopoverModule,
+  ]
+})
+export class DuelsRatingPage extends BaseTablePageComponent<DuelsRating> implements OnInit {
+  override defaultPageSize = 20;
+  override maxSize = 5;
+
+  override defaultOrdering = '-wins';
+
+  constructor(private readonly duelsApi: DuelsApiService) {
+    super();
+  }
+
+  get duelsRatingList() {
+    return this.pageResult?.data ?? [];
+  }
+
+  override ngOnInit(): void {
+    this.loadContentHeader();
+    setTimeout(() => this.reloadPage());
+  }
+
+  override getPage(): Observable<PageResult<DuelsRating>> {
+    return this.duelsApi.getDuelsRating(this.pageable);
+  }
+
+  protected override getContentHeader() {
+    return {
+      headerTitle: 'DuelsRating',
+      breadcrumb: {
+        type: '',
+        links: [
+          {
+            name: 'Duels',
+            isLink: true,
+            link: '/practice/duels',
+          },
+        ],
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated duels rating page with sortable table, avatar popovers, and pagination
- extend duels API/domain layer to fetch duels rating entries
- expose the new screen via duels routing, top-level routing, and update translations

## Testing
- `npm run lint` *(fails: ng not found in environment; npm install hit dependency resolution conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68d062ff3b50832f93bad5e8ff2bdf81