### PR TITLE
Refactor router links to use Resources constants

### DIFF
--- a/src/@core/layouts/components/header/header.component.html
+++ b/src/@core/layouts/components/header/header.component.html
@@ -49,11 +49,11 @@
             </div>
           </a>
           <ul ngbDropdownMenu aria-labelledby="navbarUserDropdown" class="dropdown-menu dropdown-menu-end">
-            <a ngbDropdownItem [routerLink]="['/users', 'user', currentUser?.username]">
+            <a ngbDropdownItem [routerLink]="Resources.UserProfile | resourceByUsername:currentUser?.username">
               <kep-icon size="small-4" name="user" type="duotone"/>
               {{ 'Profile' | translate }}
             </a>
-            <a ngbDropdownItem [routerLink]="['/settings']">
+            <a ngbDropdownItem [routerLink]="[Resources.Settings]">
               <span [data-feather]="'settings'" [class]="'me-1'"></span>
               {{ 'SettingsMenu' | translate }}
             </a>

--- a/src/@core/layouts/components/header/header.component.ts
+++ b/src/@core/layouts/components/header/header.component.ts
@@ -15,6 +15,7 @@ import { HeaderKepcoinComponent } from "@core/layouts/components/header/kepcoin/
 import { HeaderDailyTasksComponent } from "@core/layouts/components/header/daily-tasks/header-daily-tasks.component";
 import { LanguagesComponent } from "@core/layouts/components/languages/languages.component";
 import { LogoComponent } from "@shared/components/logo/logo.component";
+import { ResourceByUsernamePipe } from '@shared/pipes/resource-by-username.pipe';
 
 @Component({
   selector: 'app-header',
@@ -31,7 +32,8 @@ import { LogoComponent } from "@shared/components/logo/logo.component";
     NgbDropdownToggle,
     NgbDropdownItem,
     LanguagesComponent,
-    LogoComponent
+    LogoComponent,
+    ResourceByUsernamePipe,
   ]
 })
 export class HeaderComponent extends BaseComponent {

--- a/src/@core/layouts/components/header/kepcoin/header-kepcoin.component.html
+++ b/src/@core/layouts/components/header/kepcoin/header-kepcoin.component.html
@@ -23,7 +23,7 @@
   <a
     class="text-fixed-white header-link-icon d-flex justify-content-center align-items-center gap-1"
     style="width: inherit"
-    routerLink="/kepcoin"
+    [routerLink]="Resources.Kepcoin"
     [ngbPopover]="popContent"
     triggers="mouseenter:mouseleave"
     [closeDelay]="1000"

--- a/src/@core/layouts/components/header/notifications/header-notifications.component.html
+++ b/src/@core/layouts/components/header/notifications/header-notifications.component.html
@@ -35,7 +35,7 @@
                         {{ notification.message }}
                       }
                       @case (2) {
-                        <a routerLink="/competitions/contests/contest/{{ notification.content.contestId }}/standings">
+                        <a [routerLink]="Resources.ContestStandings | resourceById:notification.content.contestId">
                           <strong>{{ notification.content.contestTitle }}</strong>
                           | {{ 'ContestFinishedNotification' | translate }}
                           <span
@@ -67,28 +67,28 @@
                         <img height="18" src="assets/images/icons/kepcoin.png"> {{ notification.content.kepcoin }}
                       }
                       @case (4) {
-                        <a routerLink="/practice/challenges/challenge/{{ notification.content?.challengeId }}">
+                        <a [routerLink]="Resources.Challenge | resourceById:notification.content?.challengeId">
                           {{ 'ChallengeCallAcceptedNotification' | translate }}
                         </a>
                       }
                       @case (5) {
-                        <a routerLink="/practice/challenges/challenge/{{ notification.content?.challengeId }}">
+                        <a [routerLink]="Resources.Challenge | resourceById:notification.content?.challengeId">
                           {{ 'ChallengeFinishedNotification' | translate }}
                         </a>
                       }
                       @case (6) {
-                        <a routerLink="/competitions/arena/tournament/{{ notification.content?.arena?.id }}">
+                        <a [routerLink]="Resources.ArenaTournament | resourceById:notification.content?.arena?.id">
                           <strong>{{ notification.content?.arena?.title }}</strong>
                           | {{ 'ArenaFinishedNotification' | translate }}
                         </a>
                       }
                       @case (7) {
-                        <a routerLink="/practice/duels/duel/{{ notification.content?.duel?.id }}">
+                        <a [routerLink]="Resources.Duel | resourceById:notification.content?.duel?.id">
                           {{ 'DuelStarts' | translate }}
                         </a>
                       }
                       @case (8) {
-                        <a routerLink="/users/user/{{ currentUser?.username }}/achievements">
+                        <a [routerLink]="Resources.UserProfileAchievements | resourceByUsername:currentUser?.username">
                           {{ 'NewAchievement' | translate }}
                         </a>
                       }

--- a/src/@core/layouts/components/header/notifications/header-notifications.component.ts
+++ b/src/@core/layouts/components/header/notifications/header-notifications.component.ts
@@ -14,6 +14,9 @@ import { takeUntil } from 'rxjs/operators';
 import Swal from 'sweetalert2';
 import { NotificationsService } from "@core/layouts/components/header/notifications/notifications.service";
 import { SimplebarAngularModule } from "simplebar-angular";
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
+import { ResourceByUsernamePipe } from '@shared/pipes/resource-by-username.pipe';
 
 interface Notification {
   id: number;
@@ -38,6 +41,8 @@ interface Notification {
     KepIconComponent,
     NgbDropdownModule,
     SimplebarAngularModule,
+    ResourceByIdPipe,
+    ResourceByUsernamePipe,
   ]
 })
 export class HeaderNotificationsComponent implements OnInit, OnDestroy {
@@ -56,6 +61,7 @@ export class HeaderNotificationsComponent implements OnInit, OnDestroy {
 
   private _intervalId: any;
   private _unsubscribeAll = new Subject();
+  protected readonly Resources = Resources;
 
   constructor(
     public notificationsService: NotificationsService,

--- a/src/app/modules/blog/components/blog-post-card/blog-post-card.component.html
+++ b/src/app/modules/blog/components/blog-post-card/blog-post-card.component.html
@@ -27,7 +27,7 @@
       </div>
     </div>
     <a
-      [routerLink]="['/learn', 'blog', 'post', blog.id]"
+      [routerLink]="Resources.BlogPost | resourceById:blog.id"
       class="fw-medium fs-14 text-dark mb-1">
       {{ blog.title }}
     </a>
@@ -35,7 +35,7 @@
       {{ blog.bodyShort }}
     </p>
     <a
-      [routerLink]="['/learn', 'blog', 'post', blog.id]"
+      [routerLink]="Resources.BlogPost | resourceById:blog.id"
       class="text-primary fs-14 float-end">
       {{ 'View' | translate }}
       <i class="ri-arrow-right-s-line d-inline-block rtl-icon-transform align-middle"></i>

--- a/src/app/modules/blog/components/blog-post-card/blog-post-card.component.ts
+++ b/src/app/modules/blog/components/blog-post-card/blog-post-card.component.ts
@@ -5,6 +5,8 @@ import { RouterLink } from '@angular/router';
 import { UserPopoverModule } from '@shared/components/user-popover/user-popover.module';
 import { CoreDirectivesModule } from '@shared/directives/directives.module';
 import { TranslatePipe } from '@ngx-translate/core';
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'blog-post-card',
@@ -16,10 +18,12 @@ import { TranslatePipe } from '@ngx-translate/core';
     RouterLink,
     UserPopoverModule,
     CoreDirectivesModule,
-    TranslatePipe
+    TranslatePipe,
+    ResourceByIdPipe
   ]
 })
 export class BlogPostCardComponent {
   @Input() blog: Blog;
   @Input() cardImgHeight = 250;
+  protected readonly Resources = Resources;
 }

