### PR TITLE
feat: improve problem navigation and language selection

### DIFF
--- a/src/app/modules/duels/ui/pages/duel/duel.component.html
+++ b/src/app/modules/duels/ui/pages/duel/duel.component.html
@@ -105,7 +105,29 @@
                   {{ duelProblem.symbol }}. {{ duelProblem.problem.title }}
                 </h2>
                 <problem-body [problem]="duelProblem.problem"></problem-body>
+                <p class="text-center mb-1">
+                  {{ 'TimeLimit' | translate }}: {{ selectedAvailableLang?.timeLimit || duelProblem.problem.timeLimit }} {{ 'Ms' | translate }}
+                </p>
+                <p class="text-center mb-2">
+                  {{ 'MemoryLimit' | translate }} {{ selectedAvailableLang?.memoryLimit || duelProblem.problem.memoryLimit }} {{ 'Mb' | translate }}
+                </p>
                 @if (duel.status == 0 && duel.isPlayer && currentUser) {
+                  <div class="mb-2 d-flex align-items-center gap-50 flex-wrap">
+                    <label class="mb-0 fw-medium">{{ 'Lang' | translate }}:</label>
+                    <ng-select
+                      class="language-dropdown"
+                      (change)="langChange($event)"
+                      [appendTo]="'body'"
+                      [clearable]="false"
+                      [(ngModel)]="selectedLang">
+                      @for (availableLanguage of duelProblem.problem.availableLanguages; track availableLanguage.lang) {
+                        <ng-option [value]="availableLanguage.lang">
+                          <attempt-language [size]="24" [lang]="availableLanguage.lang" [langFull]="availableLanguage.langFull"/>
+                          {{ availableLanguage.langFull || availableLanguage.lang }}
+                        </ng-option>
+                      }
+                    </ng-select>
+                  </div>
                   <code-editor-modal
                     [uniqueName]="'duel-problem-' + duelProblem.problem.id"
                     [sampleTests]="duelProblem.problem.sampleTests"

--- a/src/app/modules/duels/ui/pages/duel/duel.component.scss
+++ b/src/app/modules/duels/ui/pages/duel/duel.component.scss
@@ -1,0 +1,3 @@
+.language-dropdown {
+  min-width: 200px;
+}

--- a/src/app/modules/problems/components/problem-info-card/problem-info-card.component.html
+++ b/src/app/modules/problems/components/problem-info-card/problem-info-card.component.html
@@ -99,44 +99,6 @@
   </div>
 }
 
