### PR TITLE
feat: add shared file submission card

### DIFF
--- a/src/app/modules/contests/pages/contest/contest-problem/contest-problem.component.html
+++ b/src/app/modules/contests/pages/contest/contest-problem/contest-problem.component.html
@@ -118,38 +118,14 @@
             </a>
           }
 
-          <kep-card *ngIf="contest?.userInfo?.isRegistered">
-            <div class="card-header">
-              <div class="card-title">
-                {{ 'Submit' | translate }}
-              </div>
-            </div>
-            <div class="card-body">
-              <div class="mb-2">
-                <label>{{ 'Lang' | translate }}:</label>
-                <ng-select (change)="langChange($event)" appendTo="body" [clearable]="false" [(ngModel)]="selectedLang">
-                  @for (availableLang of problem.availableLanguages; track $index) {
-                    <ng-option [value]="availableLang.lang">
-                      <attempt-language [size]="24" [lang]="availableLang.lang"/>
-                      {{ availableLang.langFull }}
-                    </ng-option>
-                  }
-                </ng-select>
-              </div>
-              <div class="mb-2">
-                <label>{{ 'File' | translate }}:</label>
-                <div class="custom-file">
-                  <input (change)="handleFileInput($event.target.files)" accept=".cpp,.py,.c,.r,.hs,.kt,.cs,.php,.js,.rs,.java" class="form-control" id="customFile"
-                         type="file"/>
-                </div>
-              </div>
-            </div>
-            <div class="card-footer text-center">
-              <button (click)="submit()" [disabled]="!fileToUpload" class="btn full-width btn-sm btn-primary">
-                {{ 'Submit' | translate }}
-              </button>
-            </div>
-          </kep-card>
+          @if (contest?.userInfo?.isRegistered) {
+            <problem-submit-card
+              [availableLanguages]="problem.availableLanguages"
+              [submitUrl]="'contests/' + contest?.id + '/submit/'"
+              [submitParams]="{ contestProblem: contestProblem.symbol }"
+              (submitted)="reloadAttempts()"
+            />
+          }
 
           <kep-card>
             <div class="table-responsive beautiful-table contest-problems">

--- a/src/app/modules/contests/pages/contest/contest-problem/contest-problem.component.ts
+++ b/src/app/modules/contests/pages/contest/contest-problem/contest-problem.component.ts
@@ -34,8 +34,7 @@ import { getResourceById, Resources } from '@app/resources';
 import { ContestClassesPipe } from '@contests/pipes/contest-classes.pipe';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 import { ProblemInfoHtmlPipe } from '@contests/pages/contest/contest-problem/problem-info-html.pipe';
-import { NgOptionComponent, NgSelectComponent } from "@ng-select/ng-select";
-import { AttemptLanguageComponent } from "@shared/components/attempt-language/attempt-language.component";
+import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
 
 const CONTESTANT_RESULTS_VISIBLE_KEY = 'contestant-results-visible';
 
@@ -58,9 +57,7 @@ const CONTESTANT_RESULTS_VISIBLE_KEY = 'contestant-results-visible';
     ContestClassesPipe,
     KepCardComponent,
     ProblemInfoHtmlPipe,
-    NgOptionComponent,
-    NgSelectComponent,
-    AttemptLanguageComponent,
+    ProblemSubmitCardComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -78,14 +75,11 @@ export class ContestProblemComponent extends BaseComponent implements OnInit, On
   public attempts: Array<Attempt> = [];
 
   public selectedAvailableLang: AvailableLanguage;
-  public selectedLang: string;
 
   public totalAttemptsCount = 0;
   public currentPage = 1;
 
   public contestant: Contestant | null;
-
-  public fileToUpload: File | null = null;
 
   private _intervalId: any;
 
@@ -109,7 +103,6 @@ export class ContestProblemComponent extends BaseComponent implements OnInit, On
       this.contestProblem = contestProblem;
       this.problem = contestProblem.problem;
       this.cdr.markForCheck();
