### PR TITLE
Fetch next/previous problem on navigation click

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -103,6 +103,8 @@ export const localeEn = {
   Week: 'Week',
   Month: 'Month',
   Problem: 'Problem',
+  PreviousProblem: 'Previous problem',
+  NextProblem: 'Next problem',
   Rating: 'Rating',
   OverallRating: 'Overall rating',
   DuelsRating: 'Duels Rating',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -99,6 +99,8 @@ export const localeRu = {
   PickOne: 'Выбрать один',
   GoToContest: 'Перейти в контест',
   Problem: 'Задача',
+  PreviousProblem: 'Предыдущая задача',
+  NextProblem: 'Следующая задача',
   Rating: 'Рейтинг',
   OverallRating: 'Общий рейтинг',
   DuelsRating: 'Рейтинг дуэлей',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -94,6 +94,8 @@ export const localeUz = {
   Week: 'Hafta',
   Month: 'Oy',
   Problem: 'Masala',
+  PreviousProblem: 'Avvalgi masala',
+  NextProblem: 'Keyingi masala',
   Rating: 'Reyting',
   OverallRating: 'Umumiy reyting',
   DuelsRating: 'Duellar reytingi',

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -2,20 +2,20 @@
   <div class="content-body">
     <app-content-header [contentHeader]="contentHeader">
       <div class="btn-group" role="group">
-        <button class="btn btn-secondary-light btn-wave" type="button">
-          <span><i data-feather="terminal"></i></span>
-          {{ 'CodeEditor.Run' | translate }}
-        </button>
-        <button class="btn btn-primary-light btn-wave" type="button">
-          <i data-feather="send"></i>
-          {{ 'CodeEditor.Submit' | translate }}
-        </button>
-      </div>
-      <div class="btn-group" role="group">
-        <button class="btn btn-primary-light btn-wave" type="button">
+        <button
+          class="btn btn-primary-light btn-wave"
+          type="button"
+          (click)="goToPreviousProblem()"
+          ngbTooltip="{{ 'PreviousProblem' | translate }}"
+        >
           <kep-icon name="left"/>
         </button>
-        <button class="btn btn-primary-light btn-wave" type="button">
+        <button
+          class="btn btn-primary-light btn-wave"
+          type="button"
+          (click)="goToNextProblem()"
+          ngbTooltip="{{ 'NextProblem' | translate }}"
+        >
           <kep-icon name="right"/>
         </button>
       </div>

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -6,7 +6,7 @@ import { Problem } from '@problems/models/problems.models';
 import { ProblemsApiService } from '../../services/problems-api.service';
 import { ApiService } from '@core/data-access/api.service';
 import { CoreCommonModule } from '@core/common.module';
-import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbNavModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { ProblemDescriptionComponent } from '@problems/pages/problem/problem-description/problem-description.component';
 import { ProblemAttemptsComponent } from '@problems/pages/problem/problem-attempts/problem-attempts.component';
 import { ProblemHacksComponent } from '@problems/pages/problem/problem-hacks/problem-hacks.component';
@@ -20,6 +20,7 @@ import { BasePageComponent } from '@core/common/classes/base-page.component';
 import { SidebarService } from '@shared/ui/sidebar/sidebar.service';
 import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-problem',
@@ -40,6 +41,7 @@ import { KepCardComponent } from '@shared/components/kep-card/kep-card.component
     NgSelectModule,
     MonacoEditorComponent,
     KepCardComponent,
+    NgbTooltipModule,
   ]
 })
 export class ProblemComponent extends BasePageComponent implements OnInit {
@@ -51,7 +53,6 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
 
   public submitEvent = new Subject();
   public checkInput = '';
-
   constructor(
     public service: ProblemsApiService,
     public api: ApiService,
@@ -137,5 +138,34 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     console.log(4142);
     this.activeId = 2;
     this.submitEvent.next(null);
+  }
+
+  goToPreviousProblem() {
+    if (!this.problem) {
+      return;
+    }
+
+    this.service.getProblemPrevious(this.problem.id)
+      .pipe(take(1))
+      .subscribe(({ id }) => this.navigateToProblem(id));
+  }
+
+  goToNextProblem() {
+    if (!this.problem) {
+      return;
+    }
+
+    this.service.getProblemNext(this.problem.id)
+      .pipe(take(1))
+      .subscribe(({ id }) => this.navigateToProblem(id));
+  }
+
+  private navigateToProblem(problemId?: number) {
+    if (!problemId || this.problem?.id === problemId) {
+      return;
+    }
+    this.router.navigate(['/practice/problems/problem', problemId], {
+      queryParams: this.route.snapshot.queryParams,
+    });
   }
 }

--- a/src/app/modules/problems/services/problems-api.service.ts
+++ b/src/app/modules/problems/services/problems-api.service.ts
@@ -35,6 +35,14 @@ export class ProblemsApiService {
     return this.api.get(`problems/${id}`);
   }
 
+  getProblemNext(id: number | string) {
+    return this.api.get(`problems/${id}/next`);
+  }
+
+  getProblemPrevious(id: number | string) {
+    return this.api.get(`problems/${id}/prev`);
+  }
+
   getStudyPlans() {
     return this.api.get('study-plans');
   }


### PR DESCRIPTION
## Summary
- remove the disabled states from the previous/next navigation buttons in the problem header
- request the adjacent problem IDs when a navigation button is clicked and navigate to the returned problem

## Testing
- npm run lint *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68d0743ae860832f94789b618c58a275