--- a/src/app/modules/blog/components/news-card/news-card.component.html
+++ b/src/app/modules/blog/components/news-card/news-card.component.html
@@ -1,4 +1,4 @@
-<a [routerLink]="['/learn', 'blog', 'post', blog.id]">
+<a [routerLink]="Resources.BlogPost | resourceById:blog.id">
   <kep-card customClass="overlay-card">
     <img [src]="blog.image" height="200" class="card-img"/>
 

--- a/src/app/modules/blog/components/news-card/news-card.component.ts
+++ b/src/app/modules/blog/components/news-card/news-card.component.ts
@@ -3,6 +3,8 @@ import { Blog } from '@app/modules/blog/blog.interfaces';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 import { RouterLink } from '@angular/router';
 import { CoreDirectivesModule } from '@shared/directives/directives.module';
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'news-card',
@@ -13,9 +15,11 @@ import { CoreDirectivesModule } from '@shared/directives/directives.module';
   imports: [
     KepCardComponent,
     RouterLink,
-    CoreDirectivesModule
+    CoreDirectivesModule,
+    ResourceByIdPipe
   ]
 })
 export class NewsCardComponent {
   @Input() blog: Blog;
+  protected readonly Resources = Resources;
 }

--- a/src/app/modules/contests/components/contest-card/contest-card/contest-countdown/contest-countdown.component.html
+++ b/src/app/modules/contests/components/contest-card/contest-card/contest-countdown/contest-countdown.component.html
@@ -36,7 +36,7 @@
     {{ 'Contests.ContestFinished' | translate }}
   </div>
   <div class="modal-footer">
-    <a [routerLink]="['/competitions', 'contests', 'contest', contest.id, 'standings']"
+    <a [routerLink]="Resources.ContestStandings | resourceById:contest.id"
        class="btn btn-primary btn-relief" rippleEffect (click)="modal.dismiss('Cross click')">
       {{ 'Contests.Standings' | translate }}
     </a>
@@ -54,7 +54,7 @@
     {{ 'Contests.ContestStarted' | translate }}
   </div>
   <div class="modal-footer">
-    <a [routerLink]="['/competitions', 'contests', 'contest', contest.id, 'problems']"
+    <a [routerLink]="Resources.ContestProblems | resourceById:contest.id"
        class="btn btn-primary btn-relief" rippleEffect (click)="modal.dismiss('Cross click')">
       {{ 'Contests.Problems' | translate }}
     </a>

--- a/src/app/modules/contests/components/contest-card/contest-card/contest-countdown/contest-countdown.component.ts
+++ b/src/app/modules/contests/components/contest-card/contest-card/contest-countdown/contest-countdown.component.ts
@@ -4,13 +4,15 @@ import { CoreCommonModule } from '@core/common.module';
 import { CountdownComponent } from '@shared/third-part-modules/countdown/countdown.component';
 import { ContestStatus } from '@contests/constants/contest-status';
 import { Contest } from '@contests/models/contest';
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'contest-countdown',
   templateUrl: './contest-countdown.component.html',
   styleUrls: ['./contest-countdown.component.scss'],
   standalone: true,