-<div class="languages mt-2">
-  <div class="d-flex mb-1">
-    <h5>
-      <i data-feather="code"></i>
-      {{ 'Languages' | translate }}
-    </h5>
-  </div>
-
-  <div class="row">
-
-    @for (availableLanguage of problem.availableLanguages; track availableLanguage) {
-      <div class="col-4 col-md-3 col-lg-6 col-xl-4 px-1">
-        <attempt-language
-          [clickable]="true"
-          [lang]="availableLanguage.lang"
-          [langFull]="availableLanguage.langFull"
-          (click)="langService.setLanguage(availableLanguage.lang)"
-        />
-      </div>
-    }
-  </div>
-
-</div>
-
-<div class="selected-language mt-2">
-  <div class="d-flex mb-1">
-    <h5>
-      <i data-feather="code"></i>
-      {{ 'SelectedLanguage' | translate }}
-    </h5>
-  </div>
-
-  <attempt-language
-    [lang]="selectedAvailableLang.lang"
-    [langFull]="selectedAvailableLang.langFull"
-  />
-</div>
-
 @if (!hideCodeGolf) {
   <div class="code-golf mt-2">
     <div class="d-flex mb-1">

--- a/src/app/modules/problems/components/problem-info-card/problem-info-card.component.ts
+++ b/src/app/modules/problems/components/problem-info-card/problem-info-card.component.ts
@@ -11,7 +11,6 @@ import { takeUntil } from 'rxjs/operators';
 import { AttemptLangs } from '@problems/constants';
 import { findAvailableLang } from '@problems/utils';
 import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
-import { AttemptLanguageComponent } from '@shared/components/attempt-language/attempt-language.component';
 
 interface IVoteResult {
   likesCount: number;
@@ -26,8 +25,6 @@ interface IVoteResult {
     ProblemsPipesModule,
     UserPopoverModule,
     KepIconComponent,
-    AttemptLanguageComponent,
-    AttemptLanguageComponent,
   ],
   templateUrl: './problem-info-card.component.html',
   styleUrl: './problem-info-card.component.scss'

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -1,23 +1,51 @@
 <div class="content-wrapper container-xxl p-0">
   <div class="content-body">
     <app-content-header [contentHeader]="contentHeader">
-      <div class="btn-group" role="group">
-        <button class="btn btn-secondary-light btn-wave" type="button">
-          <span><i data-feather="terminal"></i></span>
-          {{ 'CodeEditor.Run' | translate }}
-        </button>
-        <button class="btn btn-primary-light btn-wave" type="button">
-          <i data-feather="send"></i>
-          {{ 'CodeEditor.Submit' | translate }}
-        </button>
-      </div>
-      <div class="btn-group" role="group">
-        <button class="btn btn-primary-light btn-wave" type="button">
-          <kep-icon name="left"/>
-        </button>
-        <button class="btn btn-primary-light btn-wave" type="button">
-          <kep-icon name="right"/>
-        </button>
+      <div class="problem-header-actions d-flex align-items-center">
+        <div class="btn-group me-1" role="group">
+          <button class="btn btn-secondary-light btn-wave" type="button">
+            <span><i data-feather="terminal"></i></span>
+            {{ 'CodeEditor.Run' | translate }}
+          </button>
+          <button class="btn btn-primary-light btn-wave" type="button" (click)="codeEditorSidebarToggle()">
+            <i data-feather="send"></i>
+            {{ 'CodeEditor.Submit' | translate }}
+          </button>
+        </div>
+        <div class="me-1 problem-language-select">
+          <label class="form-label mb-0 me-50">{{ 'Lang' | translate }}:</label>
+          <ng-select
+            class="language-dropdown"
+            (change)="langChange($event)"
+            [appendTo]="'body'"
+            [clearable]="false"
+            [(ngModel)]="selectedLang">
+            @for (availableLanguage of problem.availableLanguages; track availableLanguage.lang) {
+              <ng-option [value]="availableLanguage.lang">
+                <attempt-language [size]="24" [lang]="availableLanguage.lang" [langFull]="availableLanguage.langFull"/>
+                {{ availableLanguage.langFull || availableLanguage.lang }}
+              </ng-option>
+            }
+          </ng-select>
+        </div>
+        <div class="btn-group" role="group">
+          <button
+            (click)="navigateToProblem('prev')"
+            [disabled]="isNavigating"
+            class="btn btn-primary-light btn-wave"
+            ngbTooltip="Previous problem"
+            type="button">
+            <kep-icon name="left"/>
+          </button>
+          <button
+            (click)="navigateToProblem('next')"
+            [disabled]="isNavigating"
+            class="btn btn-primary-light btn-wave"
+            ngbTooltip="Next problem"
+            type="button">
+            <kep-icon name="right"/>
+          </button>
+        </div>
       </div>
     </app-content-header>
     <section  class="mt-2">

--- a/src/app/modules/problems/pages/problem/problem.component.scss
+++ b/src/app/modules/problems/pages/problem/problem.component.scss
@@ -17,3 +17,18 @@ pre {
 }
 
 /* Дополнительные стили можно добавить по необходимости */
+
+.problem-header-actions {
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.problem-language-select {
+  display: flex;
+  align-items: center;
+  column-gap: 0.5rem;
+}
+
+.language-dropdown {
+  min-width: 200px;
+}

--- a/src/app/modules/problems/services/problems-api.service.ts
+++ b/src/app/modules/problems/services/problems-api.service.ts
@@ -35,6 +35,14 @@ export class ProblemsApiService {
     return this.api.get(`problems/${id}`);
   }
 
+  getNextProblemId(id: number) {
+    return this.api.get(`problems/${id}/next`);
+  }
+
+  getPreviousProblemId(id: number) {
+    return this.api.get(`problems/${id}/prev`);
+  }
+
   getStudyPlans() {
     return this.api.get('study-plans');
   }


### PR DESCRIPTION
## Summary
- align problem detail page language selection with contest logic and add prev/next navigation
- remove redundant language badges from the info card and reuse the unified language selector in duel submissions
- expose API helpers for problem navigation and surface per-language limits on duel problems

## Testing
- npm run lint *(fails: ng CLI not available due to unresolved Angular peer dependency conflict during npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68d06f6ab718832faaa8fc915f1a72d5