### PR TITLE
Append next parameter to social login redirects

### DIFF
--- a/src/app/modules/auth/login/login.component.html
+++ b/src/app/modules/auth/login/login.component.html
@@ -13,7 +13,7 @@
           <p class="mb-4 text-muted op-7 fw-normal text-center">{{ 'LoginText' | translate }}</p>
           <div class="d-flex mb-3 justify-content-between gap-2 flex-wrap flex-lg-nowrap">
             <a
-              href="/login/google-oauth2/"
+              [attr.href]="getSocialLoginUrl('google-oauth2')"
               class="btn btn-lg btn-light-ghost border d-flex align-items-center justify-content-center flex-fill">
               <span class="avatar avatar-xs">
                 <img alt="" src="assets/images/media/apps/google.png">
@@ -21,7 +21,7 @@
               <span class="lh-1 ms-2 fs-13 text-default">{{ 'SignUpWith' | translate:{title: 'Google'} }}</span>
             </a>
             <a
-              href="/login/github/"
+              [attr.href]="getSocialLoginUrl('github')"
               class="btn btn-lg btn-light-ghost border d-flex align-items-center justify-content-center flex-fill">
               <span class="avatar avatar-xs invert-1">
                 <img alt="" src="assets/images/media/apps/github.png">


### PR DESCRIPTION
## Summary
- normalize the desired post-login route using the available query parameter or the last navigation event
- update the Google and GitHub login buttons to append the computed route via the `next` query parameter

## Testing
- npm run lint *(fails: `ng` binary is unavailable because Angular CLI dependencies are not installed in the container)*
- npm install *(fails: dependency resolution conflict for `@fullcalendar/angular` when resolving peer dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d1266dcb38832f928cca6130e2c765