### PR TITLE
Improve 404 back navigation

### DIFF
--- a/src/app/common/global.service.ts
+++ b/src/app/common/global.service.ts
@@ -14,6 +14,7 @@ export class GlobalService {
   protected _unsubscribeAll = new Subject();
   protected _queryParams: any;
   protected _lastUrl: string;
+  protected _previousUrl: string | undefined;
 
   private _queryParamsSubject = new ReplaySubject<Params>(1);
   private _currentUserSubject = new ReplaySubject<User | null>(1);
@@ -47,7 +48,8 @@ export class GlobalService {
     this.router.events.subscribe(
       (event) => {
         if (event instanceof NavigationEnd) {
-          this._lastUrl = event.url;
+          this._previousUrl = this._lastUrl;
+          this._lastUrl = event.urlAfterRedirects ?? event.url;
         }
       }
     );
@@ -67,6 +69,10 @@ export class GlobalService {
 
   getLastUrl() {
     return this._lastUrl;
+  }
+
+  getPreviousUrl() {
+    return this._previousUrl;
   }
 
   updateQueryParams(params: Params, extras?: NavigationExtras) {

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -275,6 +275,7 @@ export const locale = {
     Purchase: 'Purchase',
     ArenaWinners: 'Arena winners',
     GoToArena: 'Go to Arena',
+    GoBack: 'Go back',
     Technology: 'Technology',
     Submit: 'Submit',
     Submitted: 'Submitted',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -180,6 +180,7 @@ export const locale = {
     Registrated: 'Зарегистрировано',
     ArenaWinners: 'Победители Арена',
     GoToArena: 'Перейти к Арена',
+    GoBack: 'Вернуться назад',
     Pefomance: 'Перфоманс',
     UnofficialParticipation: 'Для неофициального участия, нажмите эту кнопку',
     Wins: 'Выигрыши',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -133,6 +133,7 @@ export const locale = {
     Verdict: 'Natija',
     ArenaWinners: 'Arena gʻoliblari',
     GoToArena: 'Arenaga oʻtish',
+    GoBack: 'Orqaga qaytarish',
     AllAttempts: 'Barcha urinishlar',
     NumberOfAttemptsForSolve: 'Ishlash uchun urinishlar soni',
     Time: 'Vaqt',

--- a/src/app/modules/pages/miscellaneous/error/error.component.html
+++ b/src/app/modules/pages/miscellaneous/error/error.component.html
@@ -8,7 +8,7 @@
     <div class="w-100 text-center">
       <h2 class="mb-1">Page Not Found 🕵🏻‍♀️</h2>
       <p class="mb-2">Oops! 😖 The requested URL was not found on this server.</p>
-      <a class="btn btn-primary mb-2 btn-sm-block" routerLink="/" rippleEffect>Back to Home</a
+      <a class="btn btn-primary mb-2 btn-sm-block" href="javascript:void(0);" (click)="goBack()" rippleEffect>{{ 'GoBack' | translate }}</a
       ><img
         class="img-fluid"
         [src]="

--- a/src/app/modules/pages/miscellaneous/error/error.component.ts
+++ b/src/app/modules/pages/miscellaneous/error/error.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
@@ -6,6 +7,8 @@ import { Subject } from 'rxjs';
 import { CoreConfigService } from '@core/services/config.service';
 import { CoreCommonModule } from '@core/common.module';
 import { coreConfig } from '@app/app.config';
+import { TranslateModule } from '@ngx-translate/core';
+import { GlobalService } from '@app/common/global.service';
 
 @Component({
   selector: 'app-error',
@@ -14,6 +17,7 @@ import { coreConfig } from '@app/app.config';
   standalone: true,
   imports: [
     CoreCommonModule,
+    TranslateModule,
   ]
 })
 export class ErrorComponent implements OnInit {
@@ -22,7 +26,11 @@ export class ErrorComponent implements OnInit {
 
   private _unsubscribeAll: Subject<any>;
 
-  constructor(private _coreConfigService: CoreConfigService) {
+  constructor(
+    private _coreConfigService: CoreConfigService,
+    private _router: Router,
+    private _globalService: GlobalService,
+  ) {
     this._unsubscribeAll = new Subject();
 
     this._coreConfigService.config = {
@@ -51,5 +59,16 @@ export class ErrorComponent implements OnInit {
   ngOnDestroy(): void {
     this._unsubscribeAll.next(null);
     this._unsubscribeAll.complete();
+  }
+
+  goBack() {
+    const previousUrl = this._globalService.getPreviousUrl();
+
+    if (previousUrl && previousUrl !== '/404') {
+      this._router.navigateByUrl(previousUrl);
+      return;
+    }
+
+    this._router.navigateByUrl('/');
   }
 }


### PR DESCRIPTION
## Summary
- track the previous navigation URL in the global service to support smarter redirects
- update the 404 error page to use the new back navigation logic and translate the button label
- add localized "Go back" strings to the available translation dictionaries

## Testing
- npm run lint *(fails: Angular CLI unavailable because dependencies cannot be installed due to peer dependency conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68d1219cb958832fb41f1ead056d043b