### PR TITLE
Add light mode styling for Flatpickr calendars

### DIFF
--- a/src/assets/scss/custom/_plugins.scss
+++ b/src/assets/scss/custom/_plugins.scss
@@ -912,6 +912,101 @@ span.flatpickr-weekday {
   box-shadow: 1px 0 0 var(--default-border) !important;
 }
 
+html[data-theme-mode="light"] {
+  .flatpickr-calendar {
+    background-color: #fff !important;
+    border: 1px solid rgba(15, 23, 42, 0.08) !important;
+    box-shadow: 0 0.75rem 2rem rgba(15, 23, 42, 0.12) !important;
+  }
+
+  .flatpickr-calendar.arrowTop:before,
+  .flatpickr-calendar.arrowTop:after {
+    border-bottom-color: rgba(15, 23, 42, 0.08) !important;
+  }
+
+  .flatpickr-calendar.arrowBottom:before,
+  .flatpickr-calendar.arrowBottom:after {
+    border-top-color: rgba(15, 23, 42, 0.08) !important;
+  }
+
+  .flatpickr-months,
+  .flatpickr-weekdays {
+    background-color: #f8fafc !important;
+  }
+
+  .flatpickr-months .flatpickr-prev-month,
+  .flatpickr-months .flatpickr-next-month {
+    color: var(--primary) !important;
+    fill: var(--primary) !important;
+  }
+
+  .flatpickr-monthDropdown-months,
+  .flatpickr-current-month .numInput,
+  .flatpickr-time input,
+  .flatpickr-time .flatpickr-am-pm {
+    color: #0f172a !important;
+  }
+
+  .flatpickr-time {
+    background-color: #f8fafc !important;
+    border-top: 1px solid rgba(15, 23, 42, 0.08) !important;
+  }
+
+  .flatpickr-time input:hover,
+  .flatpickr-time input:focus,
+  .flatpickr-time .flatpickr-am-pm:hover,
+  .flatpickr-time .flatpickr-am-pm:focus {
+    background: rgba(var(--primary-rgb), 0.08) !important;
+  }
+
+  .flatpickr-day {
+    color: #1f2937 !important;
+  }
+
+  .flatpickr-day.today {
+    border-color: var(--primary) !important;
+    color: var(--primary) !important;
+  }
+
+  .flatpickr-day:hover,
+  .flatpickr-day:focus,
+  .flatpickr-day.prevMonthDay:hover,
+  .flatpickr-day.nextMonthDay:hover,
+  .flatpickr-day.prevMonthDay:focus,
+  .flatpickr-day.nextMonthDay:focus {
+    background: rgba(var(--primary-rgb), 0.08) !important;
+    border-color: rgba(var(--primary-rgb), 0.08) !important;
+    color: var(--primary) !important;
+  }
+
+  .flatpickr-day.selected,
+  .flatpickr-day.startRange,
+  .flatpickr-day.endRange,
+  .flatpickr-day.selected:focus,
+  .flatpickr-day.startRange:focus,
+  .flatpickr-day.endRange:focus,
+  .flatpickr-day.selected:hover,
+  .flatpickr-day.startRange:hover,
+  .flatpickr-day.endRange:hover {
+    background: var(--primary) !important;
+    border-color: var(--primary) !important;
+    color: #fff !important;
+  }
+
+  .flatpickr-day.inRange,
+  .flatpickr-day.prevMonthDay.inRange,
+  .flatpickr-day.nextMonthDay.inRange {
+    background: rgba(var(--primary-rgb), 0.1) !important;
+    border-color: rgba(var(--primary-rgb), 0.1) !important;
+    color: #0f172a !important;
+  }
+
+  .flatpickr-weekwrapper .flatpickr-weeks {
+    background-color: #fff !important;
+    box-shadow: 1px 0 0 rgba(15, 23, 42, 0.08) !important;
+  }
+}
+
 /* End:Pickers */
 
 /* Start:noUi Slider */


### PR DESCRIPTION
## Summary
- add light theme overrides for Flatpickr calendars, months header, and time inputs
- adjust hover, selection, and range states to use primary palette for light mode

## Testing
- npm run lint *(fails: `ng` command not found because dependencies are not installed in the container)*
- npm install *(fails: dependency conflict between installed Angular 19 packages and @fullcalendar/angular@6.1.9 peer requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68d064da5684832faa51411d3fbf1882