### PR TITLE
feat(duels): show all duels alongside mine

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -222,6 +222,7 @@ export const localeEn = {
   ChallengeToDuel: 'Challenge to duel',
   NoReadyPlayers: 'No ready players yet',
   MyDuels: 'My duels',
+  AllDuels: 'All duels',
   AwaitingConfirmation: 'Awaiting confirmation',
   Confirm: 'Confirm',
   NoDuelsYet: 'No duels yet',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -221,6 +221,7 @@ export const localeRu = {
   ChallengeToDuel: 'Вызвать на дуэль',
   NoReadyPlayers: 'Пока нет готовых игроков',
   MyDuels: 'Мои дуэли',
+  AllDuels: 'Все дуэли',
   AwaitingConfirmation: 'Ожидает подтверждения',
   Confirm: 'Подтвердить',
   NoDuelsYet: 'Пока нет дуэлей',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -222,6 +222,7 @@ export const localeUz = {
   ChallengeToDuel: 'Duelga chorlash',
   NoReadyPlayers: 'Hozircha tayyor ishtirokchilar yo\'q',
   MyDuels: 'Mening duellarim',
+  AllDuels: 'Barcha duellar',
   AwaitingConfirmation: 'Tasdiqlash kutilmoqda',
   Confirm: 'Tasdiqlash',
   NoDuelsYet: 'Hozircha duellar yo\'q',

--- a/src/app/modules/duels/ui/components/duels-list-section/duels-list-section.component.html
+++ b/src/app/modules/duels/ui/components/duels-list-section/duels-list-section.component.html
@@ -1,7 +1,7 @@
 <kep-card>
   <div class="card-header">
     <div class="card-title">
-      {{ 'MyDuels' | translate }}
+      {{ titleKey | translate }}
       @if (total) {
         <span class="total-count">({{ total }})</span>
       }

--- a/src/app/modules/duels/ui/components/duels-list-section/duels-list-section.component.ts
+++ b/src/app/modules/duels/ui/components/duels-list-section/duels-list-section.component.ts
@@ -23,6 +23,7 @@ import { KepCardComponent } from "@shared/components/kep-card/kep-card.component
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DuelsListSectionComponent {
+  @Input() titleKey = 'MyDuels';
   @Input() duels: Duel[] = [];
   @Input() total = 0;
   @Input() page = 1;

--- a/src/app/modules/duels/ui/pages/duels/duels.page.html
+++ b/src/app/modules/duels/ui/pages/duels/duels.page.html
@@ -37,7 +37,7 @@
         />
       </div>
 
-      <div class="col-12">
+      <div class="col-12 col-xl-6">
         <duels-list-section
           [duels]="duelsResult?.data ?? []"
           [total]="duelsTotal"
@@ -47,6 +47,21 @@
           [confirmLoadingId]="confirmLoadingId"
           [currentUsername]="currentUser?.username ?? null"
           (pageChange)="loadDuels($event)"
+          (confirm)="confirmDuel($event)"
+        />
+      </div>
+
+      <div class="col-12 col-xl-6">
+        <duels-list-section
+          titleKey="AllDuels"
+          [duels]="allDuelsResult?.data ?? []"
+          [total]="allDuelsTotal"
+          [page]="allDuelsPage"
+          [pageSize]="allDuelsPageSize"
+          [loading]="allDuelsLoading"
+          [confirmLoadingId]="confirmLoadingId"
+          [currentUsername]="currentUser?.username ?? null"
+          (pageChange)="loadAllDuels($event)"
           (confirm)="confirmDuel($event)"
         />
       </div>


### PR DESCRIPTION
## Summary
- allow the duels list section component to accept a translated title so it can be reused
- load and paginate both personal and global duel feeds on the duels page
- add the "All duels" translation key for supported locales

## Testing
- npm run lint *(fails: ng not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d066be691c832f925b4bc85bedeb05