### PR TITLE
Refactor problems rating page layout

### DIFF
--- a/src/app/modules/problems/pages/rating/rating.component.html
+++ b/src/app/modules/problems/pages/rating/rating.component.html
@@ -2,91 +2,123 @@
   <div class="content-body">
     <app-content-header [contentHeader]="contentHeader"></app-content-header>
 
-    <section class="mt-2">
-      <kep-table [spinnerHeight]="'701px'" [loading]="!total && isLoading">
-        <ng-container header>
-          <tr>
-            <th>#</th>
-            <th>{{ 'User' | translate }}</th>
-            @for (difficulty of difficultyLabels; track difficulty) {
-              <th class="text-center">
-                <table-ordering
-                  (change)="orderingChange($event)"
-                  [justifyContent]="'between'"
-                  [ordering]="difficulty"
-                  [reverse]="true"
-                  [value]="ordering">
-                  {{ difficulty | titlecase | translate }}
-                </table-ordering>
-              </th>
-            }
-
-            <th class="text-center">
-              <table-ordering
-                (change)="orderingChange($event)"
-                [justifyContent]="'center'"
-                [ordering]="'solved'"
-                [reverse]="true"
-                [value]="ordering">
-                <kep-icon name="check-square"></kep-icon>
-              </table-ordering>
-            </th>
-
-            <th class="text-center">
-              <table-ordering
-                (change)="orderingChange($event)"
-                [justifyContent]="'center'"
-                [ordering]="'rating'"
-                [reverse]="true"
-                [value]="ordering">
-                <kep-icon name="rating"></kep-icon>
-              </table-ordering>
-            </th>
-          </tr>
-        </ng-container>
-        <ng-container body>
-          @for (problemsRating of problemsRatingList; track problemsRating) {
-            <tr
-              [ngClass]="{'bg-primary-transparent': currentUser?.username == problemsRating?.user?.username }">
-              <td>{{ problemsRating.rowIndex }}</td>
-              <td>
-                <contestant-view [user]="problemsRating.user"></contestant-view>
-              </td>
-              <td class="text-center text-success">{{ problemsRating.beginner }}</td>
-              <td class="text-center text-info">{{ problemsRating.basic }}</td>
-              <td class="text-center text-blue">{{ problemsRating.normal }}</td>
-              <td class="text-center text-primary">{{ problemsRating.medium }}</td>
-              <td class="text-center text-warning">{{ problemsRating.advanced }}</td>
-              <td class="text-center text-danger">{{ problemsRating.hard }}</td>
-              <td class="text-center text-dark">{{ problemsRating.extremal }}</td>
-              <td class="text-center">
-                <span class="badge bg-primary">
-                  {{ problemsRating.solved }}
-                </span>
-              </td>
-              <td class="text-center">
-                <span class="badge bg-success-transparent">
-                  {{ problemsRating.rating }}
-                </span>
-              </td>
-            </tr>
+    <section class="mt-2 d-flex flex-column gap-3">
+      <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+        <div class="d-flex flex-wrap gap-2">
+          @for (difficulty of difficultyLabels; track difficulty) {
+            <table-ordering
+              (change)="orderingChange($event)"
+              [justifyContent]="'start'"
+              [ordering]="difficulty"
+              [reverse]="true"
+              [value]="ordering">
+              <span
+                class="btn btn-sm"
+                [ngClass]="isOrderingActive(difficulty) ? 'btn-primary' : 'btn-outline-primary'">
+                {{ difficulty | titlecase | translate }}
+              </span>
+            </table-ordering>
           }
-        </ng-container>
-        <ng-container pagination>
-          <div class="mb-1">
-            <kep-pagination
-              (pageChange)="pageChange($event)"
-              (pageSizeChange)="pageSizeChange($event)"
-              [collectionSize]="total"
-              [maxSize]="maxSize"
-              [disabled]="isLoading"
-              [pageOptions]="pageOptions"
-              [pageSize]="pageSize"
-              [page]="pageNumber">
-            </kep-pagination>
+
+          <table-ordering
+            (change)="orderingChange($event)"
+            [justifyContent]="'start'"
+            [ordering]="'solved'"
+            [reverse]="true"
+            [value]="ordering">
+            <span
+              class="btn btn-sm"
+              [ngClass]="isOrderingActive('solved') ? 'btn-primary' : 'btn-outline-primary'">
+              {{ 'Solved' | translate }}
+            </span>
+          </table-ordering>
+
+          <table-ordering
+            (change)="orderingChange($event)"
+            [justifyContent]="'start'"
+            [ordering]="'rating'"
+            [reverse]="true"
+            [value]="ordering">
+            <span
+              class="btn btn-sm"
+              [ngClass]="isOrderingActive('rating') ? 'btn-primary' : 'btn-outline-primary'">
+              {{ 'Rating' | translate }}
+            </span>
+          </table-ordering>
+        </div>
+
+        @if (!isLoading && total) {
+          <span class="text-muted small">{{ total }} {{ 'Users' | translate }}</span>
+        }
+      </div>
+
+      @if (isLoading) {
+        <kep-card>
+          <div class="card-body d-flex justify-content-center py-5">
+            <spinner></spinner>
           </div>
-        </ng-container>
-      </kep-table>
+        </kep-card>
+      } @else if (!problemsRatingList?.length) {
+        <kep-card>
+          <div class="card-body text-center py-5">
+            <div class="text-muted">{{ 'NoResultFound' | translate }}</div>
+          </div>
+        </kep-card>
+      } @else {
+        <div class="row g-3">
+          @for (problemsRating of problemsRatingList; track problemsRating.rowIndex) {
+            <div class="col-12 col-md-6 col-xl-4">
+              <kep-card customClass="h-100">
+                <div class="card-body d-flex flex-column gap-3">
+                  <div class="d-flex flex-wrap justify-content-between align-items-start gap-2">
+                    <div class="d-flex align-items-center gap-3 flex-wrap">
+                      <span class="badge bg-primary fw-semibold text-white px-3 py-2 fs-6">{{ problemsRating.rowIndex }}</span>
+                      <contestant-view [user]="problemsRating.user"></contestant-view>
+                    </div>
+
+                    <div class="d-flex flex-wrap gap-2">
+                      <div class="badge bg-primary-transparent text-primary d-inline-flex align-items-center gap-2 px-3 py-2">
+                        <span class="fw-semibold">{{ problemsRating.solved }}</span>
+                        <span class="text-uppercase small">{{ 'Solved' | translate }}</span>
+                      </div>
+                      <div class="badge bg-success-transparent text-success d-inline-flex align-items-center gap-2 px-3 py-2">
+                        <span class="fw-semibold">{{ problemsRating.rating }}</span>
+                        <span class="text-uppercase small">{{ 'Rating' | translate }}</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="d-flex flex-wrap gap-2">
+                    @for (difficulty of difficultyLabels; track difficulty) {
+                      <div
+                        class="badge d-inline-flex align-items-center gap-2 px-3 py-2"
+                        [ngClass]="getDifficultyBadgeClass(difficulty)">
+                        <span class="fw-semibold">{{ problemsRating[difficulty] }}</span>
+                        <span class="text-uppercase small">{{ difficulty | titlecase | translate }}</span>
+                      </div>
+                    }
+                  </div>
+                </div>
+              </kep-card>
+            </div>
+          }
+        </div>
+      }
+
+      @if (total) {
+        <div class="d-flex justify-content-center">
+          <kep-pagination
+            (pageChange)="pageChange($event)"
+            (pageSizeChange)="pageSizeChange($event)"
+            [collectionSize]="total"
+            [maxSize]="maxSize"
+            [disabled]="isLoading"
+            [pageOptions]="pageOptions"
+            [pageSize]="pageSize"
+            [page]="pageNumber">
+          </kep-pagination>
+        </div>
+      }
 
       <period-ratings/>
     </section>

--- a/src/app/modules/problems/pages/rating/rating.component.html
+++ b/src/app/modules/problems/pages/rating/rating.component.html
@@ -27,8 +27,8 @@
             [reverse]="true"
             [value]="ordering">
             <span
-              class="btn btn-sm"
-              [ngClass]="isOrderingActive('solved') ? 'btn-primary' : 'btn-outline-primary'">
+              [ngClass]="isOrderingActive('solved') ? 'btn-primary' : 'btn-outline-primary'"
+              class="btn btn-sm">
               {{ 'Solved' | translate }}
             </span>
           </table-ordering>
@@ -40,8 +40,8 @@
             [reverse]="true"
             [value]="ordering">
             <span
-              class="btn btn-sm"
-              [ngClass]="isOrderingActive('rating') ? 'btn-primary' : 'btn-outline-primary'">
+              [ngClass]="isOrderingActive('rating') ? 'btn-primary' : 'btn-outline-primary'"
+              class="btn btn-sm">
               {{ 'Rating' | translate }}
             </span>
           </table-ordering>
@@ -69,34 +69,39 @@
           @for (problemsRating of problemsRatingList; track problemsRating.rowIndex) {
             <div class="col-12 col-md-6 col-xl-4">
               <kep-card customClass="h-100">
-                <div class="card-body d-flex flex-column gap-3">
-                  <div class="d-flex flex-wrap justify-content-between align-items-start gap-2">
-                    <div class="d-flex align-items-center gap-3 flex-wrap">
-                      <span class="badge bg-primary fw-semibold text-white px-3 py-2 fs-6">{{ problemsRating.rowIndex }}</span>
-                      <contestant-view [user]="problemsRating.user"></contestant-view>
-                    </div>
-
-                    <div class="d-flex flex-wrap gap-2">
-                      <div class="badge bg-primary-transparent text-primary d-inline-flex align-items-center gap-2 px-3 py-2">
-                        <span class="fw-semibold">{{ problemsRating.solved }}</span>
-                        <span class="text-uppercase small">{{ 'Solved' | translate }}</span>
-                      </div>
-                      <div class="badge bg-success-transparent text-success d-inline-flex align-items-center gap-2 px-3 py-2">
-                        <span class="fw-semibold">{{ problemsRating.rating }}</span>
-                        <span class="text-uppercase small">{{ 'Rating' | translate }}</span>
-                      </div>
-                    </div>
+                <div class="card-header">
+                  <div class="d-flex align-items-center gap-2 flex-wrap">
+                    <span class="badge bg-primary fw-semibold text-white px-3 py-2 fs-6">
+                      {{ problemsRating.rowIndex }}
+                    </span>
+                    <contestant-view [user]="problemsRating.user"></contestant-view>
                   </div>
 
-                  <div class="d-flex flex-wrap gap-2">
-                    @for (difficulty of difficultyLabels; track difficulty) {
-                      <div
-                        class="badge d-inline-flex align-items-center gap-2 px-3 py-2"
-                        [ngClass]="getDifficultyBadgeClass(difficulty)">
-                        <span class="fw-semibold">{{ problemsRating[difficulty] }}</span>
-                        <span class="text-uppercase small">{{ difficulty | titlecase | translate }}</span>
-                      </div>
-                    }
+                  <div class="text-dark">
+                    <span class="me-1" ngbTooltip="{{ 'Solved' | translate }}">
+                      <kep-icon size="small-4" class="" name="check-circle"></kep-icon>
+                      {{ problemsRating.solved }}
+                    </span>
+
+                    <span ngbTooltip="{{ 'Rating' | translate }}">
+                      <kep-icon size="small-4" class="" name="rating"></kep-icon>
+                      {{ problemsRating.rating }}
+                    </span>
+                  </div>
+                </div>
+
+                <div class="card-body d-flex flex-column gap-3">
+                  <div class="font-medium-5 mt-1">
+                    <div class="font-small-4 d-md-flex d-block justify-content-between">
+                      @for (difficulty of difficultyLabels.slice(0); track difficulty) {
+                        <div class="mt-2">
+                          <span class="text-{{ $index+1 | problemDifficultyColor }}">
+                            {{ problemsRating[difficulty] }}
+                            <span class="font-small-1">{{ difficulty | titlecase | translate }}</span>
+                          </span>
+                        </div>
+                      }
+                    </div>
                   </div>
                 </div>
               </kep-card>
@@ -106,18 +111,16 @@
       }
 
       @if (total) {
-        <div class="d-flex justify-content-center">
-          <kep-pagination
-            (pageChange)="pageChange($event)"
-            (pageSizeChange)="pageSizeChange($event)"
-            [collectionSize]="total"
-            [maxSize]="maxSize"
-            [disabled]="isLoading"
-            [pageOptions]="pageOptions"
-            [pageSize]="pageSize"
-            [page]="pageNumber">
-          </kep-pagination>
-        </div>
+        <kep-pagination
+          (pageChange)="pageChange($event)"
+          (pageSizeChange)="pageSizeChange($event)"
+          [collectionSize]="total"
+          [maxSize]="maxSize"
+          [disabled]="isLoading"
+          [pageOptions]="pageOptions"
+          [pageSize]="pageSize"
+          [page]="pageNumber">
+        </kep-pagination>
       }
 
       <period-ratings/>

--- a/src/app/modules/problems/pages/rating/rating.component.scss
+++ b/src/app/modules/problems/pages/rating/rating.component.scss
@@ -1,5 +1,0 @@
-tr:first-child td, th {
-  border-bottom: none !important;
-  border-top: none !important;
-}
-

--- a/src/app/modules/problems/pages/rating/rating.component.ts
+++ b/src/app/modules/problems/pages/rating/rating.component.ts
@@ -10,27 +10,26 @@ import { BaseTablePageComponent } from '@core/common/classes/base-table-page.com
 import { Resources } from '@app/resources';
 import { Observable } from 'rxjs';
 import { difficultyLabels } from '@problems/constants/difficulties.enum';
-import { KepTableComponent } from '@shared/components/kep-table/kep-table.component';
 import { TableOrderingModule } from '@shared/components/table-ordering/table-ordering.module';
-import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
 import { ProblemsApiService } from '@problems/services/problems-api.service';
 import { PeriodRatingsComponent } from '@problems/pages/rating/period-ratings/period-ratings.component';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
 
 
 @Component({
   selector: 'page-rating',
   templateUrl: './rating.component.html',
-  styleUrls: ['./rating.component.scss'],
   standalone: true,
   imports: [
     CoreCommonModule,
     ContentHeaderModule,
     ContestantViewModule,
     KepPaginationComponent,
-    KepTableComponent,
     TableOrderingModule,
-    KepIconComponent,
     PeriodRatingsComponent,
+    KepCardComponent,
+    SpinnerComponent,
   ],
 })
 export class RatingComponent extends BaseTablePageComponent<ProblemsRating> implements OnInit {
@@ -47,6 +46,31 @@ export class RatingComponent extends BaseTablePageComponent<ProblemsRating> impl
 
   get problemsRatingList() {
     return this.pageResult?.data;
+  }
+
+  isOrderingActive(orderingKey: string) {
+    return this.ordering === orderingKey || this.ordering === `-${orderingKey}`;
+  }
+
+  getDifficultyBadgeClass(difficulty: string) {
+    switch (difficulty) {
+      case 'beginner':
+        return 'bg-success-transparent text-success';
+      case 'basic':
+        return 'bg-info-transparent text-info';
+      case 'normal':
+        return 'bg-blue-transparent text-blue';
+      case 'medium':
+        return 'bg-primary-transparent text-primary';
+      case 'advanced':
+        return 'bg-warning-transparent text-warning';
+      case 'hard':
+        return 'bg-danger-transparent text-danger';
+      case 'extremal':
+        return 'bg-dark-transparent text-dark';
+      default:
+        return 'bg-light-secondary text-body';
+    }
   }
 
   getPage(): Observable<PageResult<ProblemsRating>> {

--- a/src/app/modules/problems/pages/rating/rating.component.ts
+++ b/src/app/modules/problems/pages/rating/rating.component.ts
@@ -15,6 +15,8 @@ import { ProblemsApiService } from '@problems/services/problems-api.service';
 import { PeriodRatingsComponent } from '@problems/pages/rating/period-ratings/period-ratings.component';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
+import { NgbTooltip } from "@ng-bootstrap/ng-bootstrap";
+import { ProblemDifficultyColorPipe } from "@problems/pipes/problem-difficulty-color.pipe";
 
 
 @Component({
@@ -30,11 +32,13 @@ import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
     PeriodRatingsComponent,
     KepCardComponent,
     SpinnerComponent,
+    NgbTooltip,
+    ProblemDifficultyColorPipe,
   ],
 })
 export class RatingComponent extends BaseTablePageComponent<ProblemsRating> implements OnInit {
-  override defaultPageSize = 10;
-  override pageOptions = [10, 20, 50];
+  override defaultPageSize = 12;
+  override pageOptions = [6, 9, 12, 24];
   override defaultOrdering = '-rating';
   override maxSize = 5;
 


### PR DESCRIPTION
## Summary
- replace the problems rating table with a responsive card grid that mirrors the duels rating layout
- add loading and empty states alongside ordering controls using existing shared components

## Testing
- npm run lint *(fails: ng not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d18ef8881c832fbe18f77c09002232