### PR TITLE
Refactor problem page navigation to use child routes

### DIFF
--- a/src/app/modules/problems/pages/problem/problem-attempts/problem-attempts-route.component.ts
+++ b/src/app/modules/problems/pages/problem/problem-attempts/problem-attempts-route.component.ts
@@ -1,0 +1,34 @@
+import { Component, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Problem } from '@problems/models/problems.models';
+import { ProblemComponent } from '../problem.component';
+import { ProblemAttemptsComponent } from './problem-attempts.component';
+
+@Component({
+  standalone: true,
+  imports: [ProblemAttemptsComponent],
+  template: `
+    @if (problem && submitEvent$) {
+      <problem-attempts
+        [problem]="problem"
+        [submitEvent]="submitEvent$"
+        (hackSubmitted)="onHackSubmitted()"
+      ></problem-attempts>
+    }
+  `,
+})
+export class ProblemAttemptsRouteComponent {
+  private readonly parent = inject(ProblemComponent);
+
+  get problem(): Problem | undefined {
+    return this.parent.problem;
+  }
+
+  get submitEvent$(): Observable<void> {
+    return this.parent.submitEvent$;
+  }
+
+  onHackSubmitted() {
+    this.parent.navigateToHacks();
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem-description/problem-description-route.component.ts
+++ b/src/app/modules/problems/pages/problem/problem-description/problem-description-route.component.ts
@@ -1,0 +1,21 @@
+import { Component, inject } from '@angular/core';
+import { ProblemDescriptionComponent } from './problem-description.component';
+import { ProblemComponent } from '../problem.component';
+import { Problem } from '@problems/models/problems.models';
+
+@Component({
+  standalone: true,
+  imports: [ProblemDescriptionComponent],
+  template: `
+    @if (problem) {
+      <problem-description [problem]="problem"></problem-description>
+    }
+  `,
+})
+export class ProblemDescriptionRouteComponent {
+  private readonly parent = inject(ProblemComponent);
+
+  get problem(): Problem | undefined {
+    return this.parent.problem;
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem-hacks/problem-hacks-route.component.ts
+++ b/src/app/modules/problems/pages/problem/problem-hacks/problem-hacks-route.component.ts
@@ -1,0 +1,21 @@
+import { Component, inject } from '@angular/core';
+import { Problem } from '@problems/models/problems.models';
+import { ProblemComponent } from '../problem.component';
+import { ProblemHacksComponent } from './problem-hacks.component';
+
+@Component({
+  standalone: true,
+  imports: [ProblemHacksComponent],
+  template: `
+    @if (problem) {
+      <problem-hacks [problem]="problem"></problem-hacks>
+    }
+  `,
+})
+export class ProblemHacksRouteComponent {
+  private readonly parent = inject(ProblemComponent);
+
+  get problem(): Problem | undefined {
+    return this.parent.problem;
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -25,100 +25,79 @@
         <div class="col-lg-9 col-md-12 col-sm-12">
           <kep-card>
             <div class="card-header">
-              <ul
-                #navWithIcons="ngbNav"
-                (activeIdChange)="activeIdChange($event)" [(activeId)]="activeId" [destroyOnHide]="false"
-                class="nav-tabs" ngbNav>
-                <li [ngbNavItem]="1">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
-                    {{ 'Problem' | translate }}
-                  </a>
-                  <ng-template ngbNavContent>
-                    <problem-description [problem]="problem"></problem-description>
-                  </ng-template>
-                </li>
-
-                <li [ngbNavItem]="2">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
-                    {{ 'Attempts' | translate }}
-                  </a>
-                  <ng-template ngbNavContent>
-                    <problem-attempts
-                      (hackSubmitted)="activeId = 3;"
-                      [problem]="problem"
-                      [submitEvent]="submitEvent?.asObservable()"
+              <div class="d-flex flex-column flex-lg-row gap-1 align-items-lg-center">
+                <ul class="nav nav-tabs flex-grow-1 card-header-tabs">
+                  <li class="nav-item">
+                    <a
+                      class="nav-link"
+                      [routerLink]="['./']"
+                      routerLinkActive="active"
+                      [routerLinkActiveOptions]="{ exact: true }"
                     >
-                    </problem-attempts>
-                  </ng-template>
-                </li>
-
-                @if (problem.hasCheckInput) {
-                  <li [ngbNavItem]="3" destroyOnHide="true">
-                    <a class="nav-link" ngbNavLink>
-                      <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
-                      {{ 'Hacks' | translate }}
+                      <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
+                      {{ 'Problem' | translate }}
                     </a>
-                    <ng-template ngbNavContent>
-                      <problem-hacks [problem]="problem"></problem-hacks>
-                    </ng-template>
                   </li>
-                }
 
-                @if (studyPlanId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink routerLink="/practice/problems/study-plan/{{ studyPlanId }}">
-                      <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
+                  <li class="nav-item">
+                    <a
+                      class="nav-link"
+                      [routerLink]="['attempts']"
+                      routerLinkActive="active"
+                    >
+                      <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
+                      {{ 'Attempts' | translate }}
                     </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
                   </li>
-                }
 
-                @if (contestId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink routerLink="/competitions/contests/contest/{{ contestId }}/problems">
+                  @if (problem?.hasCheckInput) {
+                    <li class="nav-item">
+                      <a
+                        class="nav-link"
+                        [routerLink]="['hacks']"
+                        routerLinkActive="active"
+                      >
+                        <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
+                        {{ 'Hacks' | translate }}
+                      </a>
+                    </li>
+                  }
+                </ul>
+
+                <div class="d-flex gap-1 justify-content-end flex-wrap">
+                  @if (studyPlanId) {
+                    <a
+                      class="btn btn-outline-secondary btn-wave"
+                      [routerLink]="['/practice/problems/study-plan', studyPlanId]"
+                    >
+                      <span [data-feather]="'activity'"></span>
+                      <span class="ms-1">{{ 'StudyPlan' | translate }}</span>
+                    </a>
+                  }
+
+                  @if (contestId) {
+                    <a
+                      class="btn btn-outline-primary btn-wave"
+                      [routerLink]="['/competitions/contests/contest', contestId, 'problems']"
+                    >
                       <kep-icon name="contest" color="primary" type="duotone"/>
-                      {{ 'Contest' | translate }}
+                      <span class="ms-1">Contestga qaytish</span>
                     </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-              </ul>
+                  }
 
-              @if (isAuthenticated) {
-                <button (click)="codeEditorSidebarToggle()" class="btn btn-sm btn-primary">{{ 'Submit' | translate }}
-                </button>
-              }
-            </div>
-
-            <div class="card-footer">
-              <div [ngbNavOutlet]="navWithIcons"></div>
-            </div>
-          </kep-card>
-
-          @if (currentUser?.permissions.canCreateProblems) {
-            <div class="card">
-              <div class="card-header">
-                <div class="card-title">
-                  Check input
+                  @if (isAuthenticated) {
+                    <button (click)="codeEditorSidebarToggle()" class="btn btn-sm btn-primary">
+                      {{ 'Submit' | translate }}
+                    </button>
+                  }
                 </div>
               </div>
-              <div class="card-body">
-                <monaco-editor
-                  [lang]="'py'"
-                  class="mt-1"
-                  [ngModelOptions]="{standalone: true}"
-                  [(ngModel)]="checkInput"
-                ></monaco-editor>
-                <div class="btn mt-2 btn-primary btn-sm" (click)="saveCheckInput()">Save</div>
-              </div>
             </div>
-          }
+
+            <div class="card-body">
+              <router-outlet></router-outlet>
+            </div>
+          </kep-card>
         </div>
 
         <div class="col-lg-3 col-md-12 col-sm-12">

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -1,21 +1,12 @@
 import { Component, OnInit } from '@angular/core';
-import { Params } from '@angular/router';
+import { Params, RouterModule } from '@angular/router';
 import { AuthUser } from '@auth';
 import { Subject } from 'rxjs';
 import { Problem } from '@problems/models/problems.models';
-import { ProblemsApiService } from '../../services/problems-api.service';
-import { ApiService } from '@core/data-access/api.service';
 import { CoreCommonModule } from '@core/common.module';
-import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
-import { ProblemDescriptionComponent } from '@problems/pages/problem/problem-description/problem-description.component';
-import { ProblemAttemptsComponent } from '@problems/pages/problem/problem-attempts/problem-attempts.component';
-import { ProblemHacksComponent } from '@problems/pages/problem/problem-hacks/problem-hacks.component';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { CodeEditorModule } from '@shared/components/code-editor/code-editor.module';
 import { ProblemSidebarComponent } from '@problems/pages/problem/problem-sidebar/problem-sidebar.component';
 import { TourModule } from '@shared/third-part-modules/tour/tour.module';
-import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
-import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
 import { BasePageComponent } from '@core/common/classes/base-page.component';
 import { SidebarService } from '@shared/ui/sidebar/sidebar.service';
 import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
@@ -29,52 +20,38 @@ import { KepCardComponent } from '@shared/components/kep-card/kep-card.component
   imports: [
     CoreCommonModule,
     ContentHeaderModule,
-    NgbNavModule,
-    ProblemDescriptionComponent,
-    ProblemAttemptsComponent,
-    ProblemHacksComponent,
-    MonacoEditorModule,
+    RouterModule,
     CodeEditorModule,
     ProblemSidebarComponent,
     TourModule,
-    NgSelectModule,
-    MonacoEditorComponent,
     KepCardComponent,
   ]
 })
 export class ProblemComponent extends BasePageComponent implements OnInit {
   public problem: Problem;
 
-  public activeId = 1;
   public studyPlanId: number;
   public contestId: number;
 
-  public submitEvent = new Subject();
-  public checkInput = '';
+  private readonly submitEventSubject = new Subject<void>();
+  public readonly submitEvent$ = this.submitEventSubject.asObservable();
+
+  private pendingTab: 'attempts' | 'hacks' | null = null;
 
   constructor(
-    public service: ProblemsApiService,
-    public api: ApiService,
     protected coreSidebarService: SidebarService,
   ) {
     super();
   }
 
   ngOnInit(): void {
-    if (this._queryParams.tab === 'hacks') {
-      this.activeId = 3;
-    } else if (this._queryParams.tab === 'attempts') {
-      this.activeId = 2;
+    const resolvedProblem = this.route.snapshot.data['problem'];
+    if (resolvedProblem) {
+      this.setProblem(resolvedProblem);
     }
 
     this.route.data.subscribe(({ problem }) => {
-      this.problem = problem;
-      this.titleService.updateTitle(this.route, {
-        problemTitle: this.problem.title,
-        problemId: this.problem.id
-      });
-      this.checkInput = this.problem.checkInputSource;
-      this.loadContentHeader();
+      this.setProblem(problem);
     });
   }
 
@@ -84,6 +61,12 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     }
     if (params['contest']) {
       this.contestId = params['contest'];
+    }
+
+    const tab = params['tab'];
+    if (tab === 'attempts' || tab === 'hacks') {
+      this.pendingTab = tab;
+      this.applyPendingTab();
     }
   }
 
@@ -109,33 +92,81 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     };
   }
 
-  activeIdChange(index: number) {
-    if (index === 1) {
-      this.updateQueryParams({ tab: null });
-    } else if (index === 2) {
-      this.updateQueryParams({ tab: 'attempts' });
-    } else if (index === 3) {
-      this.updateQueryParams({ tab: 'hacks' });
-    }
-  }
-
-  saveCheckInput() {
-    this.api.post(`problems/${ this.problem.id }/save-check-input`, { source: this.checkInput }).subscribe(
-      () => {
-        this.toastr.success('Success');
-      }, () => {
-        this.toastr.error('Error');
-      }
-    );
-  }
-
   codeEditorSidebarToggle() {
     this.coreSidebarService.getSidebarRegistry('codeEditorSidebar').toggleOpen();
   }
 
   onSubmit() {
-    console.log(4142);
-    this.activeId = 2;
-    this.submitEvent.next(null);
+    this.submitEventSubject.next();
+    this.navigateToAttempts();
+  }
+
+  navigateToAttempts(options?: { replaceUrl?: boolean }) {
+    this.router.navigate(['attempts'], {
+      relativeTo: this.route,
+      queryParamsHandling: 'preserve',
+      replaceUrl: options?.replaceUrl,
+    });
+  }
+
+  navigateToHacks(options?: { replaceUrl?: boolean }) {
+    if (!this.problem?.hasCheckInput) {
+      return;
+    }
+
+    this.router.navigate(['hacks'], {
+      relativeTo: this.route,
+      queryParamsHandling: 'preserve',
+      replaceUrl: options?.replaceUrl,
+    });
+  }
+
+  private navigateToProblemRoot(options?: { replaceUrl?: boolean }) {
+    this.router.navigate([''], {
+      relativeTo: this.route,
+      queryParamsHandling: 'preserve',
+      replaceUrl: options?.replaceUrl,
+    });
+  }
+
+  private applyPendingTab() {
+    if (!this.pendingTab) {
+      return;
+    }
+
+    if (!this.problem) {
+      return;
+    }
+
+    if (this.pendingTab === 'hacks' && !this.problem?.hasCheckInput) {
+      this.pendingTab = null;
+      return;
+    }
+
+    if (this.pendingTab === 'attempts') {
+      this.navigateToAttempts({ replaceUrl: true });
+    } else if (this.pendingTab === 'hacks') {
+      this.navigateToHacks({ replaceUrl: true });
+    }
+
+    this.pendingTab = null;
+  }
+
+  private ensureValidChildRoute() {
+    const childPath = this.route.firstChild?.snapshot.routeConfig?.path;
+    if (childPath === 'hacks' && !this.problem?.hasCheckInput) {
+      this.navigateToProblemRoot({ replaceUrl: true });
+    }
+  }
+
+  private setProblem(problem: Problem) {
+    this.problem = problem;
+    this.titleService.updateTitle(this.route, {
+      problemTitle: this.problem.title,
+      problemId: this.problem.id
+    });
+    this.loadContentHeader();
+    this.applyPendingTab();
+    this.ensureValidChildRoute();
   }
 }

--- a/src/app/modules/problems/problems.routing.ts
+++ b/src/app/modules/problems/problems.routing.ts
@@ -29,28 +29,20 @@ export default [
       problem: ProblemResolver,
     },
     canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/attempts',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/hacks',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
+    children: [
+      {
+        path: '',
+        loadComponent: () => import('./pages/problem/problem-description/problem-description-route.component').then(c => c.ProblemDescriptionRouteComponent),
+      },
+      {
+        path: 'attempts',
+        loadComponent: () => import('./pages/problem/problem-attempts/problem-attempts-route.component').then(c => c.ProblemAttemptsRouteComponent),
+      },
+      {
+        path: 'hacks',
+        loadComponent: () => import('./pages/problem/problem-hacks/problem-hacks-route.component').then(c => c.ProblemHacksRouteComponent),
+      },
+    ],
   },
   // {
   //   path: 'problem/:id/og-image',


### PR DESCRIPTION
## Summary
- switch the problem page tabs to router-based navigation with a router outlet and add a contest return button
- remove the check input editor and adjust TypeScript logic to manage tab routing and pending query parameters
- introduce lightweight child-route wrappers and update routing to serve problem description, attempts, and hacks via dedicated routes

## Testing
- npm run lint *(fails: lint target is not configured in angular.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d078842578832f899cd8a12d5e47a6