### PR TITLE
Add route title metadata and dynamic title updates

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -91,6 +91,8 @@ export const routes: Routes = [
       {
         path: 'kep-cover',
         loadComponent: () => import('./modules/kep-cover-3/kep-cover-3.component').then(c => c.KepCover3Component),
+        data: { title: 'KepCover' },
+        title: 'KepCover'
       },
       {
         path: 'kepcoin',
@@ -110,12 +112,16 @@ export const routes: Routes = [
         path: 'login',
         loadComponent: () => import('@auth/login/login.component').then(c => c.LoginComponent),
         canActivate: [IsAuthenticatedGuard],
+        data: { title: 'Auth.Login' },
+        title: 'Auth.Login'
       }
     ]
   },
   {
     path: '**',
-    loadComponent: () => import('./modules/error/error404/error404.component').then(c => c.Error404Component)
+    loadComponent: () => import('./modules/error/error404/error404.component').then(c => c.Error404Component),
+    data: { title: 'Errors.Error404' },
+    title: 'Errors.Error404'
   }
 ];
 

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -778,6 +778,7 @@ export const localeEn = {
       ContestStandings: 'Standings | {{ contestTitle }} | Contest',
       ContestQuestions: 'Questions | {{ contestTitle }} | Contest',
       ContestRatingChanges: 'Rating changes | {{ contestTitle }} | Contest',
+      ContestOgImage: '{{ contestTitle }} | OG image | Contest',
       ContestsRating: 'Rating | Contests',
       ContestsProfile: 'Profile | Contests',
       MyContests: 'My contests',
@@ -811,7 +812,11 @@ export const localeEn = {
     },
     Hackathons: {
       Hackathons: 'Hackathons',
-      Hackathon: '{{ hackathonTitle }} | Hackathon'
+      Hackathon: '{{ hackathonTitle }} | Hackathon',
+      HackathonProjects: '{{ hackathonTitle }} | Projects | Hackathon',
+      HackathonAttempts: '{{ hackathonTitle }} | Attempts | Hackathon',
+      HackathonStandings: '{{ hackathonTitle }} | Standings | Hackathon',
+      HackathonRegistrants: '{{ hackathonTitle }} | Registrants | Hackathon'
     },
     Arena: {
       Arena: 'Arena',
@@ -830,9 +835,18 @@ export const localeEn = {
       Courses: 'Courses',
       Course: '{{ courseTitle }} | Course',
       CourseLesson: '{{ lessonTitle }} | {{ courseTitle }} | Course',
+      CourseDictionary: '{{ courseTitle }} | Dictionary | Course',
+      CourseDictionaryTraining: '{{ courseTitle }} | Dictionary training | Course',
     },
     Shop: {
       Shop: 'Shop',
+    },
+    KepCover: 'KEP Cover #3',
+    Auth: {
+      Login: 'Login',
+    },
+    Errors: {
+      Error404: 'Page not found',
     },
   },
   Errors: {

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -772,6 +772,7 @@ export const localeRu = {
       ContestStandings: 'Результаты | {{ contestTitle }} | Контест',
       ContestQuestions: 'Вопросы | {{ contestTitle }} | Контест',
       ContestRatingChanges: 'Изменения рейтингов | {{ contestTitle }} | Контест',
+      ContestOgImage: '{{ contestTitle }} | OG изображение | Контест',
       ContestsRating: 'Рейтинг | Контесты',
       ContestsProfile: 'Профиль | Контесты',
       MyContests: 'Мои контесты',
@@ -805,7 +806,11 @@ export const localeRu = {
     },
     Hackathons: {
       Hackathons: 'Хакатоны',
-      Hackathon: '{{ hackathonTitle }} | Хакатон'
+      Hackathon: '{{ hackathonTitle }} | Хакатон',
+      HackathonProjects: '{{ hackathonTitle }} | Проекты | Хакатон',
+      HackathonAttempts: '{{ hackathonTitle }} | Попытки | Хакатон',
+      HackathonStandings: '{{ hackathonTitle }} | Таблица результатов | Хакатон',
+      HackathonRegistrants: '{{ hackathonTitle }} | Участники | Хакатон'
     },
     Arena: {
       Arena: 'Арена',
@@ -824,9 +829,18 @@ export const localeRu = {
       Courses: 'Курсы',
       Course: '{{ courseTitle }} | Курс',
       CourseLesson: '{{ lessonTitle }} | {{ courseTitle }} | Курс',
+      CourseDictionary: '{{ courseTitle }} | Словарь | Курс',
+      CourseDictionaryTraining: '{{ courseTitle }} | Тренировка словаря | Курс',
     },
     Shop: {
       Shop: 'Магазин',
+    },
+    KepCover: 'KEP Cover №3',
+    Auth: {
+      Login: 'Войти',
+    },
+    Errors: {
+      Error404: 'Страница не найдена',
     },
   },
   Errors: {

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -771,6 +771,7 @@ export const localeUz = {
       ContestStandings: 'Natijalar | {{ contestTitle }} | Kontest',
       ContestQuestions: 'Savollar | {{ contestTitle }} | Kontest',
       ContestRatingChanges: 'Reyting oʻzgarishlari | {{ contestTitle }} | Kontest',
+      ContestOgImage: '{{ contestTitle }} | OG tasviri | Kontest',
       ContestsRating: 'Reyting | Kontestslar',
       ContestsProfile: 'Profil | Kontestlar',
       MyContests: 'Mening kontestlarim',
@@ -805,9 +806,13 @@ export const localeUz = {
      Tournaments: 'Turnirlar',
      Tournament: '{{ tournamentTitle }} | Turnir'
    },
-    Hackathons: {
-      Hackathons: 'Xakatonlar',
-      Hackathon: '{{ hackathonTitle }} | Xakaton'
+   Hackathons: {
+     Hackathons: 'Xakatonlar',
+      Hackathon: '{{ hackathonTitle }} | Xakaton',
+      HackathonProjects: '{{ hackathonTitle }} | Loyihalar | Xakaton',
+      HackathonAttempts: '{{ hackathonTitle }} | Urinishlar | Xakaton',
+      HackathonStandings: '{{ hackathonTitle }} | Natijalar | Xakaton',
+      HackathonRegistrants: '{{ hackathonTitle }} | Roʻyxatdan oʻtganlar | Xakaton'
     },
    Arena: {
       Arena: 'Arena',
@@ -822,13 +827,22 @@ export const localeUz = {
       Projects: 'Loyihalar',
       Project: '{{ projectTitle }} | Loyiha',
     },
-    Courses: {
-      Courses: 'Kurslar',
-      Course: '{{ courseTitle }} | Kurs',
+   Courses: {
+     Courses: 'Kurslar',
+     Course: '{{ courseTitle }} | Kurs',
       CourseLesson: '{{ lessonTitle }} | {{ courseTitle }} | Kurs',
+      CourseDictionary: '{{ courseTitle }} | Lugʻat | Kurs',
+      CourseDictionaryTraining: '{{ courseTitle }} | Lugʻat mashqi | Kurs',
+   },
+   Shop: {
+     Shop: 'Doʻkon',
+   },
+    KepCover: 'KEP Cover #3',
+    Auth: {
+      Login: 'Tizimga kirish',
     },
-    Shop: {
-      Shop: 'Doʻkon',
+    Errors: {
+      Error404: 'Sahifa topilmadi',
     },
   },
   Errors: {

--- a/src/app/modules/account-settings/account-settings.routing.ts
+++ b/src/app/modules/account-settings/account-settings.routing.ts
@@ -6,6 +6,7 @@ export default [
     path: '',
     loadComponent: () => import('./account-settings.component').then(c => c.AccountSettingsComponent),
     title: 'Users.AccountSettings',
+    data: { title: 'Users.AccountSettings' },
     canActivate: [AuthGuard],
     children: [
       {

--- a/src/app/modules/arena/arena.routing.ts
+++ b/src/app/modules/arena/arena.routing.ts
@@ -6,6 +6,7 @@ export default [
     path: '',
     loadComponent: () => import('./pages/arena/arena.component').then(c => c.ArenaComponent),
     title: 'Arena.Arena',
+    data: { title: 'Arena.Arena' },
   },
   {
     path: 'tournament/:id',

--- a/src/app/modules/blog/blog.routing.ts
+++ b/src/app/modules/blog/blog.routing.ts
@@ -5,6 +5,7 @@ export default [
     path: '',
     loadComponent: () => import('./pages/blog-list/blog-list.component').then(c => c.BlogListComponent),
     title: 'Blog.Blog',
+    data: { title: 'Blog.Blog' },
   },
   {
     path: 'post/:id',

--- a/src/app/modules/calendar/calendar.routing.ts
+++ b/src/app/modules/calendar/calendar.routing.ts
@@ -4,6 +4,7 @@ export default [
   {
     path: '',
     loadComponent: () => import('./calendar.component').then(c => c.CalendarComponent),
-    title: 'Calendar.Calendar'
+    title: 'Calendar.Calendar',
+    data: { title: 'Calendar.Calendar' }
   },
 ] satisfies Routes;

--- a/src/app/modules/challenges/challenges.routing.ts
+++ b/src/app/modules/challenges/challenges.routing.ts
@@ -6,6 +6,7 @@ export default [
     path: '',
     loadComponent: () => import('./pages/challenges/challenges.component').then(c => c.ChallengesComponent),
     title: 'Challenges.Challenges',
+    data: { title: 'Challenges.Challenges' },
   },
   {
     path: 'challenge/:id',
@@ -16,11 +17,13 @@ export default [
     path: 'rating',
     loadComponent: () => import('./pages/challenges-rating/challenges-rating.component').then(c => c.ChallengesRatingComponent),
     title: 'Challenges.ChallengesRating',
+    data: { title: 'Challenges.ChallengesRating' },
   },
   {
     path: 'user-statistics',
     loadComponent: () => import('./pages/user-statistics/user-statistics.component').then(c => c.UserStatisticsComponent),
     title: 'Challenges.UserStatistics',
+    data: { title: 'Challenges.UserStatistics' },
     canActivate: [AuthGuard],
   },
 ] satisfies Routes;

--- a/src/app/modules/contests/contests.routing.ts
+++ b/src/app/modules/contests/contests.routing.ts
@@ -7,18 +7,19 @@ export default [
   {
     path: '',
     loadComponent: () => import('./pages/contests/contests.component').then(c => c.ContestsComponent),
-    title: 'Contests.Contests'
+    title: 'Contests.Contests',
+    data: { title: 'Contests.Contests' }
   },
   {
     path: 'rating',
     loadComponent: () => import('./pages/rating/rating.component').then(c => c.RatingComponent),
-    data: {animation: 'contests-rating'},
+    data: {animation: 'contests-rating', title: 'Contests.ContestsRating'},
     title: 'Contests.ContestsRating',
   },
   {
     path: 'profile',
     loadComponent: () => import('./pages/profile/profile.component').then(c => c.ProfileComponent),
-    data: {animation: 'contests-profile'},
+    data: {animation: 'contests-profile', title: 'Contests.ContestsProfile'},
     canActivate: [AuthGuard],
     title: 'Contests.ContestsProfile',
   },
@@ -123,11 +124,12 @@ export default [
     resolve: {
       contest: ContestResolver,
     },
+    data: { title: 'Contests.ContestOgImage' },
   },
   {
     path: 'user-contests',
     loadComponent: () => import('./pages/user-contests/user-contests.component').then(c => c.UserContestsComponent),
-    data: {animation: 'user-contests'},
+    data: {animation: 'user-contests', title: 'Contests.MyContests'},
     title: 'Contests.MyContests',
   },
   {
@@ -135,6 +137,7 @@ export default [
     loadComponent: () => import('./pages/user-contests/contest-create/contest-create.component').then(c => c.ContestCreateComponent),
     data: {
       animation: 'user-contest-create',
+      title: 'Contests.CreateContest',
     },
     title: 'Contests.CreateContest',
     canActivate: [ContestCreateGuard],

--- a/src/app/modules/contests/pages/contest/contest-og-image/contest-og-image.component.ts
+++ b/src/app/modules/contests/pages/contest/contest-og-image/contest-og-image.component.ts
@@ -7,6 +7,7 @@ import { CoreCommonModule } from '@core/common.module';
 import { Contest } from '@contests/models/contest';
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
 import { LogoComponent } from "@shared/components/logo/logo.component";
+import { TitleService } from '@shared/services/title.service';
 
 @Component({
   selector: 'app-contest-og-image',
@@ -31,12 +32,14 @@ export class ContestOgImageComponent implements OnInit {
   constructor(
     public route: ActivatedRoute,
     public captureService: NgxCaptureService,
-    public api: ApiService
+    public api: ApiService,
+    private titleService: TitleService,
   ) { }
 
   ngOnInit(): void {
     this.route.data.subscribe(({contest}) => {
       this.contest = Contest.fromJSON(contest);
+      this.titleService.updateTitle(this.route, {contestTitle: this.contest.title});
     });
     return;
 

--- a/src/app/modules/courses/courses.routing.ts
+++ b/src/app/modules/courses/courses.routing.ts
@@ -12,7 +12,7 @@ export default [
   {
     path: '',
     loadComponent: () => import('./pages/courses/courses.component').then(c => c.CoursesComponent),
-    data: {animation: 'courses'},
+    data: {animation: 'courses', title: 'Courses.Courses'},
     title: 'Courses.Courses',
   },
   {
@@ -40,7 +40,7 @@ export default [
   {
     path: 'course/:id/dictionary',
     loadComponent: () => import('./pages/dictionary/dictionary.component').then(c => c.DictionaryComponent),
-    data: {animation: 'course-dictionary'},
+    data: {animation: 'course-dictionary', title: 'Courses.CourseDictionary'},
     resolve: {
       courseLessons: CourseLessonsResolver,
       course: CourseResolver,
@@ -51,7 +51,7 @@ export default [
   {
     path: 'course/:id/dictionary/training',
     loadComponent: () => import('./pages/dictionary/training/training.component').then(c => c.TrainingComponent),
-    data: {animation: 'course-dictionary-training'},
+    data: {animation: 'course-dictionary-training', title: 'Courses.CourseDictionaryTraining'},
     resolve: {
       courseLessons: CourseLessonsResolver,
       course: CourseResolver,

--- a/src/app/modules/courses/pages/dictionary/dictionary.component.ts
+++ b/src/app/modules/courses/pages/dictionary/dictionary.component.ts
@@ -34,6 +34,7 @@ export class DictionaryComponent extends BasePageComponent implements OnInit {
       this.courseDictionary = courseDictionary;
       this.loadContentHeader();
       this.contentHeader.breadcrumb.links[1].name = this.course.title;
+      this.titleService.updateTitle(this.route, {courseTitle: this.course.title});
     });
   }
 

--- a/src/app/modules/courses/pages/dictionary/training/training.component.ts
+++ b/src/app/modules/courses/pages/dictionary/training/training.component.ts
@@ -7,6 +7,7 @@ import { CoreCommonModule } from '@core/common.module';
 import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
 import { NgbProgressbarModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { SidebarComponent } from '@courses/pages/course-lesson/sidebar/sidebar.component';
+import { TitleService } from '@shared/services/title.service';
 
 @Component({
   selector: 'app-training',
@@ -65,6 +66,7 @@ export class TrainingComponent implements OnInit {
     public route: ActivatedRoute,
     private dragulaService: DragulaService,
     public toastr: ToastrService,
+    private titleService: TitleService,
   ) {
     this.route.data.subscribe(({course, courseLessons, courseDictionary}) => {
       this.course = course;
@@ -73,6 +75,7 @@ export class TrainingComponent implements OnInit {
       });
       this.courseDictionary = courseDictionary;
       this.contentHeader.breadcrumb.links[1].name = this.course.title;
+      this.titleService.updateTitle(this.route, {courseTitle: this.course.title});
     });
   }
 

--- a/src/app/modules/error/error.routes.ts
+++ b/src/app/modules/error/error.routes.ts
@@ -10,6 +10,8 @@ export const admin: Routes = [
           import('./error404/error404.component').then(
             (m) => m.Error404Component
           ),
+        data: { title: 'Errors.Error404' },
+        title: 'Errors.Error404'
       },
     ]
   }

--- a/src/app/modules/hackathons/config/routes.ts
+++ b/src/app/modules/hackathons/config/routes.ts
@@ -6,6 +6,7 @@ export default [
     path: '',
     loadComponent: () => import('../ui/pages/hackathons-list/hackathons-list.page').then(m => m.HackathonsListPage),
     title: 'Hackathons.Hackathons',
+    data: { title: 'Hackathons.Hackathons' },
   },
   {
     path: 'hackathon/:id',

--- a/src/app/modules/hackathons/ui/pages/hackathon-attempts/hackathon-attempts.page.ts
+++ b/src/app/modules/hackathons/ui/pages/hackathon-attempts/hackathon-attempts.page.ts
@@ -34,6 +34,7 @@ export class HackathonAttemptsPage extends BaseTablePageComponent<ProjectAttempt
   constructor(private repository: ProjectAttemptsRepository) {
     super();
     this.hackathon = this.route.snapshot.data.hackathon;
+    this.titleService.updateTitle(this.route, {hackathonTitle: this.hackathon.title});
 
     interval(5000).pipe(takeUntil(this._unsubscribeAll)).subscribe(
       () => this.reloadPage()

--- a/src/app/modules/hackathons/ui/pages/hackathon-projects/hackathon-projects.page.ts
+++ b/src/app/modules/hackathons/ui/pages/hackathon-projects/hackathon-projects.page.ts
@@ -25,6 +25,7 @@ export class HackathonProjectsPage extends BaseLoadComponent<HackathonProject[]>
     super();
 
     this.hackathon = this.route.snapshot.data.hackathon;
+    this.titleService.updateTitle(this.route, {hackathonTitle: this.hackathon.title});
   }
 
   getData(): Observable<HackathonProject[]> {

--- a/src/app/modules/hackathons/ui/pages/hackathon-registrants/hackathon-registrants.page.ts
+++ b/src/app/modules/hackathons/ui/pages/hackathon-registrants/hackathon-registrants.page.ts
@@ -30,6 +30,7 @@ export class HackathonRegistrantsPage extends BaseLoadComponent<any> implements 
     super();
 
     this.hackathon = this.route.snapshot.data.hackathon;
+    this.titleService.updateTitle(this.route, {hackathonTitle: this.hackathon.title});
   }
 
   getData(): Observable<any> {

--- a/src/app/modules/hackathons/ui/pages/hackathon-standings/hackathon-standings.page.ts
+++ b/src/app/modules/hackathons/ui/pages/hackathon-standings/hackathon-standings.page.ts
@@ -41,6 +41,7 @@ export class HackathonStandingsPage extends BaseLoadComponent<any> implements On
   constructor(private hackathonsApiService: HackathonsApiService) {
     super();
     this.hackathon = this.route.snapshot.data.hackathon;
+    this.titleService.updateTitle(this.route, {hackathonTitle: this.hackathon.title});
 
     interval(30000).pipe(takeUntil(this._unsubscribeAll)).subscribe(
       () => this.loadData()

--- a/src/app/modules/hackathons/ui/pages/hackathon/hackathon.page.ts
+++ b/src/app/modules/hackathons/ui/pages/hackathon/hackathon.page.ts
@@ -32,6 +32,7 @@ export class HackathonPage extends BasePageComponent implements OnInit {
   constructor() {
     super();
     this.hackathon = this.route.snapshot.data.hackathon;
+    this.titleService.updateTitle(this.route, {hackathonTitle: this.hackathon.title});
   }
 
   protected getContentHeader(): ContentHeader {

--- a/src/app/modules/home/home.routing.ts
+++ b/src/app/modules/home/home.routing.ts
@@ -7,6 +7,7 @@ export default [
     path: '',
     component: HomeComponent,
     title: 'Home',
+    data: { title: 'Home' },
     canActivate: [AuthGuard],
   },
 ] satisfies Route[];

--- a/src/app/modules/kepcoin/kepcoin.routing.ts
+++ b/src/app/modules/kepcoin/kepcoin.routing.ts
@@ -4,7 +4,7 @@ export default [
   {
     path: '',
     loadComponent: () => import('./kepcoin.component').then(c => c.KepcoinComponent),
-    data: {animation: 'kepcoin'},
+    data: {animation: 'kepcoin', title: 'Kepcoin'},
     title: 'Kepcoin',
   },
 ] satisfies Route[];

--- a/src/app/modules/landing-page/landing-page.routing.ts
+++ b/src/app/modules/landing-page/landing-page.routing.ts
@@ -6,6 +6,7 @@ export default [
     path: '',
     loadComponent: () => import('./landing-page.component').then(c => c.LandingPageComponent),
     title: 'Landing',
+    data: { title: 'Landing' },
     canActivate: [IsAuthenticatedGuard]
   },
 ] satisfies Routes;

--- a/src/app/modules/lugavar/lugavar.module.ts
+++ b/src/app/modules/lugavar/lugavar.module.ts
@@ -25,6 +25,7 @@ const routes: Routes = [
       dailyInterestingFact: DailyInterestingFactResolver,
     },
     title: 'Lugavar',
+    data: { title: 'Lugavar' },
   }
 ];
 

--- a/src/app/modules/problems/problems.routing.ts
+++ b/src/app/modules/problems/problems.routing.ts
@@ -8,6 +8,7 @@ export default [
     path: '',
     loadComponent: () => import('./pages/problems/problems.component').then(c => c.ProblemsComponent),
     title: 'Problems.Problems',
+    data: { title: 'Problems.Problems' },
   },
   // {
   //   path: 'study-plan/:id',
@@ -63,13 +64,13 @@ export default [
   {
     path: 'attempts',
     loadComponent: () => import('./pages/attempts/attempts.component').then(c => c.AttemptsComponent),
-    data: {animation: 'attempts'},
+    data: {animation: 'attempts', title: 'Problems.Attempts'},
     title: 'Problems.Attempts',
   },
   {
     path: 'attempts/:username',
     loadComponent: () => import('./pages/attempts/attempts.component').then(c => c.AttemptsComponent),
-    data: {animation: 'attempts'},
+    data: {animation: 'attempts', title: 'Problems.Attempts'},
     title: 'Problems.Attempts',
   },
   // {
@@ -82,30 +83,31 @@ export default [
     path: 'statistics',
     loadComponent: () => import('./pages/statistics/statistics.component').then(c => c.StatisticsComponent),
     title: 'Problems.Statistics',
-    data: {animation: 'statistics'},
+    data: {animation: 'statistics', title: 'Problems.Statistics'},
     canActivate: [AuthGuard],
   },
   {
     path: 'rating',
     loadComponent: () => import('./pages/rating/rating.component').then(c => c.RatingComponent),
     title: 'Problems.Rating',
-    data: {animation: 'problems-rating'}
+    data: {animation: 'problems-rating', title: 'Problems.Rating'}
   },
   {
     path: 'rating/history',
     loadComponent: () => import('./pages/rating/rating-history/rating-history.component').then(c => c.RatingHistoryComponent),
     title: 'Problems.RatingHistory',
-    data: {animation: 'problems-rating-history'}
+    data: {animation: 'problems-rating-history', title: 'Problems.RatingHistory'}
   },
   {
     path: 'hacks',
     loadComponent: () => import('./pages/hack-attempts/hack-attempts.component').then(c => c.HackAttemptsComponent),
-    data: {animation: 'hack-attempts'},
+    data: {animation: 'hack-attempts', title: 'Problems.HackAttempts'},
     title: 'Problems.HackAttempts',
   },
   {
     path: ':category',
     loadComponent: () => import('./pages/problems/category/category.component').then(c => c.CategoryComponent),
     title: 'Problems.Problems',
+    data: { title: 'Problems.Problems' },
   },
 ] satisfies Route[];

--- a/src/app/modules/projects/projects.routing.ts
+++ b/src/app/modules/projects/projects.routing.ts
@@ -4,6 +4,7 @@ export default [
   {
     path: '',
     loadComponent: () => import('@projects/ui/pages/projects-list/projects-list.page').then(c => c.ProjectsListPage),
+    data: { title: 'Projects.Projects' },
     title: 'Projects.Projects',
   },
   {

--- a/src/app/modules/shop/shop.routing.ts
+++ b/src/app/modules/shop/shop.routing.ts
@@ -5,5 +5,6 @@ export default [
     path: '',
     loadComponent: () => import('./shop.component').then(c => c.ShopComponent),
     title: 'Shop.Shop',
+    data: { title: 'Shop.Shop' },
   },
 ] satisfies Route[];

--- a/src/app/modules/testing/testing.routes.ts
+++ b/src/app/modules/testing/testing.routes.ts
@@ -4,7 +4,8 @@ export default [
   {
     path: '',
     loadComponent: () => import('@testing/ui/pages/tests-list/tests-list.page').then(m => m.TestsListPage),
-    title: 'Tests.Tests'
+    title: 'Tests.Tests',
+    data: { title: 'Tests.Tests' }
   },
   {
     path: 'test/:testId',

--- a/src/app/modules/tournaments/tournaments.routes.ts
+++ b/src/app/modules/tournaments/tournaments.routes.ts
@@ -5,6 +5,7 @@ export default [
     path: '',
     loadComponent: () => import('./ui/pages/tournaments-list/tournaments-list.page').then(m => m.TournamentsListPage),
     title: 'Tournaments.Tournaments',
+    data: { title: 'Tournaments.Tournaments' },
   },
   {
     path: 'tournament/:id',

--- a/src/app/modules/users/config/routes.ts
+++ b/src/app/modules/users/config/routes.ts
@@ -16,7 +16,7 @@ export default [
   {
     path: '',
     loadComponent: () => import('../ui/pages/users-list/users-list.page').then(c => c.UsersListPage),
-    data: {animation: 'users'},
+    data: {animation: 'users', title: 'Users.Users'},
     title: 'Users.Users',
   },
   {


### PR DESCRIPTION
## Summary
- ensure every routed page defines an i18n `data.title` entry so page titles are available throughout the app
- invoke `TitleService` in course dictionary, hackathon, and contest OG image pages to populate dynamic titles
- extend the English, Uzbek, and Russian `PageTitle` dictionaries with the keys required by the new routes

## Testing
- npm run lint *(fails: Angular project has no lint target configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d106c4ccd4832f812dae16d0b1559f