### PR TITLE
refactor: split duels page logic into widgets

### DIFF
--- a/src/app/modules/duels/ui/pages/duels/duels.page.html
+++ b/src/app/modules/duels/ui/pages/duels/duels.page.html
@@ -17,52 +17,34 @@
 
     <div class="row">
       <div class="col-12">
-        <duel-ready-status-card
-          [isReady]="isReady"
-          [disabled]="readyStatusLoading"
-          (readyChange)="onReadyStatusChange($event)"
-        ></duel-ready-status-card>
+        <duel-ready-status-widget
+          (statusChanged)="onReadyStatusChanged($event)"
+        ></duel-ready-status-widget>
       </div>
 
       <div class="col-12">
-        <duel-ready-players-section
-          [players]="readyPlayersResult?.data ?? []"
-          [total]="readyPlayersTotal"
-          [page]="readyPlayersPage"
-          [pageSize]="readyPlayersPageSize"
-          [loading]="readyPlayersLoading"
+        <duel-ready-players-widget
           [currentUsername]="currentUser?.username ?? null"
-          (pageChange)="loadReadyPlayers($event)"
-          (challenge)="openDuelModal($event)"
+          [refreshKey]="readyPlayersRefreshKey"
+          (duelCreated)="onDuelCreated()"
         />
       </div>
 
       <div class="col-12 col-xl-6">
-        <duels-list-section
-          [duels]="duelsResult?.data ?? []"
-          [total]="duelsTotal"
-          [page]="duelsPage"
-          [pageSize]="duelsPageSize"
-          [loading]="duelsLoading"
-          [confirmLoadingId]="confirmLoadingId"
+        <duels-list-widget
+          [username]="currentUser?.username ?? null"
           [currentUsername]="currentUser?.username ?? null"
-          (pageChange)="loadDuels($event)"
-          (confirm)="confirmDuel($event)"
+          [refreshKey]="myDuelsRefreshKey"
+          (duelConfirmed)="onDuelConfirmed()"
         />
       </div>
 
       <div class="col-12 col-xl-6">
-        <duels-list-section
+        <duels-list-widget
           titleKey="AllDuels"
-          [duels]="allDuelsResult?.data ?? []"
-          [total]="allDuelsTotal"
-          [page]="allDuelsPage"
-          [pageSize]="allDuelsPageSize"
-          [loading]="allDuelsLoading"
-          [confirmLoadingId]="confirmLoadingId"
           [currentUsername]="currentUser?.username ?? null"
-          (pageChange)="loadAllDuels($event)"
-          (confirm)="confirmDuel($event)"
+          [refreshKey]="allDuelsRefreshKey"
+          (duelConfirmed)="onDuelConfirmed()"
         />
       </div>
     </div>