-      // setTimeout(() => this.langService.setLanguage(this.selectedLang as any));
       this.titleService.updateTitle(this.route, {
         contestTitle: contest.title,
         problemSymbol: contestProblem.symbol,
@@ -121,7 +114,6 @@ export class ContestProblemComponent extends BaseComponent implements OnInit, On
       this.langService.getLanguage().pipe(takeUntil(this._unsubscribeAll)).subscribe(
         (lang: AttemptLangs) => {
           this.selectedAvailableLang = findAvailableLang(this.problem.availableLanguages, lang);
-          this.selectedLang = lang;
           if (!this.selectedAvailableLang) {
             setTimeout(() => {
               this.langService.setLanguage(this.problem.availableLanguages[0].lang);
@@ -239,38 +231,6 @@ export class ContestProblemComponent extends BaseComponent implements OnInit, On
   onAttemptChecked() {
     this.reloadProblems();
     this.updateContestant();
-  }
-
-  handleFileInput(files: FileList) {
-    if (files.item(0).size > 1024 * 128) {
-      this.toastr.error('Max file size 128kb');
-    } else {
-      this.fileToUpload = files.item(0);
-    }
-  }
-
-  submit() {
-    this.fileToUpload.text().then(
-      (sourceCode) => {
-        const data = {
-          sourceCode,
-          lang: this.selectedLang,
-          contestProblem: this.contestProblem.symbol,
-        };
-
-        this.api.post('contests/' + this.contest?.id + '/submit/', data).subscribe(
-          () => {
-            this.fileToUpload = null;
-            this.toastr.success('', this.translateService.instant('SubmittedSuccess'));
-            this.reloadAttempts();
-          }
-        );
-      }
-    )
-  }
-
-  langChange(lang) {
-    this.langService.setLanguage(lang);
   }
 
   ngOnDestroy(): void {

--- a/src/app/modules/duels/ui/pages/duel/duel.component.html
+++ b/src/app/modules/duels/ui/pages/duel/duel.component.html
@@ -114,6 +114,12 @@
                     [submitParams]="{ duelProblem: duelProblem.symbol }"
                     (submittedEvent)="reloadAttempts()"
                   />
+                  <problem-submit-card
+                    [availableLanguages]="duelProblem.problem.availableLanguages"
+                    [submitUrl]="'duels/' + duel.id + '/submit/'"
+                    [submitParams]="{ duelProblem: duelProblem.symbol }"
+                    (submitted)="reloadAttempts()"
+                  />
                 }
               </div>
             </kep-card>

--- a/src/app/modules/duels/ui/pages/duel/duel.component.ts
+++ b/src/app/modules/duels/ui/pages/duel/duel.component.ts
@@ -17,6 +17,7 @@ import { BaseLoadComponent } from '@core/common';
 import { takeUntil } from 'rxjs/operators';
 import { PageResult } from '@core/common/classes/page-result';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
+import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
 
 @Component({
   templateUrl: './duel.component.html',
@@ -33,7 +34,8 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
     DuelCountdownComponent,
     ProblemInfoCardComponent,
     ProblemListCardComponent,
-    NgxSkeletonLoaderModule
+    NgxSkeletonLoaderModule,
+    ProblemSubmitCardComponent
   ]
 })
 export class DuelComponent extends BaseLoadComponent<Duel> {

--- a/src/app/modules/problems/components/problem-info-card/problem-info-card.component.html
+++ b/src/app/modules/problems/components/problem-info-card/problem-info-card.component.html
@@ -99,30 +99,6 @@
   </div>
 }
 
-<div class="languages mt-2">
-  <div class="d-flex mb-1">
-    <h5>
-      <i data-feather="code"></i>
-      {{ 'Languages' | translate }}
-    </h5>
-  </div>
-
-  <div class="row">
-
-    @for (availableLanguage of problem.availableLanguages; track availableLanguage) {
-      <div class="col-4 col-md-3 col-lg-6 col-xl-4 px-1">
-        <attempt-language
-          [clickable]="true"
-          [lang]="availableLanguage.lang"
-          [langFull]="availableLanguage.langFull"
-          (click)="langService.setLanguage(availableLanguage.lang)"
-        />
-      </div>
-    }
-  </div>
-
-</div>
-
 <div class="selected-language mt-2">
   <div class="d-flex mb-1">
     <h5>

--- a/src/app/modules/problems/components/problem-info-card/problem-info-card.component.ts
+++ b/src/app/modules/problems/components/problem-info-card/problem-info-card.component.ts
@@ -27,7 +27,6 @@ interface IVoteResult {
     UserPopoverModule,
     KepIconComponent,
     AttemptLanguageComponent,
-    AttemptLanguageComponent,
   ],
   templateUrl: './problem-info-card.component.html',
   styleUrl: './problem-info-card.component.scss'

--- a/src/app/modules/problems/components/problem-submit-card/problem-submit-card.component.html
+++ b/src/app/modules/problems/components/problem-submit-card/problem-submit-card.component.html
@@ -1,0 +1,50 @@
+<kep-card>
+  <div class="card-header">
+    <div class="card-title">
+      {{ 'Submit' | translate }}
+    </div>
+  </div>
+
+  <div class="card-body">
+    <div class="mb-2" *ngIf="availableLanguages?.length">
+      <label>{{ 'Lang' | translate }}:</label>
+      <ng-select
+        appendTo="body"
+        [clearable]="false"
+        [(ngModel)]="selectedLang"
+        (change)="onLangChange($event)"
+      >
+        <ng-option *ngFor="let availableLang of availableLanguages" [value]="availableLang.lang">
+          <attempt-language [size]="24" [lang]="availableLang.lang" [langFull]="availableLang.langFull"></attempt-language>
+          {{ availableLang.langFull || availableLang.lang }}
+        </ng-option>
+      </ng-select>
+    </div>
+
+    <div class="mb-2">
+      <label>{{ 'File' | translate }}:</label>
+      <div class="custom-file">
+        <input
+          class="form-control"
+          type="file"
+          [accept]="fileAccept"
+          (change)="handleFileInput($event.target.files)"
+        />
+      </div>
+      <small class="text-muted" *ngIf="fileToUpload">
+        {{ fileToUpload.name }}
+      </small>
+    </div>
+  </div>
+
+  <div class="card-footer text-center">
+    <button
+      class="btn full-width btn-sm btn-primary"
+      type="button"
+      (click)="submit()"
+      [disabled]="disabled || !fileToUpload || !availableLanguages?.length || isSubmitting"
+    >
+      <span>{{ 'Submit' | translate }}</span>
+    </button>
+  </div>
+</kep-card>

--- a/src/app/modules/problems/components/problem-submit-card/problem-submit-card.component.scss
+++ b/src/app/modules/problems/components/problem-submit-card/problem-submit-card.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/modules/problems/components/problem-submit-card/problem-submit-card.component.ts
+++ b/src/app/modules/problems/components/problem-submit-card/problem-submit-card.component.ts
@@ -1,0 +1,182 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { AvailableLanguage } from '@problems/models/problems.models';
+import { AttemptLangs } from '@problems/constants';
+import { LanguageService } from '@problems/services/language.service';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { findAvailableLang } from '@problems/utils';
+import { ApiService } from '@core/data-access/api.service';
+import { TranslateService } from '@ngx-translate/core';
+import { ToastrService } from 'ngx-toastr';
+import { CoreCommonModule } from '@core/common.module';
+import { NgIf, NgForOf } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { NgSelectComponent, NgOptionComponent } from '@ng-select/ng-select';
+import { AttemptLanguageComponent } from '@shared/components/attempt-language/attempt-language.component';
+import { TranslateModule } from '@ngx-translate/core';
+import { finalize } from 'rxjs/operators';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+
+@Component({
+  selector: 'problem-submit-card',
+  standalone: true,
+  imports: [
+    CoreCommonModule,
+    NgIf,
+    NgForOf,
+    FormsModule,
+    NgSelectComponent,
+    NgOptionComponent,
+    AttemptLanguageComponent,
+    TranslateModule,
+    KepCardComponent,
+  ],
+  templateUrl: './problem-submit-card.component.html',
+  styleUrls: ['./problem-submit-card.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProblemSubmitCardComponent implements OnInit, OnDestroy, OnChanges {
+
+  @Input() availableLanguages: Array<AvailableLanguage> = [];
+  @Input() submitUrl: string;
+  @Input() submitParams: Record<string, unknown> = {};
+  @Input() disabled = false;
+  @Input() fileAccept = '.cpp,.py,.c,.r,.hs,.kt,.cs,.php,.js,.rs,.java';
+  @Input() maxFileSize = 1024 * 128;
+
+  @Output() submitted = new EventEmitter<void>();
+
+  public selectedLang: AttemptLangs;
+  public selectedAvailableLang: AvailableLanguage | null = null;
+
+  public fileToUpload: File | null = null;
+  public isSubmitting = false;
+
+  private readonly _unsubscribeAll = new Subject<void>();
+
+  constructor(
+    private readonly langService: LanguageService,
+    private readonly api: ApiService,
+    private readonly translateService: TranslateService,
+    private readonly toastr: ToastrService,
+    private readonly cdr: ChangeDetectorRef,
+  ) {}
+
+  ngOnInit(): void {
+    this.langService.getLanguage().pipe(takeUntil(this._unsubscribeAll)).subscribe(
+      (lang: AttemptLangs) => {
+        this.updateSelectedLanguage(lang);
+      }
+    );
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if ('availableLanguages' in changes && this.availableLanguages?.length) {
+      this.updateSelectedLanguage(this.langService.getLanguageValue());
+    }
+  }
+
+  ngOnDestroy(): void {
+    this._unsubscribeAll.next();
+    this._unsubscribeAll.complete();
+  }
+
+  onLangChange(lang: AttemptLangs) {
+    this.langService.setLanguage(lang);
+  }
+
+  handleFileInput(files: FileList | null) {
+    if (!files || files.length === 0) {
+      this.fileToUpload = null;
+      this.cdr.markForCheck();
+      return;
+    }
+
+    const file = files.item(0);
+    if (!file) {
+      this.fileToUpload = null;
+      this.cdr.markForCheck();
+      return;
+    }
+
+    if (file.size > this.maxFileSize) {
+      const maxSizeKb = Math.floor(this.maxFileSize / 1024);
+      this.toastr.error(`Max file size ${maxSizeKb}kb`);
+      this.fileToUpload = null;
+      this.cdr.markForCheck();
+      return;
+    }
+
+    this.fileToUpload = file;
+    this.cdr.markForCheck();
+  }
+
+  submit() {
+    if (this.disabled || this.isSubmitting || !this.fileToUpload || !this.submitUrl || !this.selectedLang) {
+      return;
+    }
+
+    this.isSubmitting = true;
+    const file = this.fileToUpload;
+
+    file.text().then(
+      (sourceCode) => {
+        const data = {
+          sourceCode,
+          lang: this.selectedLang,
+          ...this.submitParams,
+        };
+
+        this.api.post(this.submitUrl, data).pipe(
+          finalize(() => {
+            this.isSubmitting = false;
+            this.cdr.markForCheck();
+          })
+        ).subscribe(
+          () => {
+            this.fileToUpload = null;
+            this.cdr.markForCheck();
+            const successText = this.translateService.instant('SubmittedSuccess');
+            this.toastr.success('', successText);
+            this.submitted.emit();
+          },
+          () => {
+            this.toastr.error(this.translateService.instant('Error'));
+          }
+        );
+      },
+      () => {
+        this.isSubmitting = false;
+        this.toastr.error(this.translateService.instant('Error'));
+        this.cdr.markForCheck();
+      }
+    );
+  }
+
+  private updateSelectedLanguage(lang: AttemptLangs) {
+    if (!this.availableLanguages?.length) {
+      this.selectedAvailableLang = null;
+      this.selectedLang = lang;
+      this.cdr.markForCheck();
+      return;
+    }
+
+    const available = findAvailableLang(this.availableLanguages, lang);
+
+    if (available) {
+      this.selectedAvailableLang = available;
+      this.selectedLang = available.lang as AttemptLangs;
+      this.cdr.markForCheck();
+      return;
+    }
+
+    const fallback = this.availableLanguages[0];
+    this.selectedAvailableLang = fallback;
+    this.selectedLang = fallback.lang as AttemptLangs;
+    this.cdr.markForCheck();
+
+    if (fallback?.lang) {
+      this.langService.setLanguage(fallback.lang as AttemptLangs);
+    }
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -123,6 +123,14 @@
 
         <div class="col-lg-3 col-md-12 col-sm-12">
           <problem-sidebar [problem]="problem"></problem-sidebar>
+
+          @if (isAuthenticated) {
+            <problem-submit-card
+              [availableLanguages]="problem.availableLanguages"
+              [submitUrl]="'problems/' + problem.id + '/submit/'"
+              (submitted)="onSubmit()"
+            />
+          }
         </div>
 
       </div>

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -20,6 +20,7 @@ import { BasePageComponent } from '@core/common/classes/base-page.component';
 import { SidebarService } from '@shared/ui/sidebar/sidebar.service';
 import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
 
 @Component({
   selector: 'app-problem',
@@ -40,6 +41,7 @@ import { KepCardComponent } from '@shared/components/kep-card/kep-card.component
     NgSelectModule,
     MonacoEditorComponent,
     KepCardComponent,
+    ProblemSubmitCardComponent,
   ]
 })
 export class ProblemComponent extends BasePageComponent implements OnInit {


### PR DESCRIPTION
## Summary
- add a reusable problem submit card with shared language selection and file upload logic
- use the new submit card on contest problems, problem detail, and duel pages while removing the old language list

## Testing
- npm run lint *(fails: ng not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0745199d8832f8d7d981b84ed6485