### PR TITLE
Refactor contests rating page to card layout

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -230,6 +230,7 @@ export const localeEn = {
   AwaitingConfirmation: 'Awaiting confirmation',
   Confirm: 'Confirm',
   NoDuelsYet: 'No duels yet',
+  NoContestsRatingYet: 'No contests rating yet',
   SelectDuelPreset: 'Select duel preset',
   SelectDuelPresetDescription: 'Choose a preset and start time to challenge {{ username }}.',
   FieldRequired: 'This field is required',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -229,6 +229,7 @@ export const localeRu = {
   AwaitingConfirmation: 'Ожидает подтверждения',
   Confirm: 'Подтвердить',
   NoDuelsYet: 'Пока нет дуэлей',
+  NoContestsRatingYet: 'Пока нет рейтинга по контестам',
   SelectDuelPreset: 'Выберите пресет дуэли',
   SelectDuelPresetDescription: 'Выберите пресет и время начала, чтобы вызвать {{ username }}.',
   FieldRequired: 'Это поле обязательно',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -230,6 +230,7 @@ export const localeUz = {
   AwaitingConfirmation: 'Tasdiqlash kutilmoqda',
   Confirm: 'Tasdiqlash',
   NoDuelsYet: 'Hozircha duellar yo\'q',
+  NoContestsRatingYet: 'Hozircha kontestlar reytingi yo\'q',
   SelectDuelPreset: 'Duel presetini tanlang',
   SelectDuelPresetDescription: '{{ username }} ni chaqirish uchun preset va boshlanish vaqtini tanlang.',
   FieldRequired: 'Bu maydon majburiy',

--- a/src/app/modules/contests/pages/rating/rating.component.html
+++ b/src/app/modules/contests/pages/rating/rating.component.html
@@ -2,58 +2,72 @@
   <div class="content-body">
     <app-content-header [contentHeader]="contentHeader"></app-content-header>
 
-    <section class="mt-2">
-      <kep-table [loading]="!total && isLoading">
-        <ng-container header>
-          <tr>
-            <th class="text-center">#</th>
-            <th class="">{{ 'User' | translate }}</th>
-            <th container="body" ngbTooltip="{{ 'Contests.Contests' | translate }}" class="text-center">
-              <kep-icon name="contest"></kep-icon>
-            </th>
-            <th container="body" ngbTooltip="{{ 'Rating' | translate }}" class="text-center">
-              <kep-icon name="rating"></kep-icon>
-            </th>
-          </tr>
-        </ng-container>
-        <ng-container body>
-          @for (contestsRating of contestsRatingList; track contestsRating.username) {
-            <tr>
-              <td class="text-dark text-center">{{ contestsRating.rowIndex }}</td>
-              <td class="text-dark">
-                <contestant-view [user]="contestsRating"></contestant-view>
-              </td>
-              <td class="text-dark text-center">
-                <span class="badge bg-primary">
-                  {{ contestsRating.contestantsCount }}
-                </span>
-              </td>
-              <td class="text-center">
-                <span class="badge bg-{{ contestsRating.rating | contestsRatingColor }}-transparent">
-                  {{ contestsRating.rating }}
-                </span>
-              </td>
-            </tr>
-          }
-        </ng-container>
-        <ng-container pagination>
-          <div class="mb-1">
-            @if (total) {
-              <kep-pagination
-                (pageChange)="pageChange($event)"
-                (pageSizeChange)="pageSizeChange($event)"
-                [(page)]="pageNumber"
-                [collectionSize]="total"
-                [maxSize]="maxSize"
-                [pageOptions]="pageOptions"
-                [pageSize]="pageSize"
-                [disabled]="isLoading"
-                [rotate]="true">
-              </kep-pagination>
-            }
+    <section class="mt-2 d-flex flex-column gap-3">
+      <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+        @if (!isLoading && total) {
+          <span class="text-muted small">{{ total }} {{ 'Users' | translate }}</span>
+        }
+      </div>
+
+      @if (isLoading) {
+        <kep-card>
+          <div class="card-body d-flex justify-content-center py-5">
+            <spinner></spinner>
           </div>
-        </ng-container>
-      </kep-table>
+        </kep-card>
+      } @else if (pageResult?.total === 0) {
+        <kep-card>
+          <div class="card-body text-center py-5">
+            <div class="text-muted">{{ 'NoContestsRatingYet' | translate }}</div>
+          </div>
+        </kep-card>
+      } @else {
+        <div class="row g-3">
+          @for (contestsRating of contestsRatingList; track contestsRating.username) {
+            <div class="col-12 col-md-6 col-xl-4">
+              <kep-card customClass="h-100">
+                <div class="card-body d-flex flex-column gap-3">
+                  <div class="d-flex align-items-center gap-3 flex-wrap">
+                    <span class="badge bg-primary fw-semibold text-white px-3 py-2 fs-6">
+                      {{ contestsRating.rowIndex }}
+                    </span>
+                    <contestant-view [user]="contestsRating"></contestant-view>
+                  </div>
+                  <div class="d-flex flex-wrap gap-2">
+                    <div class="badge bg-primary-transparent text-primary d-inline-flex align-items-center gap-2 px-3 py-2">
+                      <kep-icon name="contest"></kep-icon>
+                      <span class="fw-semibold">{{ contestsRating.contestantsCount }}</span>
+                      <span class="text-uppercase small">{{ 'Contests.Contests' | translate }}</span>
+                    </div>
+                    <div
+                      class="badge bg-{{ contestsRating.rating | contestsRatingColor }}-transparent d-inline-flex align-items-center gap-2 px-3 py-2">
+                      <kep-icon name="rating"></kep-icon>
+                      <span class="fw-semibold">{{ contestsRating.rating }}</span>
+                      <span class="text-uppercase small">{{ 'Rating' | translate }}</span>
+                    </div>
+                  </div>
+                </div>
+              </kep-card>
+            </div>
+          }
+        </div>
+      }
+
+      @if (total) {
+        <div class="d-flex justify-content-center">
+          <kep-pagination
+            (pageChange)="pageChange($event)"
+            (pageSizeChange)="pageSizeChange($event)"
+            [(page)]="pageNumber"
+            [collectionSize]="total"
+            [maxSize]="maxSize"
+            [pageOptions]="pageOptions"
+            [pageSize]="pageSize"
+            [disabled]="isLoading"
+            [rotate]="true">
+          </kep-pagination>
+        </div>
+      }
     </section>
   </div>
 </div>

--- a/src/app/modules/contests/pages/rating/rating.component.ts
+++ b/src/app/modules/contests/pages/rating/rating.component.ts
@@ -6,11 +6,10 @@ import { Observable } from 'rxjs';
 import { PageResult } from '@core/common/classes/page-result';
 import { CoreCommonModule } from '@core/common.module';
 import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
-import { KepTableComponent } from '@shared/components/kep-table/kep-table.component';
 import { ContestantViewModule } from '@contests/components/contestant-view/contestant-view.module';
 import { KepPaginationComponent } from '@shared/components/kep-pagination/kep-pagination.component';
 import { ContestsRating } from '@contests/models/contests-rating';
-import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 
 @Component({
   selector: 'app-rating',
@@ -20,10 +19,9 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
   imports: [
     CoreCommonModule,
     ContentHeaderModule,
-    KepTableComponent,
     ContestantViewModule,
     KepPaginationComponent,
-    NgbTooltip,
+    KepCardComponent,
   ]
 })
 export class RatingComponent extends BaseTablePageComponent<ContestsRating> implements OnInit {


### PR DESCRIPTION
## Summary
- replace the contests rating table with a responsive card grid that mirrors the duels rating presentation, including loading and empty states
- surface the total user count and highlight rating/contest numbers with existing badge styles
- add a shared `NoContestsRatingYet` translation for English, Russian, and Uzbek locales

## Testing
- npm run lint *(fails: `ng` command missing because Angular CLI dependencies are unavailable in the container; `npm install` also fails due to upstream peer dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_68d18efe9724832fbafa596220cb4819