### PR TITLE
Add Flatpickr locale synchronization

### DIFF
--- a/src/@core/services/flatpickr-i18n.service.ts
+++ b/src/@core/services/flatpickr-i18n.service.ts
@@ -1,0 +1,33 @@
+import { inject, Injectable } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FlatpickrDefaults } from 'angularx-flatpickr';
+import english from 'flatpickr/dist/l10n/default';
+import { Russian } from 'flatpickr/dist/l10n/ru';
+import { Uzbek } from 'flatpickr/dist/l10n/uz';
+import { CustomLocale, Locale } from 'flatpickr/dist/types/locale';
+
+import { AppStateService, Language } from './app-state.service';
+
+const FLATPICKR_LOCALES: Record<Language, Locale | CustomLocale> = {
+  en: english,
+  ru: Russian,
+  uz: Uzbek,
+};
+
+@Injectable({ providedIn: 'root' })
+export class FlatpickrI18nService {
+  private readonly appStateService = inject(AppStateService);
+  private readonly flatpickrDefaults = inject(FlatpickrDefaults);
+
+  constructor() {
+    this.applyLocale(this.appStateService.getCurrentValue().language);
+
+    this.appStateService.state$
+      .pipe(takeUntilDestroyed())
+      .subscribe(({ language }) => this.applyLocale(language));
+  }
+
+  private applyLocale(language: Language): void {
+    this.flatpickrDefaults.locale = FLATPICKR_LOCALES[language];
+  }
+}

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -22,6 +22,7 @@ import { CalendarModule, DateAdapter } from 'angular-calendar';
 import { environment } from '../environments/environment';
 import { NgbCollapseModule } from '@ng-bootstrap/ng-bootstrap';
 import { AppStateService } from '@core/services/app-state.service';
+import { FlatpickrI18nService } from '@core/services/flatpickr-i18n.service';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { provideHttpClient } from '@angular/common/http';
 import { WebsocketModule } from '@shared/services/websocket';
@@ -69,6 +70,7 @@ export const appConfig: ApplicationConfig = {
       closeButton: true,
     }),
     provideAppInitializer(() => inject(AuthService).getMe()),
+    provideAppInitializer(() => inject(FlatpickrI18nService)),
     { provide: APP_BASE_HREF, useValue: '/' },
     {
       provide: TitleStrategy,


### PR DESCRIPTION
## Summary
- add a Flatpickr i18n service that maps application languages to the matching flatpickr locales
- initialize the i18n service during app startup so date pickers follow the selected language

## Testing
- npm run lint *(fails: lint target is not configured in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d066097d80832fbc3865fbe4a7d3a2