### PR TITLE
Revamp problems statistics layout

### DIFF
--- a/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.html
+++ b/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.html
@@ -1,109 +1,135 @@
-<div class="card">
+<kep-card [customClass]="'profile-card h-100'">
   <div class="card-body">
-    <div class="section-profile text-center">
-      <div class="avatar p-50 bg-primary">
-        <div class="avatar-content">
-          <i [data-feather]="'problem' | iconName" [size]="20"></i>
+    <div class="profile-card__hero">
+      <div class="profile-card__hero-main">
+        <div class="profile-card__avatar">
+          <i [data-feather]="'problem' | iconName"></i>
+        </div>
+
+        <div class="profile-card__hero-text">
+          <h5 class="profile-card__heading">{{ 'Problems' | translate }}</h5>
+          <p class="profile-card__subtitle">
+            {{ general.solved | number }} {{ 'Solved' | translate }}
+          </p>
+          <a
+            [routerLink]="[Resources.Attempts, username]"
+            class="btn btn-outline-light btn-sm profile-card__attempts"
+          >
+            {{ 'Attempts' | translate }}
+          </a>
         </div>
       </div>
-      <div class="font-medium-5 mt-1">
-        {{ 'Problems' | translate }}
-        <br>
-        <a
-          [routerLink]="[Resources.Attempts, username]"
-          class="btn btn-outline-primary btn-sm mt-1 attempts-link">
-          {{ 'Attempts' | translate }}
-        </a>
-        <div class="font-medium-4 mt-2">
-          <span ngbTooltip="{{ 'Solved' | translate }}">
+
+      <div class="profile-card__metrics">
+        <div class="profile-card__metric" ngbTooltip="{{ 'Solved' | translate }}">
+          <div class="profile-card__metric-icon">
             <i data-feather="check-circle"></i>
-            {{ general.solved }}
-          </span>
+          </div>
+          <div>
+            <div class="profile-card__metric-value">{{ general.solved | number }}</div>
+            <div class="profile-card__metric-label">{{ 'Solved' | translate }}</div>
+          </div>
+        </div>
 
-          <span ngbTooltip="{{ 'Rating' | translate }}">
-            <i [data-feather]="'rating' | iconName" class="ms-1"></i>
-            {{ general.rating }}
-          </span>
+        <div class="profile-card__metric" ngbTooltip="{{ 'Rating' | translate }}">
+          <div class="profile-card__metric-icon">
+            <i data-feather="trending-up"></i>
+          </div>
+          <div>
+            <div class="profile-card__metric-value">{{ general.rating | number }}</div>
+            <div class="profile-card__metric-label">{{ 'Rating' | translate }}</div>
+          </div>
+        </div>
+
+        <div class="profile-card__metric" ngbTooltip="{{ 'Rank' | translate }}">
+          <div class="profile-card__metric-icon">
+            <i data-feather="award"></i>
+          </div>
+          <div>
+            <div class="profile-card__metric-value">#{{ general.rank | number }}</div>
+            <div class="profile-card__metric-label">{{ 'Rank' | translate }}</div>
+            <div class="profile-card__metric-note">
+              {{ general.usersCount | number }} {{ 'Users' | translate }}
+            </div>
+          </div>
         </div>
       </div>
-
-      <div class="font-medium-4 mt-1">
-        <span ngbTooltip="{{ 'Rank' | translate }}">
-          <i [data-feather]="'users'" class="ms-1"></i>
-          <span class="font-medium-3">
-            {{ general.rank }}({{ general.usersCount }})
-          </span>
-        </span>
-      </div>
     </div>
 
-    <hr>
+    <div class="profile-card__content">
+      @if (langs.length) {
+        <div class="profile-card__section profile-card__section--languages">
+          <div class="profile-card__section-header">
+            <span class="profile-card__section-title">{{ 'Languages' | translate }}</span>
+          </div>
 
-    <div class="section-languages">
-      <div class="title">
-        {{ 'Languages' | translate }}
-      </div>
+          <div class="profile-card__language-list">
+            @for (data of langs; track data.lang) {
+              <div class="profile-card__language">
+                <div class="profile-card__language-header">
+                  <span class="profile-card__language-name">{{ data.langFull }}</span>
+                  <span class="profile-card__language-count">x{{ data.solved }}</span>
+                </div>
+                <div class="profile-card__progress">
+                  <div
+                    class="profile-card__progress-bar"
+                    [style.width.%]="getShare(data.solved, langMaxSolved)"
+                  ></div>
+                </div>
+              </div>
+            }
+          </div>
+        </div>
+      }
 
