### PR TITLE
Refactor contest tab status checks to use enum

### DIFF
--- a/src/app/modules/contests/pages/contest/contest-tab/contest-tab.component.html
+++ b/src/app/modules/contests/pages/contest/contest-tab/contest-tab.component.html
@@ -8,7 +8,7 @@
       <ng-template ngbNavContent>
       </ng-template>
     </li>
-    @if (contest?.status == -1) {
+    @if (contest?.status === ContestStatus.NOT_STARTED) {
       <li ngbNavItem>
         <a class="nav-link" [routerLink]="Resources.ContestRegistrants | resourceById:contest?.id"
            [routerLinkActiveOptions]="{exact: true}" routerLinkActive="active">
@@ -18,7 +18,7 @@
         </ng-template>
       </li>
     }
-    @if (contest?.status != -1) {
+    @if (contest?.status !== ContestStatus.NOT_STARTED) {
       <li ngbNavItem>
         <a class="nav-link" [routerLink]="Resources.ContestProblems | resourceById:contest?.id"
            routerLinkActive="active">
@@ -28,7 +28,7 @@
         </ng-template>
       </li>
     }
-    @if (contest?.status != -1) {
+    @if (contest?.status !== ContestStatus.NOT_STARTED) {
       <li ngbNavItem>
         <a class="nav-link" [routerLink]="Resources.ContestAttempts | resourceById:contest?.id"
            routerLinkActive="active">
@@ -38,7 +38,7 @@
         </ng-template>
       </li>
     }
-    @if (contest?.status != -1) {
+    @if (contest?.status !== ContestStatus.NOT_STARTED) {
       <li ngbNavItem>
         <a class="nav-link" [routerLink]="Resources.ContestStandings | resourceById:contest?.id"
            routerLinkActive="active">
@@ -48,7 +48,7 @@
         </ng-template>
       </li>
     }
-    @if (contest?.status == 1 && contest?.isRated) {
+    @if (contest?.status === ContestStatus.FINISHED && contest?.isRated) {
       <li ngbNavItem>
         <a class="nav-link" [routerLink]="Resources.ContestRatingChanges | resourceById:contest?.id"
            routerLinkActive="active">
@@ -58,7 +58,7 @@
         </ng-template>
       </li>
     }
-    @if (contest?.status != -1) {
+    @if (contest?.status !== ContestStatus.NOT_STARTED) {
       <li ngbNavItem>
         <a class="nav-link" [routerLink]="Resources.ContestStatistics | resourceById:contest?.id"
            routerLinkActive="active">
@@ -68,7 +68,7 @@
         </ng-template>
       </li>
     }
-    @if (contest?.status != -1) {
+    @if (contest?.status !== ContestStatus.NOT_STARTED) {
       <li ngbNavItem>
         <a class="nav-link" [routerLink]="Resources.ContestQuestions | resourceById:contest?.id"
            routerLinkActive="active">

--- a/src/app/modules/contests/pages/contest/contest-tab/contest-tab.component.ts
+++ b/src/app/modules/contests/pages/contest/contest-tab/contest-tab.component.ts
@@ -5,6 +5,7 @@ import { Contest } from '@contests/models/contest';
 import { ContestClassesPipe } from '@contests/pipes/contest-classes.pipe';
 import { Resources } from '@app/resources';
 import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
+import { ContestStatus } from '@contests/constants';
 
 @Component({
   selector: 'contest-tab',
@@ -17,4 +18,5 @@ export class ContestTabComponent {
   @Input() contest: Contest;
   public activeId = 1;
   protected readonly Resources = Resources;
+  protected readonly ContestStatus = ContestStatus;
 }


### PR DESCRIPTION
## Summary
- expose the ContestStatus enum to the contest tab component template
- replace contest status magic numbers in the contest tab template with ContestStatus constants

## Testing
- npm run lint *(fails: workspace has no configured lint target)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ade89404832fb68ead1d3bb9fc6c