### PR TITLE
Refactor challenges rating list into card layout

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -230,6 +230,7 @@ export const localeEn = {
   AwaitingConfirmation: 'Awaiting confirmation',
   Confirm: 'Confirm',
   NoDuelsYet: 'No duels yet',
+  NoChallengesYet: 'No challenges yet',
   SelectDuelPreset: 'Select duel preset',
   SelectDuelPresetDescription: 'Choose a preset and start time to challenge {{ username }}.',
   FieldRequired: 'This field is required',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -229,6 +229,7 @@ export const localeRu = {
   AwaitingConfirmation: 'Ожидает подтверждения',
   Confirm: 'Подтвердить',
   NoDuelsYet: 'Пока нет дуэлей',
+  NoChallengesYet: 'Пока нет челленджей',
   SelectDuelPreset: 'Выберите пресет дуэли',
   SelectDuelPresetDescription: 'Выберите пресет и время начала, чтобы вызвать {{ username }}.',
   FieldRequired: 'Это поле обязательно',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -230,6 +230,7 @@ export const localeUz = {
   AwaitingConfirmation: 'Tasdiqlash kutilmoqda',
   Confirm: 'Tasdiqlash',
   NoDuelsYet: 'Hozircha duellar yo\'q',
+  NoChallengesYet: 'Hozircha bellashuvlar yo\'q',
   SelectDuelPreset: 'Duel presetini tanlang',
   SelectDuelPresetDescription: '{{ username }} ni chaqirish uchun preset va boshlanish vaqtini tanlang.',
   FieldRequired: 'Bu maydon majburiy',

--- a/src/app/modules/challenges/pages/challenges-rating/challenges-rating.component.html
+++ b/src/app/modules/challenges/pages/challenges-rating/challenges-rating.component.html
@@ -2,71 +2,116 @@
   <div class="content-body">
     <app-content-header [contentHeader]="contentHeader"/>
 
-    <section class="mt-2">
-      <kep-table [loading]="isLoading" [empty]="pageResult?.total === 0">
-        <ng-container header>
-          <tr>
-            <th>#</th>
-            <th>{{ 'User' | translate }}</th>
-            <th>
-              <table-ordering
-                [value]="ordering"
-                [justifyContent]="'start'"
-                [ordering]="'wins'"
-                [reverse]="true"
-                (change)="orderingChange($event)">
-                {{ 'Wins' | translate }}
-              </table-ordering>
-            </th>
-            <th>
-              <table-ordering
-                [value]="ordering"
-                [justifyContent]="'start'"
-                [ordering]="'draws'"
-                [reverse]="true"
-                (change)="orderingChange($event)">
-                {{ 'Draws' | translate }}
-              </table-ordering>
-            </th>
-            <th>
-              <table-ordering
-                [value]="ordering"
-                [justifyContent]="'start'"
-                [ordering]="'losses'"
-                [reverse]="true"
-                (change)="orderingChange($event)">
-                {{ 'Losses' | translate }}
-              </table-ordering>
-            </th>
-            <th>
-              <table-ordering
-                [value]="ordering"
-                [justifyContent]="'start'"
-                [ordering]="'rating'"
-                [reverse]="false"
-                (change)="orderingChange($event)">
-                <i data-feather="bar-chart"></i>
-              </table-ordering>
-            </th>
-          </tr>
-        </ng-container>
-        <ng-container body>
+    <section class="mt-2 d-flex flex-column gap-3">
+      <div class="d-flex flex-wrap justify-content-between align-items-center gap-2">
+        <div class="d-flex flex-wrap gap-2">
+          <table-ordering
+            [value]="ordering"
+            [justifyContent]="'start'"
+            [ordering]="'wins'"
+            [reverse]="true"
+            (change)="orderingChange($event)">
+            <span
+              class="btn btn-sm"
+              [ngClass]="(ordering === 'wins' || ordering === '-wins') ? 'btn-primary' : 'btn-outline-primary'">
+              {{ 'Wins' | translate }}
+            </span>
+          </table-ordering>
+          <table-ordering
+            [value]="ordering"
+            [justifyContent]="'start'"
+            [ordering]="'draws'"
+            [reverse]="true"
+            (change)="orderingChange($event)">
+            <span
+              class="btn btn-sm"
+              [ngClass]="(ordering === 'draws' || ordering === '-draws') ? 'btn-primary' : 'btn-outline-primary'">
+              {{ 'Draws' | translate }}
+            </span>
+          </table-ordering>
+          <table-ordering
+            [value]="ordering"
+            [justifyContent]="'start'"
+            [ordering]="'losses'"
+            [reverse]="true"
+            (change)="orderingChange($event)">
+            <span
+              class="btn btn-sm"
+              [ngClass]="(ordering === 'losses' || ordering === '-losses') ? 'btn-primary' : 'btn-outline-primary'">
+              {{ 'Losses' | translate }}
+            </span>
+          </table-ordering>
+          <table-ordering
+            [value]="ordering"
+            [justifyContent]="'start'"
+            [ordering]="'rating'"
+            [reverse]="false"
+            (change)="orderingChange($event)">
+            <span
+              class="btn btn-sm"
+              [ngClass]="(ordering === 'rating' || ordering === '-rating') ? 'btn-primary' : 'btn-outline-primary'">
+              <i data-feather="bar-chart"></i>
+            </span>
+          </table-ordering>
+        </div>
+
+        @if (!isLoading && total) {
+          <span class="text-muted small">{{ total }} {{ 'Users' | translate }}</span>
+        }
+      </div>
+
+      @if (isLoading) {
+        <kep-card>
+          <div class="card-body d-flex justify-content-center py-5">
+            <spinner></spinner>
+          </div>
+        </kep-card>
+      } @else if (pageResult?.total === 0) {
+        <kep-card>
+          <div class="card-body text-center py-5">
+            <div class="text-muted">{{ 'NoChallengesYet' | translate }}</div>
+          </div>
+        </kep-card>
+      } @else {
+        <div class="row g-3">
           @for (challengesRating of challengesRatingList; track challengesRating.username) {
-            <tr>
-              <td class="fw-medium">{{ challengesRating.rowIndex }}</td>
-              <td>
-                <challenges-user-view [user]="challengesRating"></challenges-user-view>
-              </td>
-              <td><span class="badge bg-success-transparent">{{ challengesRating.wins }}</span></td>
-              <td><span class="badge bg-secondary-transparent">{{ challengesRating.draws }}</span></td>
-              <td><span class="badge bg-danger-transparent">{{ challengesRating.losses }}</span></td>
-              <td>
-                <span class="badge bg-{{ challengesRating.rankTitle | challengesRankColor }}">{{ challengesRating.rating }}</span>
-              </td>
-            </tr>
+            <div class="col-12 col-md-6 col-xl-4">
+              <kep-card customClass="h-100">
+                <div class="card-body d-flex flex-column gap-3">
+                  <div class="d-flex align-items-center gap-3 flex-wrap">
+                    <span class="badge bg-primary fw-semibold text-white px-3 py-2 fs-6">{{ challengesRating.rowIndex }}</span>
+                    <challenges-user-view
+                      [user]="challengesRating"
+                      [withRating]="true"
+                      [light]="false"></challenges-user-view>
+                  </div>
+                  <div class="d-flex flex-wrap gap-3 fs-6">
+                    <div class="text-success fw-semibold d-flex align-items-center gap-1">
+                      {{ challengesRating.wins }}
+                      <span [ngbTooltip]="'Wins' | translate">W</span>
+                    </div>
+                    <div class="text-info fw-semibold d-flex align-items-center gap-1">
+                      {{ challengesRating.draws }}
+                      <span [ngbTooltip]="'Draws' | translate">D</span>
+                    </div>
+                    <div class="text-danger fw-semibold d-flex align-items-center gap-1">
+                      {{ challengesRating.losses }}
+                      <span [ngbTooltip]="'Losses' | translate">L</span>
+                    </div>
+                    <div class="text-muted fw-semibold d-flex align-items-center gap-1">
+                      {{ challengesRating.all }}
+                      <span [ngbTooltip]="'Challenges' | translate">Σ</span>
+                    </div>
+                  </div>
+                </div>
+              </kep-card>
+            </div>
           }
-        </ng-container>
-        <ng-container pagination>
+        </div>
+      }
+
+      @if (total) {
+        <div class="d-flex justify-content-center">
           <kep-pagination
             [collectionSize]="total"
             [page]="pageNumber"
@@ -76,8 +121,8 @@
             [disabled]="isLoading"
             (pageChange)="pageChange($event)">
           </kep-pagination>
-        </ng-container>
-      </kep-table>
+        </div>
+      }
     </section>
   </div>
 </div>

--- a/src/app/modules/challenges/pages/challenges-rating/challenges-rating.component.ts
+++ b/src/app/modules/challenges/pages/challenges-rating/challenges-rating.component.ts
@@ -6,11 +6,12 @@ import { Observable } from 'rxjs';
 import { CoreCommonModule } from '@core/common.module';
 import { KepPaginationComponent } from '@shared/components/kep-pagination/kep-pagination.component';
 import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
-import { KepTableComponent } from '@shared/components/kep-table/kep-table.component';
 import { TableOrderingModule } from '@shared/components/table-ordering/table-ordering.module';
 import {
   ChallengesUserViewComponent
 } from '@challenges/components/challenges-user-view/challenges-user-view.component';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { ChallengesRating } from '@challenges/interfaces/challenges-rating';
 
 @Component({
@@ -23,12 +24,14 @@ import { ChallengesRating } from '@challenges/interfaces/challenges-rating';
     ChallengesUserViewComponent,
     KepPaginationComponent,
     ContentHeaderModule,
-    KepTableComponent,
     TableOrderingModule,
+    KepCardComponent,
+    NgbTooltip,
   ]
 })
 export class ChallengesRatingComponent extends BaseTablePageComponent<ChallengesRating> implements OnInit {
-  override defaultPageSize = 20;
+  override defaultPageSize = 12;
+  override pageOptions = [6, 9, 12, 24];
   override maxSize = 5;
 
   override defaultOrdering = '-rating';
@@ -38,7 +41,7 @@ export class ChallengesRatingComponent extends BaseTablePageComponent<Challenges
   }
 
   get challengesRatingList() {
-    return this.pageResult?.data;
+    return this.pageResult?.data ?? [];
   }
 
   ngOnInit() {


### PR DESCRIPTION
## Summary
- replace the challenges rating table with a responsive card grid similar to the duels rating page
- add win/draw/loss/all statistics with tooltips inside each card and expose user information through the existing view component
- introduce a NoChallengesYet translation string in all supported locales

## Testing
- `npm run lint` *(fails: ng CLI not available in PATH)*
- `npx ng lint` *(fails: npm could not determine executable)*
- `node ./node_modules/@angular/cli/bin/ng lint` *(fails: Angular CLI package not installed because npm install is blocked by peer dependency conflicts)*
- `npm install` *(fails: dependency resolution conflict between @fullcalendar/angular and Angular 19 packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d1be137324832f884c9413008eeeb6