-      <div class="languages">
-        @for (data of langs; track data) {
-          <div class="d-flex language justify-content-between">
-            <div class="lang">
-              <span class="badge badge-{{ data.lang }}">
-                {{ data.langFull }}
+      @if (tags.length) {
+        <div class="profile-card__section profile-card__section--tags">
+          <div class="profile-card__section-header">
+            <span class="profile-card__section-title">{{ 'Tags' | translate }}</span>
+          </div>
+
+          <div class="profile-card__tag-cloud">
+            @for (tag of tags; track tag.name) {
+              <span class="profile-card__tag">
+                <span class="badge bg-light-primary text-primary">{{ tag.name }}</span>
+                <span class="profile-card__tag-count">x{{ tag.value }}</span>
               </span>
-            </div>
-            <div class="result">
-              <strong>x{{ data.solved }}</strong>
-            </div>
+            }
           </div>
-        }
-      </div>
-    </div>
+        </div>
+      }
 
-    <hr>
-
-    <div class="section-tags">
-      <div class="title">
-        {{ 'Tags' | translate }}
-      </div>
-
-      <div class="tags">
-        @for (tag of tags; track tag) {
-          <div class="tag">
-            <span class="badge badge-pill bg-primary">
-              {{ tag.name }}
-            </span>
-            x{{ tag.value }}
+      @if (topics.length) {
+        <div class="profile-card__section profile-card__section--topics">
+          <div class="profile-card__section-header">
+            <span class="profile-card__section-title">{{ 'Topics' | translate }}</span>
           </div>
-        }
-      </div>
-    </div>
 
-    <hr>
-
-    <div class="section-topics">
-      <div class="title">
-        {{ 'Topics' | translate }}
-      </div>
-
-      <div class="topics">
-        @for (topic of topics; track topic) {
-          <div class="topic d-flex justify-content-between">
-            <div class="d-flex topic-info justify-content-start">
-              <div class="topic-icon">
-                <kep-icon [name]="topic.icon"></kep-icon>
+          <div class="profile-card__topic-list">
+            @for (topic of topics; track topic.id) {
+              <div class="profile-card__topic">
+                <div class="profile-card__topic-info">
+                  <div class="profile-card__topic-icon">
+                    <kep-icon [name]="topic.icon"></kep-icon>
+                  </div>
+                  <div>
+                    <div class="profile-card__topic-name">{{ topic.topic }}</div>
+                    <div class="profile-card__topic-solved">
+                      {{ topic.solved | number }} {{ 'Problems' | translate }}
+                    </div>
+                  </div>
+                </div>
+                <div class="profile-card__progress profile-card__progress--topic">
+                  <div
+                    class="profile-card__progress-bar"
+                    [style.width.%]="getShare(topic.solved, topicMaxSolved)"
+                  ></div>
+                </div>
               </div>
-              <div class="topic-title">
-                {{ topic.topic }}
-              </div>
-            </div>
-            <div class="solved">
-              x{{ topic.solved }}
-            </div>
+            }
           </div>
-        }
-      </div>
+        </div>
+      }
     </div>
-
   </div>
-</div>
+</kep-card>

