### PR TITLE
Refactor contests rating page layout

### DIFF
--- a/src/app/modules/contests/pages/rating/rating.component.html
+++ b/src/app/modules/contests/pages/rating/rating.component.html
@@ -2,58 +2,95 @@
   <div class="content-body">
     <app-content-header [contentHeader]="contentHeader"></app-content-header>
 
-    <section class="mt-2">
-      <kep-table [loading]="!total && isLoading">
-        <ng-container header>
-          <tr>
-            <th class="text-center">#</th>
-            <th class="">{{ 'User' | translate }}</th>
-            <th container="body" ngbTooltip="{{ 'Contests.Contests' | translate }}" class="text-center">
-              <kep-icon name="contest"></kep-icon>
-            </th>
-            <th container="body" ngbTooltip="{{ 'Rating' | translate }}" class="text-center">
-              <kep-icon name="rating"></kep-icon>
-            </th>
-          </tr>
-        </ng-container>
-        <ng-container body>
-          @for (contestsRating of contestsRatingList; track contestsRating.username) {
-            <tr>
-              <td class="text-dark text-center">{{ contestsRating.rowIndex }}</td>
-              <td class="text-dark">
-                <contestant-view [user]="contestsRating"></contestant-view>
-              </td>
-              <td class="text-dark text-center">
-                <span class="badge bg-primary">
-                  {{ contestsRating.contestantsCount }}
-                </span>
-              </td>
-              <td class="text-center">
-                <span class="badge bg-{{ contestsRating.rating | contestsRatingColor }}-transparent">
-                  {{ contestsRating.rating }}
-                </span>
-              </td>
-            </tr>
+    <section class="mt-2 d-flex flex-column gap-3">
+      <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+        <div class="d-flex flex-wrap gap-2">
+          @for (orderingKey of orderingOptions; track orderingKey) {
+            <table-ordering
+              (change)="orderingChange($event)"
+              [justifyContent]="'start'"
+              [ordering]="orderingKey"
+              [reverse]="true"
+              [value]="ordering">
+              <span
+                class="btn btn-sm"
+                [ngClass]="isOrderingActive(orderingKey) ? 'btn-primary' : 'btn-outline-primary'">
+                {{ orderingLabels[orderingKey] | translate }}
+              </span>
+            </table-ordering>
           }
-        </ng-container>
-        <ng-container pagination>
-          <div class="mb-1">
-            @if (total) {
-              <kep-pagination
-                (pageChange)="pageChange($event)"
-                (pageSizeChange)="pageSizeChange($event)"
-                [(page)]="pageNumber"
-                [collectionSize]="total"
-                [maxSize]="maxSize"
-                [pageOptions]="pageOptions"
-                [pageSize]="pageSize"
-                [disabled]="isLoading"
-                [rotate]="true">
-              </kep-pagination>
-            }
+        </div>
+
+        @if (!isLoading && total) {
+          <span class="text-muted small">{{ total }} {{ 'Users' | translate }}</span>
+        }
+      </div>
+
+      @if (isLoading) {
+        <kep-card>
+          <div class="card-body d-flex justify-content-center py-5">
+            <spinner></spinner>
           </div>
-        </ng-container>
-      </kep-table>
+        </kep-card>
+      } @else if (!contestsRatingList?.length) {
+        <kep-card>
+          <div class="card-body text-center py-5">
+            <div class="text-muted">{{ 'NoResultFound' | translate }}</div>
+          </div>
+        </kep-card>
+      } @else {
+        <div class="row g-3">
+          @for (contestsRating of contestsRatingList; track contestsRating.rowIndex) {
+            <div class="col-12 col-md-6 col-xl-4">
+              <kep-card customClass="h-100">
+                <div class="card-body d-flex flex-column gap-3">
+                  <div class="d-flex align-items-center gap-3 flex-wrap">
+                    <span class="badge bg-primary fw-semibold text-white px-3 py-2 fs-6">{{ contestsRating.rowIndex }}</span>
+                    <contestant-view [user]="contestsRating"></contestant-view>
+                  </div>
+
+                  <div class="d-flex flex-wrap gap-2 align-items-center">
+                    <span
+                      [ngbTooltip]="'Rating' | translate"
+                      class="badge bg-{{ contestsRating.rating | contestsRatingColor }}-transparent">
+                      <contests-rating-image [size]="16" [title]="contestsRating.ratingTitle"></contests-rating-image>
+                      {{ contestsRating.rating }}
+                    </span>
+                    <span
+                      [ngbTooltip]="'MaxRating' | translate"
+                      class="badge bg-{{ contestsRating.maxRating | contestsRatingColor }}-transparent">
+                      <contests-rating-image [size]="16" [title]="contestsRating.maxRatingTitle"></contests-rating-image>
+                      {{ contestsRating.maxRating }}
+                    </span>
+                    <span
+                      [ngbTooltip]="'Contests.Contests' | translate"
+                      class="badge bg-primary-transparent d-flex align-items-center gap-1">
+                      <kep-icon name="contest" size="small-4"></kep-icon>
+                      {{ contestsRating.contestantsCount }}
+                    </span>
+                  </div>
+                </div>
+              </kep-card>
+            </div>
+          }
+        </div>
+      }
+
+      @if (total) {
+        <div class="d-flex justify-content-center">
+          <kep-pagination
+            (pageChange)="pageChange($event)"
+            (pageSizeChange)="pageSizeChange($event)"
+            [collectionSize]="total"
+            [maxSize]="maxSize"
+            [page]="pageNumber"
+            [pageOptions]="pageOptions"
+            [pageSize]="pageSize"
+            [disabled]="isLoading"
+            [rotate]="true">
+          </kep-pagination>
+        </div>
+      }
     </section>
   </div>
 </div>

--- a/src/app/modules/contests/pages/rating/rating.component.ts
+++ b/src/app/modules/contests/pages/rating/rating.component.ts
@@ -6,11 +6,13 @@ import { Observable } from 'rxjs';
 import { PageResult } from '@core/common/classes/page-result';
 import { CoreCommonModule } from '@core/common.module';
 import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
-import { KepTableComponent } from '@shared/components/kep-table/kep-table.component';
 import { ContestantViewModule } from '@contests/components/contestant-view/contestant-view.module';
 import { KepPaginationComponent } from '@shared/components/kep-pagination/kep-pagination.component';
 import { ContestsRating } from '@contests/models/contests-rating';
 import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { TableOrderingModule } from '@shared/components/table-ordering/table-ordering.module';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
 
 @Component({
   selector: 'app-rating',
@@ -20,16 +22,26 @@ import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
   imports: [
     CoreCommonModule,
     ContentHeaderModule,
-    KepTableComponent,
     ContestantViewModule,
     KepPaginationComponent,
     NgbTooltip,
+    TableOrderingModule,
+    KepCardComponent,
+    SpinnerComponent,
   ]
 })
 export class RatingComponent extends BaseTablePageComponent<ContestsRating> implements OnInit {
   override maxSize = 5;
-  override defaultPageSize = 20;
-  override pageOptions = [10, 20, 50];
+  override defaultPageSize = 12;
+  override pageOptions = [12, 24, 36];
+  override defaultOrdering = '-rating';
+
+  public readonly orderingOptions = ['rating', 'maxRating', 'contestantsCount'] as const;
+  public readonly orderingLabels: Record<(typeof this.orderingOptions)[number], string> = {
+    rating: 'Rating',
+    maxRating: 'MaxRating',
+    contestantsCount: 'Contests.Contests',
+  };
 
   constructor(
     public service: ContestsService,
@@ -41,16 +53,12 @@ export class RatingComponent extends BaseTablePageComponent<ContestsRating> impl
     return this.pageResult?.data;
   }
 
-  ngOnInit(): void {
-    this.loadContentHeader();
-    setTimeout(() => this.reloadPage());
+  getPage(): Observable<PageResult<ContestsRating>> | null {
+    return this.service.getContestsRating(this.pageable);
   }
 
-  getPage(): Observable<PageResult<ContestsRating>> | null {
-    return this.service.getContestsRating({
-      page: this.pageNumber,
-      pageSize: this.pageSize,
-    });
+  isOrderingActive(orderingKey: string) {
+    return this.ordering === orderingKey || this.ordering === `-${orderingKey}`;
   }
 
   protected getContentHeader(): ContentHeader {


### PR DESCRIPTION
## Summary
- restyle the contests rating page to use responsive cards instead of the table
- expose ordering controls for rating, max rating and contest count with translated labels
- pass ordering to the API and surface rating, max rating and contest count badges on each card

## Testing
- npm run lint *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68d199692268832fbc7fe8e1821c3884