-  imports: [CoreCommonModule, CountdownComponent, NgbTooltipModule]
+  imports: [CoreCommonModule, CountdownComponent, NgbTooltipModule, ResourceByIdPipe]
 })
 export class ContestCountdownComponent implements OnInit {
 
@@ -23,6 +25,7 @@ export class ContestCountdownComponent implements OnInit {
 
   @ViewChild('finishModal') public finishModalRef: TemplateRef<any>;
   @ViewChild('startModal') public startModalRef: TemplateRef<any>;
+  protected readonly Resources = Resources;
 
   constructor(
     private modalService: NgbModal,

--- a/src/app/modules/contests/components/contests-table/contest-standings-popover/contest-standings-popover.component.html
+++ b/src/app/modules/contests/components/contests-table/contest-standings-popover/contest-standings-popover.component.html
@@ -38,7 +38,7 @@
 </ng-template>
 
 <a
-  [routerLink]="['/competitions', 'contests', 'contest', contest.id, 'standings']"
+  [routerLink]="Resources.ContestStandings | resourceById:contest.id"
   [ngbPopover]="popContent"
   triggers="mouseenter:mouseleave"
   [closeDelay]="3000"

--- a/src/app/modules/contests/components/contests-table/contest-standings-popover/contest-standings-popover.component.ts
+++ b/src/app/modules/contests/components/contests-table/contest-standings-popover/contest-standings-popover.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { ApiService } from '@core/data-access/api.service';
 
 import { Contest } from '@contests/models/contest';
+import { Resources } from '@app/resources';
 
 @Component({
   selector: 'contest-standings-popover',
@@ -21,6 +22,8 @@ export class ContestStandingsPopoverComponent implements OnInit {
 
   ngOnInit(): void {
   }
+
+  protected readonly Resources = Resources;
 
   loadContestants() {
     this.api.get(`contests/${this.contest.id}/top10-contestants`).subscribe((result: any) => {

--- a/src/app/modules/contests/components/contests-table/contests-table.component.html
+++ b/src/app/modules/contests/components/contests-table/contests-table.component.html
@@ -28,7 +28,7 @@
           <tr>
             <td class="text-center text-dark">
               <i [data-feather]="'contest' | iconName" [size]="20"></i>
-              <a [routerLink]="['/competitions', 'contests', 'contest', contest.id]">
+              <a [routerLink]="Resources.Contest | resourceById:contest.id">
                 {{ contest.title }}
               </a>
               <br>
@@ -71,7 +71,7 @@
                 <div>
                   <!-- <contest-standings-popover [contest]="contest"></contest-standings-popover> -->
                   <a class="btn btn-sm round"
-                     [routerLink]="['/competitions', 'contests', 'contest', contest.id, 'standings']">
+                     [routerLink]="Resources.ContestStandings | resourceById:contest.id">
                     {{ 'Contests.Standings' | translate }}
                   </a>
                   <br>

--- a/src/app/modules/contests/components/contests-table/contests-table.component.ts
+++ b/src/app/modules/contests/components/contests-table/contests-table.component.ts
@@ -4,6 +4,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { ContestStatus } from '@contests/constants/contest-status';
 import { Contest } from '@contests/models/contest';
+import { Resources } from '@app/resources';
 
 @Component({
   selector: 'contests-table',
@@ -20,6 +21,8 @@ export class ContestsTableComponent implements OnInit, OnDestroy {
   public currentUser: AuthUser;
 
   private _unsubscribeAll = new Subject();
+
+  protected readonly Resources = Resources;
 
   constructor(
     public authService: AuthService,

--- a/src/app/modules/contests/components/contests-table/contests-table.module.ts
+++ b/src/app/modules/contests/components/contests-table/contests-table.module.ts
@@ -13,6 +13,7 @@ import { KepPaginationComponent } from '@shared/components/kep-pagination/kep-pa
 import { ContestClassesPipe } from '@contests/pipes/contest-classes.pipe';
 import { KepTableComponent } from '@shared/components/kep-table/kep-table.component';
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @NgModule({
   declarations: [
@@ -32,6 +33,7 @@ import { KepCardComponent } from "@shared/components/kep-card/kep-card.component
     ContestClassesPipe,
     KepTableComponent,
     KepCardComponent,
+    ResourceByIdPipe,
   ],
   exports: [
     ContestsTableComponent,

--- a/src/app/modules/contests/pages/contest/contest-problem/contest-problem.component.html
+++ b/src/app/modules/contests/pages/contest/contest-problem/contest-problem.component.html
@@ -111,7 +111,7 @@
           @if (contest?.status == 1 || currentUser?.isSuperuser) {
             <a
               rippleEffect
-              routerLink="/practice/problems/problem/{{ contestProblem?.problem?.id }}"
+              [routerLink]="Resources.Problem | resourceById:contestProblem?.problem?.id"
               [queryParams]="{'contest': contest?.id}"
               class="mb-4 full-width btn btn-primary">
               {{ 'Upsolve' | translate }}
@@ -140,13 +140,13 @@
                         'bg-danger-transparent': !_contestProblem.isSolved && _contestProblem.isAttempted
                       }">
                         <a
-                          [routerLink]="['/competitions', 'contests', 'contest', contest?.id, 'problem', _contestProblem.symbol]">
+                          [routerLink]="Resources.ContestProblem | resourceByParams:{id: contest?.id, symbol: _contestProblem.symbol}">
                           {{ _contestProblem.symbol }}
                         </a>
                       </td>
                       <td>
                         <a
-                          [routerLink]="['/competitions', 'contests', 'contest', contest?.id, 'problem', _contestProblem.symbol]">
+                          [routerLink]="Resources.ContestProblem | resourceByParams:{id: contest?.id, symbol: _contestProblem.symbol}">
                           <span class="text-primary">
                           </span>
                           {{ _contestProblem.problem.title }}

--- a/src/app/modules/contests/pages/contest/contest-problem/contest-problem.component.ts
+++ b/src/app/modules/contests/pages/contest/contest-problem/contest-problem.component.ts
@@ -35,6 +35,8 @@ import { ContestClassesPipe } from '@contests/pipes/contest-classes.pipe';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 import { ProblemInfoHtmlPipe } from '@contests/pages/contest/contest-problem/problem-info-html.pipe';
 import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
+import { ResourceByParamsPipe } from '@shared/pipes/resource-by-params.pipe';
 
 const CONTESTANT_RESULTS_VISIBLE_KEY = 'contestant-results-visible';
 
@@ -58,6 +60,8 @@ const CONTESTANT_RESULTS_VISIBLE_KEY = 'contestant-results-visible';
     KepCardComponent,
     ProblemInfoHtmlPipe,
     ProblemSubmitCardComponent,
+    ResourceByIdPipe,
+    ResourceByParamsPipe,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/app/modules/contests/pages/contest/contest-standings/contest-standings-countdown/contest-standings-countdown.component.html
+++ b/src/app/modules/contests/pages/contest/contest-standings/contest-standings-countdown/contest-standings-countdown.component.html
@@ -135,7 +135,7 @@
   </div>
   <div class="modal-footer">
     <a (click)="modal.dismiss('Cross click')"
-       [routerLink]="['/competitions', 'contests', 'contest', contest.id, 'standings']"
+       [routerLink]="Resources.ContestStandings | resourceById:contest.id"
        class="btn btn-primary btn-relief" rippleEffect>
       {{ 'Contests.Standings' | translate }}
     </a>
@@ -154,7 +154,7 @@
   </div>
   <div class="modal-footer">
     <a (click)="modal.dismiss('Cross click')"
-       [routerLink]="['/competitions', 'contests', 'contest', contest.id, 'problems']"
+       [routerLink]="Resources.ContestProblems | resourceById:contest.id"
        class="btn btn-primary btn-relief" rippleEffect>
       {{ 'Contests.Problems' | translate }}
     </a>

--- a/src/app/modules/contests/pages/contest/contest-standings/contest-standings-countdown/contest-standings-countdown.component.ts
+++ b/src/app/modules/contests/pages/contest/contest-standings/contest-standings-countdown/contest-standings-countdown.component.ts
@@ -4,6 +4,8 @@ import { CoreCommonModule } from '@core/common.module';
 import { ContestStatus } from '@contests/constants/contest-status';
 import { Contest } from '@contests/models/contest';
 import { ScriptService } from '@shared/services/script.service';
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 const JQUERY_SCRIPT_PATH = 'https://code.jquery.com/jquery-3.7.1.min.js';
 const TWEENMAX_SCRIPT_PATH = '//cdnjs.cloudflare.com/ajax/libs/gsap/latest/TweenMax.min.js';
@@ -15,7 +17,7 @@ const SCRIPT_PATH = 'assets/js/contest-countdown.js';
   templateUrl: './contest-standings-countdown.component.html',
   styleUrls: ['./contest-standings-countdown.component.scss'],
   standalone: true,
-  imports: [CoreCommonModule],
+  imports: [CoreCommonModule, ResourceByIdPipe],
   schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 export class ContestStandingsCountdownComponent implements OnInit {
@@ -28,6 +30,7 @@ export class ContestStandingsCountdownComponent implements OnInit {
   public minutes = 0;
   public seconds = 0;
   protected readonly ContestStatus = ContestStatus;
+  protected readonly Resources = Resources;
 
   constructor(
     private modalService: NgbModal,

--- a/src/app/modules/contests/pages/contest/contest-tab/contest-tab.component.html
+++ b/src/app/modules/contests/pages/contest/contest-tab/contest-tab.component.html
@@ -1,7 +1,7 @@
 <div class="contests-colors {{ contest | contestClasses }}">
   <ul ngbNav #navWithIcons="ngbNav" class="nav-tabs" [(activeId)]="activeId">
     <li ngbNavItem>
-      <a class="nav-link" [routerLink]="['/competitions', 'contests', 'contest', contest?.id]"
+      <a class="nav-link" [routerLink]="Resources.Contest | resourceById:contest?.id"
          [routerLinkActiveOptions]="{exact: true}" routerLinkActive="active">
         <kep-icon name="contest"></kep-icon>
         {{ 'Contests.Contest' | translate }}</a>
@@ -10,7 +10,7 @@
     </li>
     @if (contest?.status == -1) {
       <li ngbNavItem>
-        <a class="nav-link" [routerLink]="['/competitions', 'contests', 'contest', contest?.id, 'registrants']"
+        <a class="nav-link" [routerLink]="Resources.ContestRegistrants | resourceById:contest?.id"
            [routerLinkActiveOptions]="{exact: true}" routerLinkActive="active">
           <kep-icon name="users"></kep-icon>
           {{ 'Registrants' | translate }}</a>
@@ -20,7 +20,7 @@
     }
     @if (contest?.status != -1) {
       <li ngbNavItem>
-        <a class="nav-link" [routerLink]="['/competitions', 'contests', 'contest', contest?.id, 'problems']"
+        <a class="nav-link" [routerLink]="Resources.ContestProblems | resourceById:contest?.id"
            routerLinkActive="active">
           <kep-icon name="problem"></kep-icon>
           {{ 'Problems' | translate }}</a>
@@ -30,7 +30,7 @@
     }
     @if (contest?.status != -1) {
       <li ngbNavItem>
-        <a class="nav-link" [routerLink]="['/competitions', 'contests', 'contest', contest?.id, 'attempts']"
+        <a class="nav-link" [routerLink]="Resources.ContestAttempts | resourceById:contest?.id"
            routerLinkActive="active">
           <kep-icon name="attempt"></kep-icon>
           {{ 'Attempts' | translate }}</a>
@@ -40,7 +40,7 @@
     }
     @if (contest?.status != -1) {
       <li ngbNavItem>
-        <a class="nav-link" [routerLink]="['/competitions', 'contests', 'contest', contest?.id, 'standings']"
+        <a class="nav-link" [routerLink]="Resources.ContestStandings | resourceById:contest?.id"
            routerLinkActive="active">
           <kep-icon name="ranking"></kep-icon>
           {{ 'Contests.Standings' | translate }}</a>
@@ -50,7 +50,7 @@
     }
     @if (contest?.status == 1 && contest?.isRated) {
       <li ngbNavItem>
-        <a class="nav-link" [routerLink]="['/competitions', 'contests', 'contest', contest?.id, 'rating-changes']"
+        <a class="nav-link" [routerLink]="Resources.ContestRatingChanges | resourceById:contest?.id"
            routerLinkActive="active">
           <kep-icon name="rating-changes"></kep-icon>
           {{ 'Contests.RatingChanges' | translate }}</a>
@@ -60,7 +60,7 @@
     }
     @if (contest?.status != -1) {
       <li ngbNavItem>
-        <a class="nav-link" [routerLink]="['/competitions', 'contests', 'contest', contest?.id, 'questions']"
+        <a class="nav-link" [routerLink]="Resources.ContestQuestions | resourceById:contest?.id"
            routerLinkActive="active">
           <kep-icon name="question"></kep-icon>
           {{ 'Questions' | translate }}</a>

--- a/src/app/modules/contests/pages/contest/contest-tab/contest-tab.component.ts
+++ b/src/app/modules/contests/pages/contest/contest-tab/contest-tab.component.ts
@@ -3,15 +3,18 @@ import { CoreCommonModule } from '@core/common.module';
 import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { Contest } from '@contests/models/contest';
 import { ContestClassesPipe } from '@contests/pipes/contest-classes.pipe';
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'contest-tab',
   templateUrl: './contest-tab.component.html',
   styleUrls: ['./contest-tab.component.scss'],
   standalone: true,
-  imports: [CoreCommonModule, NgbNavModule, ContestClassesPipe]
+  imports: [CoreCommonModule, NgbNavModule, ContestClassesPipe, ResourceByIdPipe]
 })
 export class ContestTabComponent {
   @Input() contest: Contest;
   public activeId = 1;
+  protected readonly Resources = Resources;
 }

--- a/src/app/modules/courses/components/course-card/course-card.component.html
+++ b/src/app/modules/courses/components/course-card/course-card.component.html
@@ -1,6 +1,6 @@
 <kep-card>
   @if (!course.inThePipeline) {
-    <a class="card-img" routerLink="/learn/courses/course/{{ course.id }}">
+    <a class="card-img" [routerLink]="Resources.Course | resourceById:course.id">
       <img class="card-img-top img-fluid" src="{{ course.logo }}" alt="Course logo"/>
     </a>
   } @else {
@@ -26,7 +26,7 @@
     </div>
     <h5 class="card-title mt-2">
       @if (!course.inThePipeline) {
-        <a routerLink="/learn/courses/course/{{ course.id }}">
+        <a [routerLink]="Resources.Course | resourceById:course.id">
           {{ course.title }}
         </a>
       } @else {

--- a/src/app/modules/duels/ui/components/duels-list-section/duels-list-section.component.html
+++ b/src/app/modules/duels/ui/components/duels-list-section/duels-list-section.component.html
@@ -18,7 +18,7 @@
         <div class="col-12">
           <duels-list-card
             [duel]="duel"
-            [viewLink]="['/practice', 'duels', 'duel', duel.id]"
+            [viewLink]="Resources.Duel | resourceById:duel.id"
             [confirmAvailable]="isConfirmAvailable(duel)"
             [confirmDisabled]="isConfirmLoading(duel)"
             [confirmLoading]="isConfirmLoading(duel)"

--- a/src/app/modules/duels/ui/components/duels-list-section/duels-list-section.component.ts
+++ b/src/app/modules/duels/ui/components/duels-list-section/duels-list-section.component.ts
@@ -6,6 +6,8 @@ import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
 import { KepPaginationComponent } from '@shared/components/kep-pagination/kep-pagination.component';
 import { DuelsListCardComponent } from '@duels/ui/components/duels-list-card/duels-list-card.component';
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'duels-list-section',
@@ -17,6 +19,7 @@ import { KepCardComponent } from "@shared/components/kep-card/kep-card.component
     KepPaginationComponent,
     DuelsListCardComponent,
     KepCardComponent,
+    ResourceByIdPipe,
   ],
   templateUrl: './duels-list-section.component.html',
   styleUrls: ['./duels-list-section.component.scss'],
@@ -34,6 +37,8 @@ export class DuelsListSectionComponent {
 
   @Output() pageChange = new EventEmitter<number>();
   @Output() confirm = new EventEmitter<Duel>();
+
+  protected readonly Resources = Resources;
 
   get hasDuels(): boolean {
     return this.duels.length > 0;

--- a/src/app/modules/duels/ui/pages/duels-rating/duels-rating.page.html
+++ b/src/app/modules/duels/ui/pages/duels-rating/duels-rating.page.html
@@ -60,7 +60,7 @@
                     [username]="duelsRating.user.username"
                     [avatar]="duelsRating.user.avatar">
                   </user-avatar-popover>
-                  <a [routerLink]="['/users', 'user', duelsRating.user.username]" class="fw-medium">
+                  <a [routerLink]="Resources.UserProfile | resourceByUsername:duelsRating.user.username" class="fw-medium">
                     {{ duelsRating.user.username }}
                   </a>
                 </div>

--- a/src/app/modules/duels/ui/pages/duels-rating/duels-rating.page.ts
+++ b/src/app/modules/duels/ui/pages/duels-rating/duels-rating.page.ts
@@ -10,6 +10,8 @@ import { KepTableComponent } from '@shared/components/kep-table/kep-table.compon
 import { KepPaginationComponent } from '@shared/components/kep-pagination/kep-pagination.component';
 import { TableOrderingModule } from '@shared/components/table-ordering/table-ordering.module';
 import { UserPopoverModule } from '@shared/components/user-popover/user-popover.module';
+import { ResourceByUsernamePipe } from '@shared/pipes/resource-by-username.pipe';
+import { Resources } from '@app/resources';
 
 @Component({
   selector: 'page-duels-rating',
@@ -23,6 +25,7 @@ import { UserPopoverModule } from '@shared/components/user-popover/user-popover.
     KepPaginationComponent,
     TableOrderingModule,
     UserPopoverModule,
+    ResourceByUsernamePipe,
   ]
 })
 export class DuelsRatingPage extends BaseTablePageComponent<DuelsRating> implements OnInit {
@@ -57,7 +60,7 @@ export class DuelsRatingPage extends BaseTablePageComponent<DuelsRating> impleme
           {
             name: 'Duels',
             isLink: true,
-            link: '/practice/duels',
+            link: Resources.Duels,
           },
         ],
       },

--- a/src/app/modules/duels/ui/pages/duels/duels.page.html
+++ b/src/app/modules/duels/ui/pages/duels/duels.page.html
@@ -5,7 +5,7 @@
         <a
           [ngClass.lt-md]="'btn-sm'"
           class="btn btn-primary-light"
-          [routerLink]="['/practice', 'duels', 'rating']"
+          [routerLink]="Resources.DuelsRating"
         >
           <kep-icon class="font-medium-1" name="ranking"></kep-icon>
           <span [ngClass.lt-md]="'d-none'">

--- a/src/app/modules/hackathons/ui/components/hackathon-tab/hackathon-tab.component.html
+++ b/src/app/modules/hackathons/ui/components/hackathon-tab/hackathon-tab.component.html
@@ -7,7 +7,7 @@
     <li ngbNavItem>
       <a
         [routerLinkActiveOptions]="{exact:true}"
-        [routerLink]="['/competitions','hackathons','hackathon', hackathon?.id]"
+        [routerLink]="Resources.Hackathon | resourceById:hackathon?.id"
         class="nav-link text-center mb-0"
         routerLinkActive="active"
       >
@@ -21,7 +21,7 @@
       <li ngbNavItem>
         <a
             class="nav-link text-center mb-0"
-          [routerLink]="['/competitions','hackathons','hackathon', hackathon?.id, 'projects']"
+          [routerLink]="Resources.HackathonProjects | resourceById:hackathon?.id"
           routerLinkActive="active"
         >
           <div class="mb-2">
@@ -33,7 +33,7 @@
       <li ngbNavItem>
         <a
           class="nav-link text-center mb-0"
-          [routerLink]="['/competitions','hackathons','hackathon', hackathon?.id, 'attempts']"
+          [routerLink]="Resources.HackathonAttempts | resourceById:hackathon?.id"
           routerLinkActive="active"
         >
           <div class="mb-2">
@@ -46,7 +46,7 @@
       <li ngbNavItem>
         <a
           class="nav-link text-center mb-0"
-          [routerLink]="['/competitions','hackathons','hackathon', hackathon?.id, 'standings']"
+          [routerLink]="Resources.HackathonStandings | resourceById:hackathon?.id"
           routerLinkActive="active"
         >
           <div class="mb-2">
@@ -59,7 +59,7 @@
       <li ngbNavItem>
         <a
           class="nav-link text-center mb-0"
-          [routerLink]="['/competitions','hackathons','hackathon', hackathon?.id, 'registrants']"
+          [routerLink]="Resources.HackathonRegistrants | resourceById:hackathon?.id"
           routerLinkActive="active"
         >
           <div class="mb-2">

--- a/src/app/modules/hackathons/ui/components/hackathon-tab/hackathon-tab.component.ts
+++ b/src/app/modules/hackathons/ui/components/hackathon-tab/hackathon-tab.component.ts
@@ -2,16 +2,19 @@ import { Component, Input, ViewEncapsulation } from '@angular/core';
 import { CoreCommonModule } from '@core/common.module';
 import { NgbNavModule } from '@ng-bootstrap/ng-bootstrap';
 import { Hackathon } from '@hackathons/domain';
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'hackathon-tab',
   templateUrl: './hackathon-tab.component.html',
   styleUrls: ['./hackathon-tab.component.scss'],
   standalone: true,
-  imports: [CoreCommonModule, NgbNavModule],
+  imports: [CoreCommonModule, NgbNavModule, ResourceByIdPipe],
   encapsulation: ViewEncapsulation.None
 })
 export class HackathonTabComponent {
   @Input() hackathon: Hackathon;
   public activeId = 1;
+  protected readonly Resources = Resources;
 }

--- a/src/app/modules/hackathons/ui/components/hackathon-table/hackathon-table.component.html
+++ b/src/app/modules/hackathons/ui/components/hackathon-table/hackathon-table.component.html
@@ -53,7 +53,7 @@
             <div>
               <a
                 class="btn btn-primary btn-sm"
-                [routerLink]="['/competitions', 'hackathons', 'hackathon', hackathon.id, 'standings']">
+                [routerLink]="Resources.HackathonStandings | resourceById:hackathon.id">
                 {{ 'Hackathons.Standings' | translate }}
               </a>
               <br>

--- a/src/app/modules/hackathons/ui/components/hackathon-table/hackathon-table.component.ts
+++ b/src/app/modules/hackathons/ui/components/hackathon-table/hackathon-table.component.ts
@@ -7,6 +7,8 @@ import { UserPopoverModule } from "@shared/components/user-popover/user-popover.
 import { DatePipe } from "@angular/common";
 import { RouterLink } from "@angular/router";
 import { CountUpModule } from "ngx-countup";
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'hackathon-table',
@@ -20,9 +22,11 @@ import { CountUpModule } from "ngx-countup";
     UserPopoverModule,
     DatePipe,
     RouterLink,
-    CountUpModule
+    CountUpModule,
+    ResourceByIdPipe
   ]
 })
 export class HackathonTableComponent {
   @Input() hackathon: Hackathon;
+  protected readonly Resources = Resources;
 }

--- a/src/app/modules/kepcoin/components/earns-list/earns-list.component.html
+++ b/src/app/modules/kepcoin/components/earns-list/earns-list.component.html
@@ -52,14 +52,14 @@
                 }
                 @case (EarnType.ContestParticipated) {
                   <span>
-                    {{ 'ContestParticipant' | translate }}: <a [routerLink]="['/competitions', 'contests', 'contest', earn.detail.contest.id]">
+                    {{ 'ContestParticipant' | translate }}: <a [routerLink]="Resources.Contest | resourceById:earn.detail.contest.id">
                     <u class="text-primary">{{ earn.detail.contest.title }}</u>
                   </a>
                   </span>
                 }
                 @case (EarnType.ArenaParticipated) {
                   <span>
-                    {{ 'ArenaParticipant' | translate }}: <a [routerLink]="['/competitions', 'arena', 'tournament', earn.detail.arena.id]">
+                    {{ 'ArenaParticipant' | translate }}: <a [routerLink]="Resources.ArenaTournament | resourceById:earn.detail.arena.id">
                     <u class="text-primary">{{ earn.detail.arena.title }}</u>
                   </a>
                   </span>

--- a/src/app/modules/kepcoin/components/earns-list/earns-list.component.ts
+++ b/src/app/modules/kepcoin/components/earns-list/earns-list.component.ts
@@ -3,14 +3,17 @@ import { RouterLink } from '@angular/router';
 import { CoreCommonModule } from '@core/common.module';
 import { CoreDirectivesModule } from '@shared/directives/directives.module';
 import { EarnType } from '../../enums';
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'kepcoin-earns-list',
   standalone: true,
-  imports: [CoreCommonModule, RouterLink, CoreDirectivesModule],
+  imports: [CoreCommonModule, RouterLink, CoreDirectivesModule, ResourceByIdPipe],
   templateUrl: './earns-list.component.html'
 })
 export class EarnsListComponent {
   @Input() earns: any[] = [];
   EarnType = EarnType;
+  protected readonly Resources = Resources;
 }

--- a/src/app/modules/kepcoin/components/spends-list/spends-list.component.html
+++ b/src/app/modules/kepcoin/components/spends-list/spends-list.component.html
@@ -15,21 +15,21 @@
               @switch (spend.type) {
                 @case (SpendType.AttemptView) {
                   <span>
-                    {{ 'ViewAttempt' | translate }} <a class="text-primary" routerLink="/practice/problems/attempts/{{ spend.detail.attemptId }}">
+                    {{ 'ViewAttempt' | translate }} <a class="text-primary" [routerLink]="Resources.Attempt | resourceById:spend.detail.attemptId">
                     <u>{{ spend.detail.attemptId }}</u>
                   </a>
                   </span>
                 }
                 @case (SpendType.AttemptTestView) {
                   <span>
-                    {{ 'ViewTestAttempt' | translate }} <a class="text-primary" routerLink="/practice/problems/attempts/{{ spend.detail.attemptId }}">
+                    {{ 'ViewTestAttempt' | translate }} <a class="text-primary" [routerLink]="Resources.Attempt | resourceById:spend.detail.attemptId">
                     <u>{{ spend.detail.attemptId }}</u>
                   </a>
                   </span>
                 }
                 @case (SpendType.ProblemSolution) {
                   <span>
-                    {{ 'ViewProblemSolution' | translate }} <a class="text-primary" routerLink="/practice/problems/problem/{{ spend.detail.problemId }}">
+                    {{ 'ViewProblemSolution' | translate }} <a class="text-primary" [routerLink]="Resources.Problem | resourceById:spend.detail.problemId">
                     <u>{{ spend.detail.problemId }}. {{ spend.detail.problemTitle }}</u>
                   </a>
                   </span>
@@ -57,7 +57,7 @@
                 }
                 @case (SpendType.TestPass) {
                   <span>
-                    {{ 'PassTest' | translate }} <a class="text-primary" routerLink="/practice/tests/test/{{ spend.detail.test.id }}">
+                    {{ 'PassTest' | translate }} <a class="text-primary" [routerLink]="Resources.Test | resourceById:spend.detail.test.id">
                     <u>{{ spend.detail.test.title }}</u>
                   </a>
                   </span>

--- a/src/app/modules/kepcoin/components/spends-list/spends-list.component.ts
+++ b/src/app/modules/kepcoin/components/spends-list/spends-list.component.ts
@@ -3,14 +3,17 @@ import { RouterLink } from '@angular/router';
 import { CoreCommonModule } from '@core/common.module';
 import { CoreDirectivesModule } from '@shared/directives/directives.module';
 import { SpendType } from '../../enums';
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'kepcoin-spends-list',
   standalone: true,
-  imports: [CoreCommonModule, RouterLink, CoreDirectivesModule],
+  imports: [CoreCommonModule, RouterLink, CoreDirectivesModule, ResourceByIdPipe],
   templateUrl: './spends-list.component.html'
 })
 export class SpendsListComponent {
   @Input() spends: any[] = [];
   SpendType = SpendType;
+  protected readonly Resources = Resources;
 }

--- a/src/app/modules/problems/components/attempts-table/attempts-table.module.ts
+++ b/src/app/modules/problems/components/attempts-table/attempts-table.module.ts
@@ -17,6 +17,7 @@ import { KepcoinViewModule } from '@shared/components/kepcoin-view/kepcoin-view.
 import { KepTableComponent } from '@shared/components/kep-table/kep-table.component';
 import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
 import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
+import { ResourceByParamsPipe } from '@shared/pipes/resource-by-params.pipe';
 import { AttemptLanguageComponent } from '@shared/components/attempt-language/attempt-language.component';
 import { AttemptVerdictComponent } from '@shared/components/attempt-verdict/attempt-verdict.component';
 
@@ -45,6 +46,7 @@ import { AttemptVerdictComponent } from '@shared/components/attempt-verdict/atte
     KepTableComponent,
     KepIconComponent,
     ResourceByIdPipe,
+    ResourceByParamsPipe,
     AttemptLanguageComponent,
     AttemptLanguageComponent,
     AttemptVerdictComponent,

--- a/src/app/modules/problems/components/attempts-table/table/table.component.html
+++ b/src/app/modules/problems/components/attempts-table/table/table.component.html
@@ -103,7 +103,7 @@
           @if (contest) {
             @if (attempt?.contestProblem?.contest) {
               <a
-                [routerLink]="['/competitions', 'contests', 'contest', attempt?.contestProblem?.contest, 'problem', attempt.contestProblem.symbol]">
+                [routerLink]="Resources.ContestProblem | resourceByParams:{id: attempt?.contestProblem?.contest, symbol: attempt.contestProblem.symbol}">
                 <u class="text-primary">{{ attempt.contestProblem.symbol }}. {{ attempt.problemTitle }}</u>
               </a>
             } @else {

--- a/src/app/modules/problems/components/hack-attempts-table/hack-attempts-table.module.ts
+++ b/src/app/modules/problems/components/hack-attempts-table/hack-attempts-table.module.ts
@@ -13,6 +13,7 @@ import { TableComponent } from './table/table.component';
 import { ClipboardModule } from 'app/shared/components/clipboard/clipboard.module';
 import { ProblemsPipesModule } from '../../pipes/problems-pipes.module';
 import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @NgModule({
   declarations: [
@@ -32,6 +33,7 @@ import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/
     MonacoEditorComponent,
     ClipboardModule,
     ProblemsPipesModule,
+    ResourceByIdPipe,
   ],
   exports: [
     HackAttemptsTableComponent

--- a/src/app/modules/problems/components/hack-attempts-table/table/table.component.html
+++ b/src/app/modules/problems/components/hack-attempts-table/table/table.component.html
@@ -43,7 +43,7 @@
             {{ hackAttempt.attemptId }}
           </td>
           <td>
-            <a [routerLink]="['/practice', 'problems', 'problem', hackAttempt.problemId]" class="text-primary">
+            <a [routerLink]="Resources.Problem | resourceById:hackAttempt.problemId" class="text-primary">
               {{ hackAttempt.problemId }}. {{ hackAttempt.problemTitle }}
             </a>
           </td>

--- a/src/app/modules/problems/components/hack-attempts-table/table/table.component.ts
+++ b/src/app/modules/problems/components/hack-attempts-table/table/table.component.ts
@@ -3,6 +3,7 @@ import { bounceAnimation, shakeAnimation } from 'angular-animations';
 import { AuthService, AuthUser } from '@auth';
 import { ProblemsApiService } from '@problems/services/problems-api.service';
 import { HackAttempt } from '../../../models/hack-attempt.models';
+import { Resources } from '@app/resources';
 
 @Component({
   selector: 'base-table',
@@ -43,4 +44,5 @@ export class TableComponent implements OnInit {
     return item.id;
   }
 
+  protected readonly Resources = Resources;
 }

--- a/src/app/modules/problems/components/study-plan-card/study-plan-card.component.html
+++ b/src/app/modules/problems/components/study-plan-card/study-plan-card.component.html
@@ -1,4 +1,4 @@
-<a class="study-plan-{{ studyPlan.id }}" routerLink="/practice/problems/study-plan/{{ studyPlan.id }}">
+<a class="study-plan-{{ studyPlan.id }}" [routerLink]="Resources.StudyPlan | resourceById:studyPlan.id">
   <div class="card">
     <div class="card-header d-block">
       <div class="study-plan-title">

--- a/src/app/modules/problems/components/study-plan-card/study-plan-card.component.ts
+++ b/src/app/modules/problems/components/study-plan-card/study-plan-card.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { StudyPlan } from '../../models/problems.models';
+import { Resources } from '@app/resources';
 
 @Component({
   selector: 'study-plan-card',
@@ -10,6 +11,8 @@ import { StudyPlan } from '../../models/problems.models';
 export class StudyPlanCardComponent implements OnInit {
 
   @Input() studyPlan: StudyPlan;
+
+  protected readonly Resources = Resources;
 
   constructor() { }
 

--- a/src/app/modules/problems/components/study-plan-card/study-plan-card.module.ts
+++ b/src/app/modules/problems/components/study-plan-card/study-plan-card.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { StudyPlanCardComponent } from './study-plan-card.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { RouterModule } from '@angular/router';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @NgModule({
   declarations: [
@@ -12,6 +13,7 @@ import { RouterModule } from '@angular/router';
     TranslateModule,
     CommonModule,
     RouterModule,
+    ResourceByIdPipe,
   ],
   exports: [
     StudyPlanCardComponent,

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -68,7 +68,7 @@
 
                 @if (studyPlanId) {
                   <li [ngbNavItem]="4">
-                    <a ngbNavLink routerLink="/practice/problems/study-plan/{{ studyPlanId }}">
+                    <a ngbNavLink [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
                       <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
                     </a>
                     <ng-template ngbNavContent>
@@ -79,7 +79,7 @@
 
                 @if (contestId) {
                   <li [ngbNavItem]="4">
-                    <a ngbNavLink routerLink="/competitions/contests/contest/{{ contestId }}/problems">
+                    <a ngbNavLink [routerLink]="Resources.ContestProblems | resourceById:contestId">
                       <kep-icon name="contest" color="primary" type="duotone"/>
                       {{ 'Contest' | translate }}
                     </a>

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -23,6 +23,7 @@ import { KepCardComponent } from '@shared/components/kep-card/kep-card.component
 
 import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
 import { take } from 'rxjs/operators';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'app-problem',
@@ -46,6 +47,7 @@ import { take } from 'rxjs/operators';
 
     ProblemSubmitCardComponent,
     NgbTooltipModule,
+    ResourceByIdPipe,
   ]
 })
 export class ProblemComponent extends BasePageComponent implements OnInit {

--- a/src/app/modules/problems/pages/problems/sections/section-info/section-info.component.html
+++ b/src/app/modules/problems/pages/problems/sections/section-info/section-info.component.html
@@ -29,7 +29,7 @@
   <div class="mt-2 col-lg-8 col-12 offset-lg-2 offset-0">
     <div class="row">
       <div class="col-12 col-md-6">
-        <a  class="card card-info" routerLink="/learn/blog/post/52">
+        <a  class="card card-info" [routerLink]="Resources.BlogPost | resourceById:52">
           <div class="card-header">
             <div class="card-title">
               {{ 'AboutProblems' | translate }}
@@ -42,7 +42,7 @@
       </div>
 
       <div class="col-12 col-md-6">
-        <a  class="card card-info" routerLink="/learn/blog/post/46">
+        <a  class="card card-info" [routerLink]="Resources.BlogPost | resourceById:46">
           <div class="card-header">
             <div class="card-title">
               {{ 'AboutVerdicts' | translate }}

--- a/src/app/modules/problems/pages/problems/sections/section-info/section-info.component.ts
+++ b/src/app/modules/problems/pages/problems/sections/section-info/section-info.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { CoreCommonModule } from '@core/common.module';
 import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'section-info',
@@ -10,6 +12,9 @@ import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component
   imports: [
     CoreCommonModule,
     KepIconComponent,
+    ResourceByIdPipe,
   ]
 })
-export class SectionInfoComponent {}
+export class SectionInfoComponent {
+  protected readonly Resources = Resources;
+}

--- a/src/app/modules/problems/pages/problems/sections/section-sidebar/section-sidebar.component.html
+++ b/src/app/modules/problems/pages/problems/sections/section-sidebar/section-sidebar.component.html
@@ -131,7 +131,7 @@
             @for (attempt of lastAttempts; track attempt) {
               <tr>
                 <td class="ms-1">
-                  <a [routerLink]="['/practice', 'problems', 'problem', attempt.problemId]">
+                  <a [routerLink]="Resources.Problem | resourceById:attempt.problemId">
                     <span class="text-primary">{{ attempt.problemId }}. {{ attempt.problemTitle }}</span>
                   </a>
                 </td>
@@ -150,7 +150,7 @@
           </tbody>
         </table>
         <div class="card-footer text-center">
-          <button class="btn btn-primary bg-primary btn-sm round" routerLink="attempts">
+          <button class="btn btn-primary bg-primary btn-sm round" [routerLink]="Resources.Attempts">
             {{ 'AllAttempts' | translate }}
             <i data-feather="arrow-right"></i>
           </button>

--- a/src/app/modules/problems/pages/problems/sections/section-sidebar/section-sidebar.component.ts
+++ b/src/app/modules/problems/pages/problems/sections/section-sidebar/section-sidebar.component.ts
@@ -11,6 +11,7 @@ import { PageResult } from '@core/common/classes/page-result';
 import { Observable } from 'rxjs';
 import { FormsModule } from "@angular/forms";
 import { TranslatePipe } from "@ngx-translate/core";
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 export interface TopRating {
   username: string;
@@ -29,6 +30,7 @@ export interface TopRating {
     ContestantViewModule,
     FormsModule,
     TranslatePipe,
+    ResourceByIdPipe,
   ]
 })
 export class SectionSidebarComponent extends BaseComponent implements OnInit {

--- a/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.html
+++ b/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.html
@@ -21,7 +21,7 @@
         </div>
         <div class="attempt-info" *ngIf="facts?.firstAttempt">
           <div [ngbTooltip]="tipContent" class="problem-title">
-            <a routerLink="/practice/problems/problem/{{ facts.firstAttempt.problemId }}" class="text-primary">
+            <a [routerLink]="Resources.Problem | resourceById:facts.firstAttempt.problemId" class="text-primary">
               {{ facts.firstAttempt.problemId }}. {{ facts.firstAttempt.problemTitle }}
             </a>
           </div>
@@ -51,7 +51,7 @@
         </div>
         <div class="attempt-info" *ngIf="facts?.firstAccepted">
           <div [ngbTooltip]="tipContent" class="problem-title">
-            <a routerLink="/practice/problems/problem/{{ facts.firstAccepted.problemId }}" class="text-primary">
+            <a [routerLink]="Resources.Problem | resourceById:facts.firstAccepted.problemId" class="text-primary">
               {{ facts.firstAccepted.problemId }}. {{ facts.firstAccepted.problemTitle }}
             </a>
           </div>
@@ -80,7 +80,7 @@
         </div>
         <div class="attempt-info" *ngIf="facts?.lastAttempt">
           <div [ngbTooltip]="tipContent" class="problem-title">
-            <a routerLink="/practice/problems/problem/{{ facts.lastAttempt.problemId }}" class="text-primary">
+            <a [routerLink]="Resources.Problem | resourceById:facts.lastAttempt.problemId" class="text-primary">
               {{ facts.lastAttempt.problemId }}. {{ facts.lastAttempt.problemTitle }}
             </a>
           </div>
@@ -110,7 +110,7 @@
         </div>
         <div class="attempt-info" *ngIf="facts?.lastAccepted">
           <div [ngbTooltip]="tipContent" class="problem-title">
-            <a routerLink="/practice/problems/problem/{{ facts.lastAccepted.problemId }}" class="text-primary">
+            <a [routerLink]="Resources.Problem | resourceById:facts.lastAccepted.problemId" class="text-primary">
               {{ facts.lastAccepted.problemId }}. {{ facts.lastAccepted.problemTitle }}
             </a>
           </div>
@@ -139,7 +139,7 @@
         </div>
         <div class="attempt-info" *ngIf="facts?.mostAttemptedProblem">
           <div [ngbTooltip]="tipContent" class="problem-title">
-            <a routerLink="/practice/problems/problem/{{ facts.mostAttemptedProblem.problemId }}" class="text-primary">
+            <a [routerLink]="Resources.Problem | resourceById:facts.mostAttemptedProblem.problemId" class="text-primary">
               {{ facts.mostAttemptedProblem.problemId }}. {{ facts.mostAttemptedProblem.problemTitle }}
             </a>
           </div>
@@ -164,7 +164,7 @@
         </div>
         <div class="attempt-info" *ngIf="facts?.mostAttemptedForSolveProblem">
           <div [ngbTooltip]="tipContent" class="problem-title">
-            <a routerLink="/practice/problems/problem/{{ facts.mostAttemptedForSolveProblem.problemId }}"
+            <a [routerLink]="Resources.Problem | resourceById:facts.mostAttemptedForSolveProblem.problemId"
                class="text-primary">
               {{ facts.mostAttemptedForSolveProblem.problemId }}. {{ facts.mostAttemptedForSolveProblem.problemTitle }}
             </a>

--- a/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.ts
+++ b/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.ts
@@ -2,6 +2,8 @@ import { Component, Input, OnInit } from '@angular/core';
 import { ProblemsStatisticsService } from '../../../services/problems-statistics.service';
 import { CoreCommonModule } from '@core/common.module';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 export interface Facts {
   firstAttempt: any;
@@ -19,13 +21,14 @@ export interface Facts {
   templateUrl: './section-facts.component.html',
   styleUrls: ['./section-facts.component.scss'],
   standalone: true,
-  imports: [CoreCommonModule, NgbTooltipModule],
+  imports: [CoreCommonModule, NgbTooltipModule, ResourceByIdPipe],
 })
 export class SectionFactsComponent implements OnInit {
 
   @Input() username: string;
 
   public facts: Facts;
+  protected readonly Resources = Resources;
 
   constructor(
     public statisticsService: ProblemsStatisticsService,

--- a/src/app/modules/problems/pages/study-plan/study-plan.component.html
+++ b/src/app/modules/problems/pages/study-plan/study-plan.component.html
@@ -261,7 +261,7 @@
                             </div>
                           </div>
                           <div class="problem-button">
-                            <a [routerLink]="['/practice', 'problems', 'problem', problem.id]"
+                            <a [routerLink]="Resources.Problem | resourceById:problem.id"
                                [queryParams]="{'study-plan': studyPlan.id}"
                                rippleEffect class="text-white btn btn-primary btn-sm">
                               {{ 'Solve' | translate }}

--- a/src/app/modules/problems/pages/study-plan/study-plan.component.ts
+++ b/src/app/modules/problems/pages/study-plan/study-plan.component.ts
@@ -12,6 +12,8 @@ import { ProblemsPipesModule } from '@problems/pipes/problems-pipes.module';
 import { KepcoinSpendSwalModule } from '@shared/components/kepcoin-spend-swal/kepcoin-spend-swal.module';
 import { StudyPlanCardModule } from '@problems/components/study-plan-card/study-plan-card.module';
 import { ApexChartModule } from '@shared/third-part-modules/apex-chart/apex-chart.module';
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'app-study-plan',
@@ -27,6 +29,7 @@ import { ApexChartModule } from '@shared/third-part-modules/apex-chart/apex-char
     KepcoinSpendSwalModule,
     StudyPlanCardModule,
     ApexChartModule,
+    ResourceByIdPipe,
   ]
 })
 export class StudyPlanComponent implements OnInit {
@@ -139,5 +142,7 @@ export class StudyPlanComponent implements OnInit {
       );
     }, 1000);
   }
+
+  protected readonly Resources = Resources;
 
 }

--- a/src/app/modules/tournaments/ui/components/duel-card/duel-card.component.html
+++ b/src/app/modules/tournaments/ui/components/duel-card/duel-card.component.html
@@ -1,4 +1,4 @@
-<a [routerLink]="['/practice', 'duels', 'duel', duel.id]" class="duel-card">
+<a [routerLink]="Resources.Duel | resourceById:duel.id" class="duel-card">
   <kep-card>
     <div class="table-responsive">
       <table class="table">

--- a/src/app/modules/tournaments/ui/components/duel-card/duel-card.component.ts
+++ b/src/app/modules/tournaments/ui/components/duel-card/duel-card.component.ts
@@ -3,6 +3,8 @@ import { ContestantViewModule } from "@contests/components/contestant-view/conte
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
 import { RouterLink } from "@angular/router";
 import { Duel } from "@duels/domain/entities";
+import { Resources } from '@app/resources';
+import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
   selector: 'duel-card',
@@ -12,9 +14,11 @@ import { Duel } from "@duels/domain/entities";
   imports: [
     ContestantViewModule,
     KepCardComponent,
-    RouterLink
+    RouterLink,
+    ResourceByIdPipe
   ]
 })
 export class DuelCardComponent {
   @Input() duel: Duel;
+  protected readonly Resources = Resources;
 }

--- a/src/app/modules/users/ui/pages/user-profile/user-profile.component.html
+++ b/src/app/modules/users/ui/pages/user-profile/user-profile.component.html
@@ -67,7 +67,7 @@
               </ul>
 
               @if (currentUser?.username == user.username) {
-                <a routerLink="/settings" class="btn btn-primary"
+                <a [routerLink]="[Resources.Settings]" class="btn btn-primary"
                    rippleEffect>
                   <i data-feather="edit" class="d-block d-md-none"></i>
                   <span class="fw-medium d-none d-md-block">{{ 'Edit' | translate }}</span>

--- a/src/app/resources.ts
+++ b/src/app/resources.ts
@@ -3,6 +3,8 @@ export enum Resources {
 
   Problems = '/practice/problems',
   Problem = '/practice/problems/problem/:id',
+  Attempt = '/practice/problems/attempts/:id',
+  StudyPlan = '/practice/problems/study-plan/:id',
 
   Attempts = '/practice/problems/attempts',
   AttemptsByUser = '/practice/problems/attempts/:username',
@@ -10,12 +12,20 @@ export enum Resources {
   Contests = '/competitions/contests',
   Contest = '/competitions/contests/contest/:id',
   ContestStandings = '/competitions/contests/contest/:id/standings',
+  ContestProblems = '/competitions/contests/contest/:id/problems',
+  ContestAttempts = '/competitions/contests/contest/:id/attempts',
+  ContestRegistrants = '/competitions/contests/contest/:id/registrants',
+  ContestRatingChanges = '/competitions/contests/contest/:id/rating-changes',
+  ContestQuestions = '/competitions/contests/contest/:id/questions',
+  ContestProblem = '/competitions/contests/contest/:id/problem/:symbol',
 
   Challenges = '/practice/challenges',
   ChallengesRating = '/practice/challenges/rating',
   Challenge = '/practice/challenges/challenge/:id',
 
   Duels = '/practice/duels',
+  DuelsRating = '/practice/duels/duels-rating',
+  Duel = '/practice/duels/duel/:id',
 
   Arena = '/competitions/arena',
   ArenaTournament = '/competitions/arena/tournament/:id',
@@ -40,6 +50,7 @@ export enum Resources {
   Courses = '/learn/courses',
   Course = '/learn/courses/course/:id',
   CourseFirstLesson = '/learn/courses/course/:id/lesson/1',
+  BlogPost = '/learn/blog/post/:id',
 
   Blog = '/learn/blog',
   Lugavar = '/learn/lugavar',
@@ -65,6 +76,7 @@ export enum Resources {
   SettingsTeams = `${Settings}/teams`,
   SettingsSystem = `${Settings}/system`,
   TeamJoin = '/teams/:id/join',
+
 }
 
 export function getResourceById(resource: Resources, id: number | string) {
@@ -73,4 +85,10 @@ export function getResourceById(resource: Resources, id: number | string) {
 
 export function getResourceByUsername(resource: Resources, username: string) {
   return resource.replace(':username', username);
+}
+
+export function getResourceByParams(resource: Resources, params: Record<string, string | number>) {
+  return Object.entries(params).reduce((result, [key, value]) => (
+    result.replace(`:${key}`, value.toString())
+  ), resource);
 }

--- a/src/app/shared/components/user-popover/user-avatar-popover/user-avatar-popover.component.html
+++ b/src/app/shared/components/user-popover/user-avatar-popover/user-avatar-popover.component.html
@@ -62,7 +62,7 @@
 </ng-template>
 
 <a
-  [routerLink]="['/users', 'user', username]"
+  [routerLink]="Resources.UserProfile | resourceByUsername:username"
 >
   <img
     [src]="avatar"

--- a/src/app/shared/components/user-popover/user-avatar-popover/user-avatar-popover.component.ts
+++ b/src/app/shared/components/user-popover/user-avatar-popover/user-avatar-popover.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { ApiService } from '@core/data-access/api.service';
 import { AuthUser } from '@auth';
+import { Resources } from '@app/resources';
 
 @Component({
   selector: 'user-avatar-popover',
@@ -22,6 +23,8 @@ export class UserAvatarPopoverComponent implements OnInit {
 
   ngOnInit(): void {
   }
+
+  protected readonly Resources = Resources;
 
   loadUser() {
     if (!this.user) {

--- a/src/app/shared/components/user-popover/user-popover.module.ts
+++ b/src/app/shared/components/user-popover/user-popover.module.ts
@@ -10,6 +10,7 @@ import { UserAvatarPopoverComponent } from './user-avatar-popover/user-avatar-po
 import { KepBadgeComponent } from '@shared/components/kep-badge/kep-badge.component';
 import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { ResourceByUsernamePipe } from '@shared/pipes/resource-by-username.pipe';
 
 @NgModule({
   declarations: [
@@ -26,7 +27,8 @@ import { KepCardComponent } from '@shared/components/kep-card/kep-card.component
     NgbTooltipModule,
     KepBadgeComponent,
     KepIconComponent,
-    KepCardComponent
+    KepCardComponent,
+    ResourceByUsernamePipe
   ],
   exports: [
     UserPopoverComponent,

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.html
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.html
@@ -24,7 +24,7 @@
       </div>
       <div class="card-footer border-0 bg-transparent pt-0">
         <a
-          [routerLink]="['/users', 'user', username]"
+          [routerLink]="Resources.UserProfile | resourceByUsername:username"
           class="btn btn-outline-primary btn-sm w-100"
         >
           {{ 'UserPopover.ViewDetails' | translate }}

--- a/src/app/shared/components/user-popover/user-popover/user-popover.component.ts
+++ b/src/app/shared/components/user-popover/user-popover/user-popover.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectorRef, Component, inject, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { ApiService } from '@core/data-access/api.service';
 import { User } from "@users/domain";
+import { Resources } from '@app/resources';
 
 type RatingKey = 'skillsRating' | 'activityRating' | 'contestsRating' | 'challengesRating';
 
@@ -64,6 +65,8 @@ export class UserPopoverComponent implements OnInit {
 
   ngOnInit(): void {
   }
+
+  protected readonly Resources = Resources;
 
   loadUser() {
     if (!this.user) {

--- a/src/app/shared/pipes/resource-by-params.pipe.ts
+++ b/src/app/shared/pipes/resource-by-params.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { getResourceByParams, Resources } from '@app/resources';
+
+@Pipe({
+  name: 'resourceByParams',
+  standalone: true
+})
+export class ResourceByParamsPipe implements PipeTransform {
+  transform(resource: Resources, params: Record<string, string | number>): string {
+    return getResourceByParams(resource, params);
+  }
+}


### PR DESCRIPTION
## Summary
- replace hard-coded `routerLink` usages with `Resources` constants throughout the application
- expand the shared `Resources` enum and add a reusable `resourceByParams` pipe for multi-parameter routes
- update affected components to expose `Resources` in templates and import the required resource pipes

## Testing
- `npm run lint` *(fails: local Angular CLI is unavailable because dependencies could not be installed due to peer constraint conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68d07e1e7f10832f815f0cf026719bec