--- a/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.scss
+++ b/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.scss
@@ -1,72 +1,260 @@
-.section-languages {
-  margin-top: 2rem;
+.profile-card {
+  position: relative;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 
-  .title {
-    font-size: 1.2rem;
-    font-weight: 600;
-  }
-
-  .languages {
-    margin-top: 1rem;
-
-    .language {
-      margin-bottom: 0.5rem;
-    }
-  }
-}
-
-.section-tags {
-  margin-top: 1rem;
-
-  .title {
-    font-size: 1.2rem;
-    font-weight: 600;
-  }
-
-  .tags {
-    margin-top: 1rem;
+  .card-body {
+    padding: 0;
     display: flex;
-    flex-wrap: wrap;
-
-    .tag {
-      display: inline-block;
-      margin-top: 0.5rem;
-      margin-right: 0.5rem;
-    }
+    flex-direction: column;
+    height: 100%;
   }
 }
 
-.section-topics {
-  margin-top: 1rem;
+.profile-card__hero {
+  padding: 1.5rem;
+  background: linear-gradient(135deg, rgba(var(--bs-primary-rgb), 0.95), rgba(93, 99, 247, 0.95));
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
 
-  .title {
-    font-size: 1.2rem;
-    font-weight: 600;
+@media (min-width: 576px) {
+  .profile-card__hero {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
+}
 
-  .topics {
-    margin-top: 1rem;
+.profile-card__hero-main {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
 
-    .topic {
-      margin-bottom: 0.2rem;
+.profile-card__avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.16);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
 
-      .topic-info {
-        align-items: center;
-      }
+.profile-card__avatar i {
+  width: 28px;
+  height: 28px;
+  color: #fff;
+}
 
-      .topic-title {
-        font-weight: 500;
-        margin-left: 0.5rem;
-      }
+.profile-card__hero-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
 
-      .topic-image {
-        width: 48px;
+.profile-card__heading {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #fff;
+}
 
-        img {
-          width: 100%;
-          object-fit: contain;
-        }
-      }
-    }
+.profile-card__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.profile-card__attempts {
+  align-self: flex-start;
+  border-color: rgba(255, 255, 255, 0.65);
+  color: #fff;
+}
+
+.profile-card__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+@media (max-width: 575.98px) {
+  .profile-card__metrics {
+    padding-top: 0.25rem;
   }
+}
+
+.profile-card__metric {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.16);
+  border-radius: 1rem;
+  min-width: 160px;
+  flex: 1 1 160px;
+}
+
+.profile-card__metric-icon i {
+  width: 22px;
+  height: 22px;
+  color: #fff;
+}
+
+.profile-card__metric-value {
+  font-weight: 600;
+  font-size: 1.2rem;
+  color: #fff;
+  line-height: 1.1;
+}
+
+.profile-card__metric-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.profile-card__metric-note {
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.profile-card__content {
+  padding: 1.75rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  flex: 1 1 auto;
+}
+
+.profile-card__section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profile-card__section + .profile-card__section {
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(var(--bs-body-color-rgb, 73, 80, 87), 0.12);
+}
+
+.profile-card__section-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--bs-heading-color, var(--bs-body-color));
+}
+
+.profile-card__language-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.profile-card__language-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 500;
+  color: var(--bs-body-color);
+}
+
+.profile-card__language-name {
+  font-size: 0.95rem;
+}
+
+.profile-card__language-count {
+  font-weight: 600;
+  color: var(--bs-primary);
+}
+
+.profile-card__progress {
+  height: 6px;
+  background-color: rgba(var(--bs-primary-rgb), 0.12);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.profile-card__progress-bar {
+  height: 100%;
+  background: linear-gradient(135deg, var(--bs-primary), rgba(var(--bs-primary-rgb), 0.65));
+  border-radius: inherit;
+  transition: width 0.3s ease;
+}
+
+.profile-card__progress--topic {
+  background-color: rgba(var(--bs-success-rgb, 25, 135, 84), 0.16);
+}
+
+.profile-card__progress--topic .profile-card__progress-bar {
+  background: linear-gradient(135deg, var(--bs-success, #28a745), rgba(var(--bs-success-rgb, 25, 135, 84), 0.75));
+}
+
+.profile-card__tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.profile-card__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.profile-card__tag-count {
+  font-weight: 500;
+  color: var(--bs-body-color);
+}
+
+.profile-card__topic-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profile-card__topic {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.profile-card__topic-info {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.profile-card__topic-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(var(--bs-primary-rgb), 0.12);
+  color: var(--bs-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.profile-card__topic-icon kep-icon,
+.profile-card__topic-icon span {
+  font-size: 1.1rem;
+}
+
+.profile-card__topic-name {
+  font-weight: 600;
+  color: var(--bs-body-color);
+}
+
+.profile-card__topic-solved {
+  font-size: 0.85rem;
+  color: var(--bs-secondary-color, #6c757d);
 }

--- a/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.ts
+++ b/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.ts
@@ -3,6 +3,7 @@ import { AuthService } from '@auth';
 import { ProblemsStatisticsService } from '@problems/services/problems-statistics.service';
 import { CoreCommonModule } from '@core/common.module';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 import { GeneralInfo } from '@problems/models/statistics.models';
 import { getCategoryIcon } from '@problems/utils/category';
 import { Resources } from "@app/resources";
@@ -34,6 +35,7 @@ interface TopicInfo {
   imports: [
     CoreCommonModule,
     NgbTooltipModule,
+    KepCardComponent,
   ]
 })
 export class SectionProfileComponent implements OnInit {
@@ -52,6 +54,8 @@ export class SectionProfileComponent implements OnInit {
   public langs: Array<LangInfo> = [];
   public tags: Array<TagInfo> = [];
   public topics: Array<TopicInfo> = [];
+  public langMaxSolved = 0;
+  public topicMaxSolved = 0;
 
   constructor(
     public authService: AuthService,
@@ -69,23 +73,45 @@ export class SectionProfileComponent implements OnInit {
     this.statisticsService.getByLang(this.username).subscribe(
       (langs: Array<LangInfo>) => {
         this.langs = langs.sort((a, b) => b.solved - a.solved);
+        this.langMaxSolved = this.langs.reduce(
+          (max, lang) => lang.solved > max ? lang.solved : max,
+          0,
+        );
       }
     );
 
     this.statisticsService.getByTag(this.username).subscribe(
       (tags: Array<TagInfo>) => {
-        this.tags = tags.sort((a, b) => b.value - a.value);
+        this.tags = tags
+          .sort((a, b) => b.value - a.value)
+          .slice(0, 18);
       }
     );
 
     this.statisticsService.getByTopic(this.username).subscribe(
       (topics: Array<TopicInfo>) => {
-        this.topics = topics.map((topic) => {
-          topic.icon = getCategoryIcon(topic.id);
-          return topic;
-        });
+        this.topics = topics
+          .map((topic) => {
+            topic.icon = getCategoryIcon(topic.id);
+            return topic;
+          })
+          .sort((a, b) => b.solved - a.solved);
+
+        this.topicMaxSolved = this.topics.reduce(
+          (max, topic) => topic.solved > max ? topic.solved : max,
+          0,
+        );
       }
     );
   }
 
+  public getShare(value: number, max: number): number {
+    if (!max || !value) {
+      return 0;
+    }
+
+    const percent = Math.round((value / max) * 100);
+
+    return Math.min(100, percent);
+  }
 }

--- a/src/app/modules/problems/pages/statistics/statistics.component.html
+++ b/src/app/modules/problems/pages/statistics/statistics.component.html
@@ -1,32 +1,41 @@
 @if (username) {
   <div class="content-wrapper container-xxl p-0">
     <div class="content-body">
-      <section class="mt-2">
-        <div class="row">
-          <div class="col-lg-3 col-md-6 col-sm-12">
+      <section class="problems-statistics mt-2">
+        <div class="row g-3 align-items-stretch">
+          <div class="col-xl-4 col-lg-5 col-12">
             <section-profile [username]="username"></section-profile>
           </div>
-          <div class="col-lg-9 col-md-6 col-sm-12">
-            <div class="row">
-              <div class="col-lg-6 col-12">
+
+          <div class="col-xl-8 col-lg-7 col-12">
+            <div class="row g-3 align-items-stretch">
+              <div class="col-md-6 col-12">
                 <section-difficulties [username]="username"></section-difficulties>
               </div>
-              <div class="col-lg-6 col-12">
+              <div class="col-md-6 col-12">
                 <section-activity [username]="username"></section-activity>
               </div>
               <div class="col-12">
                 <section-heatmap [username]="username"></section-heatmap>
               </div>
-              <div class="col-lg-6 col-12">
-                <section-facts [username]="username"></section-facts>
-              </div>
-              <div class="col-lg-6 col-12">
+            </div>
+          </div>
+        </div>
+
+        <div class="row g-3 align-items-stretch">
+          <div class="col-xl-8 col-lg-7 col-12">
+            <div class="row g-3 align-items-stretch">
+              <div class="col-md-6 col-12">
                 <section-attempts-for-solve [username]="username"></section-attempts-for-solve>
               </div>
-              <div class="col-12">
+              <div class="col-md-6 col-12">
                 <section-time [username]="username"></section-time>
               </div>
             </div>
+          </div>
+
+          <div class="col-xl-4 col-lg-5 col-12">
+            <section-facts [username]="username"></section-facts>
           </div>
         </div>
       </section>

--- a/src/app/modules/problems/pages/statistics/statistics.component.scss
+++ b/src/app/modules/problems/pages/statistics/statistics.component.scss
@@ -1,0 +1,20 @@
+:host {
+  .problems-statistics {
+    display: flex;
+    flex-direction: column;
+
+    > .row + .row {
+      margin-top: 1.5rem;
+    }
+
+    .row .row {
+      margin-top: 0;
+    }
+  }
+
+  @media (max-width: 991.98px) {
+    .problems-statistics > .row + .row {
+      margin-top: 1.25rem;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the problems statistics page layout with balanced columns and spacing
- rebuild the profile summary card with a gradient hero, overview metrics, and modernised language/tag/topic sections
- enhance statistics styling and data helpers for richer visualisation (progress bars, sorted data, limited tag cloud)

## Testing
- `npm run lint` *(fails: no lint target configured; Angular CLI suggests adding ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bb6d3fc4832f96a58c148c68688b