### PR TITLE
feat: improve problem navigation and language handling

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -337,6 +337,8 @@ export const locale = {
     Purchased: 'Purchased',
     Finish: 'Finish',
     Next: 'Next',
+    NextProblem: 'Next problem',
+    PreviousProblem: 'Previous problem',
     Back: 'Back',
     NewAchievement: 'New achievement',
     ArenaFinishedNotification: 'Arena finished | Results',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -335,6 +335,8 @@ export const locale = {
     Purchased: 'Куплено',
     Finish: 'Закончить',
     Next: 'Следующий',
+    NextProblem: 'Следующая задача',
+    PreviousProblem: 'Предыдущая задача',
     Back: 'Назад',
     NewAchievement: 'Новое достижение',
     ArenaFinishedNotification: 'Арена закончена | Результаты',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -334,6 +334,8 @@ export const locale = {
     Purchased: 'Xarid qilingan',
     Finish: 'Tugatish',
     Next: 'Keyingisi',
+    NextProblem: 'Keyingi masala',
+    PreviousProblem: 'Oldingi masala',
     Back: 'Orqaga',
     NewAchievement: 'Yangi yutuq',
     ArenaFinishedNotification: 'Arena yakunlandi | Natijalar',

--- a/src/app/modules/duels/pages/duel/duel.component.html
+++ b/src/app/modules/duels/pages/duel/duel.component.html
@@ -113,10 +113,10 @@
                 {{ 'TIME_LIMIT' | translate }}:
               </small>
             </div>
-            <div class="col problem-header">
+              <div class="col problem-header">
               <small class="text-center">
                 <span class="text-info">
-                  {{ availableLang.timeLimit || duelProblem.problem.timeLimit }} {{ 'MS' | translate }}
+                  {{ availableLang?.timeLimit || duelProblem.problem.timeLimit }} {{ 'MS' | translate }}
                 </span>
               </small>
             </div>
@@ -130,7 +130,7 @@
             <div class="col mb-2 problem-header">
               <small class="text-center">
                 <span class="text-primary">
-                  {{ availableLang.memoryLimit || duelProblem.problem.memoryLimit }} {{ 'MB' | translate }}
+                  {{ availableLang?.memoryLimit || duelProblem.problem.memoryLimit }} {{ 'MB' | translate }}
                 </span>
               </small>
             </div>

--- a/src/app/modules/problems/components/problem-info-card/problem-info-card.component.html
+++ b/src/app/modules/problems/components/problem-info-card/problem-info-card.component.html
@@ -99,45 +99,23 @@
   </div>
 }
 
-<div class="languages mt-2">
-  <div class="d-flex mb-1">
-    <h5>
-      <i data-feather="code"></i>
-      {{ 'Languages' | translate }}
-    </h5>
+@if (selectedAvailableLang) {
+  <div class="selected-language mt-2">
+    <div class="d-flex mb-1">
+      <h5>
+        <i data-feather="code"></i>
+        {{ 'SelectedLanguage' | translate }}
+      </h5>
+    </div>
+
+    <attempt-language
+      [lang]="selectedAvailableLang.lang"
+      [langFull]="selectedAvailableLang.langFull"
+    />
   </div>
+}
 
-  <div class="row">
-
-    @for (availableLanguage of problem.availableLanguages;track availableLanguage) {
-      <div class="col-4 col-md-3 col-lg-6 col-xl-4 px-25">
-        <attempt-language
-          [clickable]="true"
-          [lang]="availableLanguage.lang"
-          [langFull]="availableLanguage.langFull"
-          (click)="langService.setLanguage(availableLanguage.lang)"
-        />
-      </div>
-    }
-  </div>
-
-</div>
-
-<div class="selected-language mt-2">
-  <div class="d-flex mb-1">
-    <h5>
-      <i data-feather="code"></i>
-      {{ 'SelectedLanguage' | translate }}
-    </h5>
-  </div>
-
-  <attempt-language
-    [lang]="selectedAvailableLang.lang"
-    [langFull]="selectedAvailableLang.langFull"
-  />
-</div>
-
-@if (!hideCodeGolf) {
+@if (!hideCodeGolf && selectedAvailableLang) {
   <div class="code-golf mt-2">
     <div class="d-flex mb-1">
       <h5>

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -1,6 +1,29 @@
 <div class="content-wrapper container-xxl p-0">
   <div class="content-body">
-    <app-content-header [contentHeader]="contentHeader"></app-content-header>
+    <app-content-header [contentHeader]="contentHeader" [hasActions]="true">
+      <div actions class="d-flex gap-50">
+        <button
+          type="button"
+          class="btn btn-sm btn-outline-primary"
+          [disabled]="!previousProblemId"
+          (click)="navigateToProblem(previousProblemId)"
+          ngbTooltip="{{ 'PreviousProblem' | translate }}"
+          container="body"
+        >
+          <i data-feather="chevron-left"></i>
+        </button>
+        <button
+          type="button"
+          class="btn btn-sm btn-outline-primary"
+          [disabled]="!nextProblemId"
+          (click)="navigateToProblem(nextProblemId)"
+          ngbTooltip="{{ 'NextProblem' | translate }}"
+          container="body"
+        >
+          <i data-feather="chevron-right"></i>
+        </button>
+      </div>
+    </app-content-header>
     <section [@fadeInOnEnter] class="mt-2">
       <div class="row">
         <div class="col-lg-9 col-md-12 col-sm-12">

--- a/src/app/modules/problems/services/problems-api.service.ts
+++ b/src/app/modules/problems/services/problems-api.service.ts
@@ -33,6 +33,14 @@ export class ProblemsApiService {
     return this.api.get(`problems/${ id }`);
   }
 
+  getProblemNext(id: number | string) {
+    return this.api.get(`problems/${ id }/next`);
+  }
+
+  getProblemPrev(id: number | string) {
+    return this.api.get(`problems/${ id }/prev`);
+  }
+
   getStudyPlans() {
     return this.api.get('study-plans');
   }


### PR DESCRIPTION
## Summary
- add previous and next navigation controls to the problem detail header and ensure the selected language matches the problem
- centralize submit language handling for duels and remove the redundant language list from the problem info card
- expose API helpers for adjacent problems and translate new navigation tooltips

## Testing
- npm run lint *(fails: Angular CLI not available because npm install cannot resolve peer dependency conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68d06a58f2e0832fb04753a41bf1472f