--- a/src/app/modules/duels/ui/pages/duels/duels.page.ts
+++ b/src/app/modules/duels/ui/pages/duels/duels.page.ts
@@ -1,23 +1,12 @@
-import { Component, inject, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { BasePageComponent } from '@core/common/classes/base-page.component';
 import { ContentHeader } from '@shared/ui/components/content-header/content-header.component';
 import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
 import { CoreCommonModule } from '@core/common.module';
-import { DuelsApiService } from '@duels/data-access';
-import { Duel, DuelPreset, DuelReadyPlayer } from '@duels/domain';
-import { PageResult } from '@core/common/classes/page-result';
-import { finalize, takeUntil } from 'rxjs/operators';
-import { NgbModalModule, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
-import { FormBuilder, Validators } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import {
-  DuelReadyStatusCardComponent
-} from '@duels/ui/components/duel-ready-status-card/duel-ready-status-card.component';
-import {
-  DuelReadyPlayersSectionComponent
-} from '@duels/ui/components/duel-ready-players-section/duel-ready-players-section.component';
-import { DuelsListSectionComponent } from '@duels/ui/components/duels-list-section/duels-list-section.component';
-import { DuelPresetModalComponent } from '@duels/ui/components/duel-preset-modal/duel-preset-modal.component';
+import { DuelReadyStatusWidgetComponent } from '@duels/ui/widgets/duel-ready-status-widget/duel-ready-status-widget.component';
+import { DuelReadyPlayersWidgetComponent } from '@duels/ui/widgets/duel-ready-players-widget/duel-ready-players-widget.component';
+import { DuelsListWidgetComponent } from '@duels/ui/widgets/duels-list-widget/duels-list-widget.component';
 
 @Component({
   selector: 'page-duels',
@@ -27,304 +16,33 @@ import { DuelPresetModalComponent } from '@duels/ui/components/duel-preset-modal
   imports: [
     CoreCommonModule,
     ContentHeaderModule,
-    NgbModalModule,
     TranslateModule,
-    DuelReadyStatusCardComponent,
-    DuelReadyPlayersSectionComponent,
-    DuelsListSectionComponent,
+    DuelReadyStatusWidgetComponent,
+    DuelReadyPlayersWidgetComponent,
+    DuelsListWidgetComponent,
   ]
 })
-export class DuelsPage extends BasePageComponent implements OnInit {
-  isReady = false;
-  readyStatusLoading = false;
-  readyPlayersPage = 1;
-  readyPlayersPageSize = 12;
-  readyPlayersResult: PageResult<DuelReadyPlayer> | null = null;
-  readyPlayersLoading = false;
-  duelsPage = 1;
-  duelsPageSize = 10;
-  duelsResult: PageResult<Duel> | null = null;
-  duelsLoading = false;
-  allDuelsPage = 1;
-  allDuelsPageSize = 10;
-  allDuelsResult: PageResult<Duel> | null = null;
-  allDuelsLoading = false;
-  duelPresets: DuelPreset[] = [];
-  duelPresetsLoading = false;
-  selectedOpponent: DuelReadyPlayer | null = null;
-  confirmLoadingId: number | null = null;
-  protected readonly duelsApi = inject(DuelsApiService);
-  private fb = inject(FormBuilder);
-  duelForm = this.fb.group({
-    presetId: [null as number | null, Validators.required],
-    startTime: ['', Validators.required],
-  });
-  private modalRef: NgbModalRef | null = null;
-
-  get readyPlayersTotal(): number {
-    return this.readyPlayersResult?.total || 0;
-  }
-
-  get duelsTotal(): number {
-    return this.duelsResult?.total || 0;
-  }
-
-  get allDuelsTotal(): number {
-    return this.allDuelsResult?.total || 0;
-  }
-
-  get minStartTime(): string {
-    return this.formatDateInput(new Date());
-  }
-
-  override ngOnInit(): void {
-    super.ngOnInit();
-    this.loadReadyStatus();
-    this.loadReadyPlayers();
-    this.loadAllDuels();
-  }
+export class DuelsPage extends BasePageComponent {
+  readyPlayersRefreshKey = 0;
+  myDuelsRefreshKey = 0;
+  allDuelsRefreshKey = 0;
 
   override afterChangeCurrentUser(): void {
-    if (this.currentUser) {
-      this.loadDuels();
-    } else {
-      this.duelsResult = null;
-    }
-    this.loadAllDuels();
+    this.triggerListsReload();
   }
 
-  onReadyStatusChange(ready: boolean): void {
-    if (this.readyStatusLoading) {
-      return;
-    }
-
-    const previous = this.isReady;
-    this.isReady = ready;
-    this.readyStatusLoading = true;
-    this.duelsApi.updateReadyStatus(ready)
-      .pipe(
-        takeUntil(this._unsubscribeAll),
-        finalize(() => this.readyStatusLoading = false),
-      )
-      .subscribe({
-        next: status => {
-          this.isReady = status?.ready ?? ready;
-          this.loadReadyPlayers();
-        },
-        error: () => {
-          this.isReady = previous;
-        }
-      });
+  onReadyStatusChanged(_: boolean): void {
+    this.readyPlayersRefreshKey++;
   }
 
-  loadReadyStatus(): void {
-    this.readyStatusLoading = true;
-    this.duelsApi.getReadyStatus()
-      .pipe(
-        takeUntil(this._unsubscribeAll),
-        finalize(() => {
-          this.readyStatusLoading = false;
-        })
-      )
-      .subscribe({
-        next: status => this.isReady = status?.ready ?? false,
-        error: () => this.isReady = false,
-      });
+  onDuelCreated(): void {
+    this.myDuelsRefreshKey++;
+    this.allDuelsRefreshKey++;
   }
 
-  loadReadyPlayers(page?: number): void {
-    if (page) {
-      this.readyPlayersPage = page;
-    }
-    this.readyPlayersLoading = true;
-    this.duelsApi.getReadyPlayers({
-      page: this.readyPlayersPage,
-      page_size: this.readyPlayersPageSize,
-    })
-      .pipe(
-        takeUntil(this._unsubscribeAll),
-        finalize(() => this.readyPlayersLoading = false)
-      )
-      .subscribe({
-        next: result => this.readyPlayersResult = result,
-        error: () => this.readyPlayersResult = null,
-      });
-  }
-
-  loadDuels(page?: number): void {
-    if (!this.currentUser) {
-      return;
-    }
-
-    if (page) {
-      this.duelsPage = page;
-    }
-
-    this.duelsLoading = true;
-    this.duelsApi.getDuels({
-      page: this.duelsPage,
-      page_size: this.duelsPageSize,
-      username: this.currentUser.username,
-    })
-      .pipe(
-        takeUntil(this._unsubscribeAll),
-        finalize(() => this.duelsLoading = false),
-      )
-      .subscribe({
-        next: result => {
-          this.duelsResult = result;
-          this.cdr.markForCheck();
-        },
-        error: () => {
-          this.duelsResult = null;
-          this.cdr.markForCheck();
-        },
-      });
-  }
-
-  loadAllDuels(page?: number): void {
-    if (page) {
-      this.allDuelsPage = page;
-    }
-
-    this.allDuelsLoading = true;
-    this.duelsApi.getDuels({
-      page: this.allDuelsPage,
-      page_size: this.allDuelsPageSize,
-    })
-      .pipe(
-        takeUntil(this._unsubscribeAll),
-        finalize(() => this.allDuelsLoading = false),
-      )
-      .subscribe({
-        next: result => {
-          this.allDuelsResult = result;
-          this.cdr.markForCheck();
-        },
-        error: () => {
-          this.allDuelsResult = null;
-          this.cdr.markForCheck();
-        },
-      });
-  }
-
-  openDuelModal(opponent: DuelReadyPlayer): void {
-    this.selectedOpponent = opponent;
-    this.duelPresets = [];
-    this.duelPresetsLoading = true;
-    const startTime = this.defaultStartTime();
-    this.duelForm.reset({
-      presetId: null,
-      startTime: this.formatDateInput(startTime),
-    });
-    this.modalRef = this.modalService.open(DuelPresetModalComponent, {
-      size: 'lg',
-      centered: true,
-    });
-
-    const component = this.modalRef.componentInstance as DuelPresetModalComponent;
-    component.form = this.duelForm;
-    component.opponent = opponent;
-    component.presets = this.duelPresets;
-    component.loading = this.duelPresetsLoading;
-    component.minDate = this.minStartTime;
-    this.cdr.detectChanges();
-
-    const createSubscription = component.create.subscribe(() => this.createDuel());
-
-    this.modalRef.result.finally(() => {
-      createSubscription.unsubscribe();
-      this.modalRef = null;
-      this.selectedOpponent = null;
-    });
-    this.duelsApi.getDuelPresets(opponent.username)
-      .pipe(
-        takeUntil(this._unsubscribeAll),
-      )
-      .subscribe({
-        next: presets => {
-          this.duelPresets = presets;
-          this.duelPresetsLoading = false;
-          if (this.modalRef?.componentInstance) {
-            const modalComponent = this.modalRef.componentInstance as DuelPresetModalComponent;
-            modalComponent.presets = this.duelPresets;
-            modalComponent.loading = this.duelPresetsLoading;
-          }
-          this.cdr.detectChanges();
-        },
-        error: () => {
-          this.duelPresets = [];
-          this.duelPresetsLoading = false;
-          if (this.modalRef?.componentInstance) {
-            const modalComponent = this.modalRef.componentInstance as DuelPresetModalComponent;
-            modalComponent.presets = this.duelPresets;
-            modalComponent.loading = this.duelPresetsLoading;
-          }
-          this.cdr.detectChanges();
-        },
-      });
-  }
-
-  closeModal(): void {
-    this.modalRef?.close();
-    this.modalRef = null;
-    this.selectedOpponent = null;
-  }
-
-  createDuel(): void {
-    if (!this.selectedOpponent) {
-      return;
-    }
-
-    if (this.duelForm.invalid) {
-      this.duelForm.markAllAsTouched();
-      return;
-    }
-
-    const {presetId, startTime} = this.duelForm.value;
-    this.duelsApi.createDuel({
-      duel_username: this.selectedOpponent.username,
-      duel_preset: presetId!,
-      start_time: this.toBackendDate(startTime as string),
-    })
-      .pipe(takeUntil(this._unsubscribeAll))
-      .subscribe({
-        next: response => {
-          this.toastr.success(this.translateService.instant('DuelCreated'), this.translateService.instant('Successfully'));
-          this.closeModal();
-          this.loadDuels();
-          this.loadAllDuels();
-          const duelId = response?.id;
-          if (duelId) {
-            this.router.navigate(['/practice', 'duels', 'duel', duelId]);
-          }
-        },
-        error: () => {
-          this.toastr.error(this.translateService.instant('ServerError'), this.translateService.instant('Error'));
-        }
-      });
-  }
-
-  confirmDuel(duel: Duel): void {
-    if (this.confirmLoadingId) {
-      return;
-    }
-    this.confirmLoadingId = duel.id;
-    this.duelsApi.confirmDuel(duel.id)
-      .pipe(
-        takeUntil(this._unsubscribeAll),
-        finalize(() => this.confirmLoadingId = null)
-      )
-      .subscribe({
-        next: () => {
-          this.toastr.success(this.translateService.instant('Successfully'));
-          this.loadDuels();
-          this.loadAllDuels();
-        },
-        error: () => {
-          this.toastr.error(this.translateService.instant('ServerError'), this.translateService.instant('Error'));
-        }
-      });
+  onDuelConfirmed(): void {
+    this.myDuelsRefreshKey++;
+    this.allDuelsRefreshKey++;
   }
 
   protected override getContentHeader(): ContentHeader {
@@ -339,29 +57,9 @@ export class DuelsPage extends BasePageComponent implements OnInit {
     };
   }
 
-  private formatDateInput(date: Date): string {
-    const pad = (value: number) => value.toString().padStart(2, '0');
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
-  }
-
-  private defaultStartTime(): Date {
-    const date = new Date();
-    date.setMinutes(date.getMinutes() + 5);
-    date.setSeconds(0, 0);
-    return date;
-  }
-
-  private toBackendDate(value: string): string {
-    const date = new Date(value);
-    if (isNaN(date.getTime())) {
-      return value;
-    }
-    const pad = (num: number) => num.toString().padStart(2, '0');
-    const local = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
-    const offset = -date.getTimezoneOffset();
-    const sign = offset >= 0 ? '+' : '-';
-    const offsetHours = pad(Math.floor(Math.abs(offset) / 60));
-    const offsetMinutes = pad(Math.abs(offset) % 60);
-    return `${local}${sign}${offsetHours}:${offsetMinutes}`;
+  private triggerListsReload(): void {
+    this.readyPlayersRefreshKey++;
+    this.myDuelsRefreshKey++;
+    this.allDuelsRefreshKey++;
   }
 }

--- a/src/app/modules/duels/ui/widgets/duel-ready-players-widget/duel-ready-players-widget.component.ts
+++ b/src/app/modules/duels/ui/widgets/duel-ready-players-widget/duel-ready-players-widget.component.ts
@@ -1,0 +1,259 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+  inject,
+} from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { TranslateService } from '@ngx-translate/core';
+import { ToastrService } from 'ngx-toastr';
+import { finalize, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { PageResult } from '@core/common/classes/page-result';
+import { DuelsApiService } from '@duels/data-access';
+import { DuelPreset, DuelReadyPlayer } from '@duels/domain';
+import { DuelReadyPlayersSectionComponent } from '@duels/ui/components/duel-ready-players-section/duel-ready-players-section.component';
+import { DuelPresetModalComponent } from '@duels/ui/components/duel-preset-modal/duel-preset-modal.component';
+import { NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
+
+@Component({
+  selector: 'duel-ready-players-widget',
+  standalone: true,
+  imports: [DuelReadyPlayersSectionComponent, NgbModalModule],
+  template: `
+    <duel-ready-players-section
+      [players]="readyPlayersResult?.data ?? []"
+      [total]="readyPlayersResult?.total ?? 0"
+      [page]="readyPlayersPage"
+      [pageSize]="readyPlayersPageSize"
+      [loading]="readyPlayersLoading"
+      [currentUsername]="currentUsername"
+      (pageChange)="loadReadyPlayers($event)"
+      (challenge)="openDuelModal($event)"
+    />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DuelReadyPlayersWidgetComponent implements OnInit, OnChanges, OnDestroy {
+  @Input() currentUsername: string | null = null;
+  @Input() set refreshKey(value: number) {
+    if (this._refreshKey === value) {
+      return;
+    }
+    this._refreshKey = value;
+    if (this.initialized) {
+      this.loadReadyPlayers();
+    }
+  }
+
+  @Output() readonly duelCreated = new EventEmitter<void>();
+
+  readyPlayersPage = 1;
+  readyPlayersPageSize = 12;
+  readyPlayersResult: PageResult<DuelReadyPlayer> | null = null;
+  readyPlayersLoading = false;
+
+  duelPresets: DuelPreset[] = [];
+  duelPresetsLoading = false;
+  selectedOpponent: DuelReadyPlayer | null = null;
+
+  private readonly duelsApi = inject(DuelsApiService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly modalService = inject(NgbModal);
+  private readonly fb = inject(FormBuilder);
+  private readonly translateService = inject(TranslateService);
+  private readonly toastr = inject(ToastrService);
+  private readonly router = inject(Router);
+  private readonly destroy$ = new Subject<void>();
+
+  duelForm = this.fb.group({
+    presetId: [null as number | null, Validators.required],
+    startTime: ['', Validators.required],
+  });
+  private modalRef: NgbModalRef | null = null;
+  private initialized = false;
+  private _refreshKey = 0;
+
+  ngOnInit(): void {
+    this.initialized = true;
+    this.loadReadyPlayers();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['currentUsername'] && !changes['currentUsername'].firstChange) {
+      this.readyPlayersPage = 1;
+      this.loadReadyPlayers();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.closeModal();
+  }
+
+  loadReadyPlayers(page?: number): void {
+    if (page) {
+      this.readyPlayersPage = page;
+    }
+
+    this.readyPlayersLoading = true;
+    this.duelsApi.getReadyPlayers({
+      page: this.readyPlayersPage,
+      page_size: this.readyPlayersPageSize,
+    })
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.readyPlayersLoading = false;
+          this.cdr.markForCheck();
+        }),
+      )
+      .subscribe({
+        next: result => {
+          this.readyPlayersResult = result;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.readyPlayersResult = null;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  openDuelModal(opponent: DuelReadyPlayer): void {
+    this.selectedOpponent = opponent;
+    this.duelPresets = [];
+    this.duelPresetsLoading = true;
+    const startTime = this.defaultStartTime();
+    this.duelForm.reset({
+      presetId: null,
+      startTime: this.formatDateInput(startTime),
+    });
+    this.modalRef = this.modalService.open(DuelPresetModalComponent, {
+      size: 'lg',
+      centered: true,
+    });
+
+    const component = this.modalRef.componentInstance as DuelPresetModalComponent;
+    component.form = this.duelForm;
+    component.opponent = opponent;
+    component.presets = this.duelPresets;
+    component.loading = this.duelPresetsLoading;
+    component.minDate = this.minStartTime;
+    this.cdr.detectChanges();
+
+    const createSubscription = component.create.subscribe(() => this.createDuel());
+
+    this.modalRef.result.finally(() => {
+      createSubscription.unsubscribe();
+      this.modalRef = null;
+      this.selectedOpponent = null;
+    });
+
+    this.duelsApi.getDuelPresets(opponent.username)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: presets => {
+          this.duelPresets = presets;
+          this.duelPresetsLoading = false;
+          this.updateModalPresets();
+        },
+        error: () => {
+          this.duelPresets = [];
+          this.duelPresetsLoading = false;
+          this.updateModalPresets();
+        },
+      });
+  }
+
+  closeModal(): void {
+    this.modalRef?.close();
+    this.modalRef = null;
+    this.selectedOpponent = null;
+  }
+
+  get minStartTime(): string {
+    return this.formatDateInput(new Date());
+  }
+
+  private createDuel(): void {
+    if (!this.selectedOpponent) {
+      return;
+    }
+
+    if (this.duelForm.invalid) {
+      this.duelForm.markAllAsTouched();
+      return;
+    }
+
+    const { presetId, startTime } = this.duelForm.value;
+    this.duelsApi.createDuel({
+      duel_username: this.selectedOpponent.username,
+      duel_preset: presetId!,
+      start_time: this.toBackendDate(startTime as string),
+    })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: response => {
+          this.toastr.success(this.translateService.instant('DuelCreated'), this.translateService.instant('Successfully'));
+          this.closeModal();
+          this.loadReadyPlayers();
+          this.duelCreated.emit();
+          const duelId = response?.id;
+          if (duelId) {
+            this.router.navigate(['/practice', 'duels', 'duel', duelId]);
+          }
+        },
+        error: () => {
+          this.toastr.error(this.translateService.instant('ServerError'), this.translateService.instant('Error'));
+        },
+      });
+  }
+
+  private updateModalPresets(): void {
+    if (!this.modalRef?.componentInstance) {
+      return;
+    }
+
+    const modalComponent = this.modalRef.componentInstance as DuelPresetModalComponent;
+    modalComponent.presets = this.duelPresets;
+    modalComponent.loading = this.duelPresetsLoading;
+    this.cdr.detectChanges();
+  }
+
+  private formatDateInput(date: Date): string {
+    const pad = (value: number) => value.toString().padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+  }
+
+  private defaultStartTime(): Date {
+    const date = new Date();
+    date.setMinutes(date.getMinutes() + 5);
+    date.setSeconds(0, 0);
+    return date;
+  }
+
+  private toBackendDate(value: string): string {
+    const date = new Date(value);
+    if (isNaN(date.getTime())) {
+      return value;
+    }
+    const pad = (num: number) => num.toString().padStart(2, '0');
+    const local = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+    const offset = -date.getTimezoneOffset();
+    const sign = offset >= 0 ? '+' : '-';
+    const offsetHours = pad(Math.floor(Math.abs(offset) / 60));
+    const offsetMinutes = pad(Math.abs(offset) % 60);
+    return `${local}${sign}${offsetHours}:${offsetMinutes}`;
+  }
+}

--- a/src/app/modules/duels/ui/widgets/duel-ready-status-widget/duel-ready-status-widget.component.ts
+++ b/src/app/modules/duels/ui/widgets/duel-ready-status-widget/duel-ready-status-widget.component.ts
@@ -1,0 +1,90 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, OnDestroy, OnInit, Output, inject } from '@angular/core';
+import { finalize, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { DuelsApiService } from '@duels/data-access';
+import { DuelReadyStatusCardComponent } from '@duels/ui/components/duel-ready-status-card/duel-ready-status-card.component';
+
+@Component({
+  selector: 'duel-ready-status-widget',
+  standalone: true,
+  imports: [DuelReadyStatusCardComponent],
+  template: `
+    <duel-ready-status-card
+      [isReady]="isReady"
+      [disabled]="loading"
+      (readyChange)="onReadyStatusChange($event)"
+    />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DuelReadyStatusWidgetComponent implements OnInit, OnDestroy {
+  @Output() readonly statusChanged = new EventEmitter<boolean>();
+
+  isReady = false;
+  loading = false;
+
+  private readonly duelsApi = inject(DuelsApiService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroy$ = new Subject<void>();
+
+  ngOnInit(): void {
+    this.loadReadyStatus();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  onReadyStatusChange(ready: boolean): void {
+    if (this.loading) {
+      return;
+    }
+
+    const previous = this.isReady;
+    this.isReady = ready;
+    this.loading = true;
+    this.duelsApi.updateReadyStatus(ready)
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.loading = false;
+          this.cdr.markForCheck();
+        }),
+      )
+      .subscribe({
+        next: status => {
+          this.isReady = status?.ready ?? ready;
+          this.statusChanged.emit(this.isReady);
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.isReady = previous;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  private loadReadyStatus(): void {
+    this.loading = true;
+    this.duelsApi.getReadyStatus()
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.loading = false;
+          this.cdr.markForCheck();
+        }),
+      )
+      .subscribe({
+        next: status => {
+          this.isReady = status?.ready ?? false;
+          this.statusChanged.emit(this.isReady);
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.isReady = false;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+}

--- a/src/app/modules/duels/ui/widgets/duels-list-widget/duels-list-widget.component.ts
+++ b/src/app/modules/duels/ui/widgets/duels-list-widget/duels-list-widget.component.ts
@@ -1,0 +1,154 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  OnInit,
+  Output,
+  SimpleChanges,
+  inject,
+} from '@angular/core';
+import { finalize, takeUntil } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { PageResult } from '@core/common/classes/page-result';
+import { DuelsApiService } from '@duels/data-access';
+import { Duel } from '@duels/domain';
+import { DuelsListSectionComponent } from '@duels/ui/components/duels-list-section/duels-list-section.component';
+import { TranslateService } from '@ngx-translate/core';
+import { ToastrService } from 'ngx-toastr';
+
+@Component({
+  selector: 'duels-list-widget',
+  standalone: true,
+  imports: [DuelsListSectionComponent],
+  template: `
+    <duels-list-section
+      [titleKey]="titleKey"
+      [duels]="duelsResult?.data ?? []"
+      [total]="duelsResult?.total ?? 0"
+      [page]="page"
+      [pageSize]="pageSize"
+      [loading]="loading"
+      [confirmLoadingId]="confirmLoadingId"
+      [currentUsername]="currentUsername"
+      (pageChange)="loadDuels($event)"
+      (confirm)="confirmDuel($event)"
+    />
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DuelsListWidgetComponent implements OnInit, OnChanges, OnDestroy {
+  @Input() titleKey = 'MyDuels';
+  @Input() username: string | null = null;
+  @Input() currentUsername: string | null = null;
+  @Input() pageSize = 10;
+  @Input() set refreshKey(value: number) {
+    if (this._refreshKey === value) {
+      return;
+    }
+    this._refreshKey = value;
+    if (this.initialized) {
+      this.loadDuels();
+    }
+  }
+
+  @Output() readonly duelConfirmed = new EventEmitter<void>();
+
+  page = 1;
+  duelsResult: PageResult<Duel> | null = null;
+  loading = false;
+  confirmLoadingId: number | null = null;
+
+  private readonly duelsApi = inject(DuelsApiService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly translateService = inject(TranslateService);
+  private readonly toastr = inject(ToastrService);
+  private readonly destroy$ = new Subject<void>();
+  private initialized = false;
+  private _refreshKey = 0;
+
+  ngOnInit(): void {
+    this.initialized = true;
+    this.loadDuels();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['username'] && !changes['username'].firstChange) {
+      this.page = 1;
+      this.loadDuels();
+    }
+    if (changes['pageSize'] && !changes['pageSize'].firstChange) {
+      this.page = 1;
+      this.loadDuels();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  loadDuels(page?: number): void {
+    if (page) {
+      this.page = page;
+    }
+
+    this.loading = true;
+    const params: Record<string, unknown> = {
+      page: this.page,
+      page_size: this.pageSize,
+    };
+
+    if (this.username) {
+      params['username'] = this.username;
+    }
+
+    this.duelsApi.getDuels(params)
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.loading = false;
+          this.cdr.markForCheck();
+        }),
+      )
+      .subscribe({
+        next: result => {
+          this.duelsResult = result;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.duelsResult = null;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  confirmDuel(duel: Duel): void {
+    if (this.confirmLoadingId) {
+      return;
+    }
+
+    this.confirmLoadingId = duel.id;
+    this.duelsApi.confirmDuel(duel.id)
+      .pipe(
+        takeUntil(this.destroy$),
+        finalize(() => {
+          this.confirmLoadingId = null;
+          this.cdr.markForCheck();
+        }),
+      )
+      .subscribe({
+        next: () => {
+          this.toastr.success(this.translateService.instant('Successfully'));
+          this.loadDuels();
+          this.duelConfirmed.emit();
+        },
+        error: () => {
+          this.toastr.error(this.translateService.instant('ServerError'), this.translateService.instant('Error'));
+        },
+      });
+  }
+}


### PR DESCRIPTION
## Summary
- extract ready status, ready players, and duels list behaviours into dedicated widget components
- simplify the duels page to orchestrate widgets through refresh keys and outputs
- update the duels page template to render the new widgets

## Testing
- npm run lint *(fails: ng CLI not available because dependencies cannot be installed due to peer conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68d120556b70832fa6aff7c7c75c770a