### PR TITLE
Refactor problem page navigation into routed tabs

### DIFF
--- a/src/app/modules/problems/pages/problem/problem-attempts/problem-attempts-route.component.ts
+++ b/src/app/modules/problems/pages/problem/problem-attempts/problem-attempts-route.component.ts
@@ -1,0 +1,35 @@
+import { Component, inject } from '@angular/core';
+import { ProblemAttemptsComponent } from './problem-attempts.component';
+import { ProblemComponent } from '../problem.component';
+import { Problem } from '../../../models/problems.models';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-problem-attempts-route',
+  standalone: true,
+  imports: [ProblemAttemptsComponent],
+  template: `
+    @if (problem && submitEvent$) {
+      <problem-attempts
+        [problem]="problem"
+        [submitEvent]="submitEvent$"
+        (hackSubmitted)="onHackSubmitted()"
+      ></problem-attempts>
+    }
+  `,
+})
+export class ProblemAttemptsRouteComponent {
+  private readonly parent = inject(ProblemComponent);
+
+  get problem(): Problem | undefined {
+    return this.parent.problem;
+  }
+
+  get submitEvent$(): Observable<void> {
+    return this.parent.submitEvent$;
+  }
+
+  onHackSubmitted() {
+    this.parent.onHackSubmitted();
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem-description/problem-description-route.component.ts
+++ b/src/app/modules/problems/pages/problem/problem-description/problem-description-route.component.ts
@@ -1,0 +1,22 @@
+import { Component, inject } from '@angular/core';
+import { ProblemDescriptionComponent } from './problem-description.component';
+import { ProblemComponent } from '../problem.component';
+import { Problem } from '../../../models/problems.models';
+
+@Component({
+  selector: 'app-problem-description-route',
+  standalone: true,
+  imports: [ProblemDescriptionComponent],
+  template: `
+    @if (problem) {
+      <problem-description [problem]="problem"></problem-description>
+    }
+  `,
+})
+export class ProblemDescriptionRouteComponent {
+  private readonly parent = inject(ProblemComponent);
+
+  get problem(): Problem | undefined {
+    return this.parent.problem;
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem-hacks/problem-hacks-route.component.ts
+++ b/src/app/modules/problems/pages/problem/problem-hacks/problem-hacks-route.component.ts
@@ -1,0 +1,22 @@
+import { Component, inject } from '@angular/core';
+import { ProblemHacksComponent } from './problem-hacks.component';
+import { ProblemComponent } from '../problem.component';
+import { Problem } from '../../../models/problems.models';
+
+@Component({
+  selector: 'app-problem-hacks-route',
+  standalone: true,
+  imports: [ProblemHacksComponent],
+  template: `
+    @if (problem) {
+      <problem-hacks [problem]="problem"></problem-hacks>
+    }
+  `,
+})
+export class ProblemHacksRouteComponent {
+  private readonly parent = inject(ProblemComponent);
+
+  get problem(): Problem | undefined {
+    return this.parent.problem;
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -24,101 +24,67 @@
       <div class="row">
         <div class="col-lg-9 col-md-12 col-sm-12">
           <kep-card>
-            <div class="card-header">
-              <ul
-                #navWithIcons="ngbNav"
-                (activeIdChange)="activeIdChange($event)" [(activeId)]="activeId" [destroyOnHide]="false"
-                class="nav-tabs" ngbNav>
-                <li [ngbNavItem]="1">
-                  <a class="nav-link" ngbNavLink>
+            <div class="card-header d-flex flex-wrap align-items-center gap-2 justify-content-between">
+              <ul class="nav nav-tabs flex-grow-1">
+                <li class="nav-item">
+                  <a
+                    class="nav-link"
+                    routerLink="./"
+                    routerLinkActive="active"
+                    [routerLinkActiveOptions]="{ exact: true }"
+                  >
                     <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
                     {{ 'Problem' | translate }}
                   </a>
-                  <ng-template ngbNavContent>
-                    <problem-description [problem]="problem"></problem-description>
-                  </ng-template>
                 </li>
 
-                <li [ngbNavItem]="2">
-                  <a class="nav-link" ngbNavLink>
+                <li class="nav-item">
+                  <a class="nav-link" routerLink="attempts" routerLinkActive="active">
                     <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
                     {{ 'Attempts' | translate }}
                   </a>
-                  <ng-template ngbNavContent>
-                    <problem-attempts
-                      (hackSubmitted)="activeId = 3;"
-                      [problem]="problem"
-                      [submitEvent]="submitEvent?.asObservable()"
-                    >
-                    </problem-attempts>
-                  </ng-template>
                 </li>
 
                 @if (problem.hasCheckInput) {
-                  <li [ngbNavItem]="3" destroyOnHide="true">
-                    <a class="nav-link" ngbNavLink>
+                  <li class="nav-item">
+                    <a class="nav-link" routerLink="hacks" routerLinkActive="active">
                       <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
                       {{ 'Hacks' | translate }}
                     </a>
-                    <ng-template ngbNavContent>
-                      <problem-hacks [problem]="problem"></problem-hacks>
-                    </ng-template>
                   </li>
                 }
 
                 @if (studyPlanId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink routerLink="/practice/problems/study-plan/{{ studyPlanId }}">
+                  <li class="nav-item">
+                    <a class="nav-link" routerLink="/practice/problems/study-plan/{{ studyPlanId }}">
                       <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
                     </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (contestId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink routerLink="/competitions/contests/contest/{{ contestId }}/problems">
-                      <kep-icon name="contest" color="primary" type="duotone"/>
-                      {{ 'Contest' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
                   </li>
                 }
               </ul>
 
-              @if (isAuthenticated) {
-                <button (click)="codeEditorSidebarToggle()" class="btn btn-sm btn-primary">{{ 'Submit' | translate }}
-                </button>
-              }
+              <div class="d-flex align-items-center gap-1 ms-auto">
+                @if (contestId) {
+                  <a
+                    class="btn btn-sm btn-outline-primary"
+                    routerLink="/competitions/contests/contest/{{ contestId }}/problems"
+                  >
+                    <kep-icon name="contest" color="primary" type="duotone" class="me-1"/>
+                    Contestga qaytish
+                  </a>
+                }
+
+                @if (isAuthenticated) {
+                  <button (click)="codeEditorSidebarToggle()" class="btn btn-sm btn-primary">{{ 'Submit' | translate }}
+                  </button>
+                }
+              </div>
             </div>
 
             <div class="card-footer">
-              <div [ngbNavOutlet]="navWithIcons"></div>
+              <router-outlet></router-outlet>
             </div>
           </kep-card>
-
-          @if (currentUser?.permissions.canCreateProblems) {
-            <div class="card">
-              <div class="card-header">
-                <div class="card-title">
-                  Check input
-                </div>
-              </div>
-              <div class="card-body">
-                <monaco-editor
-                  [lang]="'py'"
-                  class="mt-1"
-                  [ngModelOptions]="{standalone: true}"
-                  [(ngModel)]="checkInput"
-                ></monaco-editor>
-                <div class="btn mt-2 btn-primary btn-sm" (click)="saveCheckInput()">Save</div>
-              </div>
-            </div>
-          }
         </div>
 
         <div class="col-lg-3 col-md-12 col-sm-12">

--- a/src/app/modules/problems/problems.routing.ts
+++ b/src/app/modules/problems/problems.routing.ts
@@ -29,28 +29,24 @@ export default [
       problem: ProblemResolver,
     },
     canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/attempts',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/hacks',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
+    children: [
+      {
+        path: '',
+        pathMatch: 'full',
+        loadComponent: () => import('./pages/problem/problem-description/problem-description-route.component')
+          .then(c => c.ProblemDescriptionRouteComponent),
+      },
+      {
+        path: 'attempts',
+        loadComponent: () => import('./pages/problem/problem-attempts/problem-attempts-route.component')
+          .then(c => c.ProblemAttemptsRouteComponent),
+      },
+      {
+        path: 'hacks',
+        loadComponent: () => import('./pages/problem/problem-hacks/problem-hacks-route.component')
+          .then(c => c.ProblemHacksRouteComponent),
+      },
+    ],
   },
   // {
   //   path: 'problem/:id/og-image',


### PR DESCRIPTION
## Summary
- replace the problem page tabset with router-based navigation and a router outlet
- move problem description, attempts, and hacks content into dedicated child route components
- replace the contest tab with a "Contestga qaytish" button and remove the admin-only check input editor

## Testing
- `npm run lint` *(fails: `ng` CLI unavailable in the environment)*
- `npm install` *(fails: peer dependency conflict for @fullcalendar/angular)*

------
https://chatgpt.com/codex/tasks/task_e_68d07bb70acc832fac08ee9b53b70250