### PR TITLE
Revamp problems statistics page with new unified API

### DIFF
--- a/src/app/modules/problems/components/problems-activity-card/problems-activity-card.component.html
+++ b/src/app/modules/problems/components/problems-activity-card/problems-activity-card.component.html
@@ -1,48 +1,47 @@
-<kep-card>
-  @if (isLoading) {
-    <div [style.height.px]="200">
-      <spinner></spinner>
-    </div>
-  } @else {
-    <div class="card-header">
-      <div class="card-title">
-        {{ 'Activity' | translate }}
+<kep-card customClass="statistics-activity">
+  <div class="statistics-activity__header">
+    <div class="statistics-activity__title">
+      <div class="statistics-activity__icon">
+        <kep-icon name="activity"></kep-icon>
       </div>
-      <div role="group" aria-label="Basic radio toggle button group" class="btn-group">
-        <input [(ngModel)]="activityDays" (click)="activityDataUpdate(7)"  [value]="7" type="radio" name="btnradio" id="btnradio1" checked="" class="btn-check">
-        <label for="btnradio1" class="btn btn-outline-primary">7</label>
-        <input [(ngModel)]="activityDays" (click)="activityDataUpdate(14)"  [value]="14" type="radio" name="btnradio" id="btnradio2" class="btn-check">
-        <label for="btnradio2" class="btn btn-outline-primary">14</label>
-        <input [(ngModel)]="activityDays" (click)="activityDataUpdate(30)"  [value]="30" type="radio" name="btnradio" id="btnradio3" class="btn-check">
-        <label for="btnradio3" class="btn btn-outline-primary">30</label>
+      <div>
+        <div class="statistics-activity__label">{{ 'RecentActivity' | translate }}</div>
+        <div class="statistics-activity__sub">{{ 'Problems' | translate }}</div>
       </div>
     </div>
+    @if (daysOptions?.length) {
+      <div class="statistics-activity__filters">
+        @for (day of daysOptions; track day) {
+          <button
+            type="button"
+            class="btn btn-sm"
+            [class.btn-primary]="day === selectedDays"
+            [class.btn-outline-primary]="day !== selectedDays"
+            (click)="onSelectDays(day)"
+          >
+            {{ day }}
+          </button>
+        }
+      </div>
+    }
+  </div>
 
-    <div class="card-body">
-      <div class="mt-2">
-        <div class="row">
-          <div [ngClass]="{
-          'col-6': activitySolved > 0,
-          'col-12': activitySolved == 0
-        }">
-            <div class="text-center">
-              <div class="avatar bg-primary-transparent p-50 m-0 mb-1">
-                <div class="avatar-content">
-                  <kep-icon class="font-medium-3" name="check-circle"></kep-icon>
-                </div>
-              </div>
-              <h2 class="text-dark">{{ activitySolved }}</h2>
-              <p class="font-medium-1 mb-2">{{ 'Problems' | translate }}</p>
-            </div>
-          </div>
-
-          <div class="col-6">
-            @if (activityChart && activitySolved > 0) {
-              <apex-chart [options]="activityChart"/>
-            }
-          </div>
-        </div>
+  <div class="statistics-activity__body">
+    @if (isLoading) {
+      <div class="statistics-activity__loading">
+        <spinner></spinner>
       </div>
-    </div>
-  }
+    } @else {
+      <div class="statistics-activity__overview">
+        <div class="statistics-activity__count">{{ activitySolved }}</div>
+        <div class="statistics-activity__hint">{{ 'Solved' | translate }}</div>
+      </div>
+      <div class="statistics-activity__chart" *ngIf="activityChart && hasActivity">
+        <apex-chart [options]="activityChart"></apex-chart>
+      </div>
+      @if (!hasActivity) {
+        <div class="statistics-activity__empty">{{ 'NoActivity' | translate }}</div>
+      }
+    }
+  </div>
 </kep-card>

--- a/src/app/modules/problems/components/problems-activity-card/problems-activity-card.component.scss
+++ b/src/app/modules/problems/components/problems-activity-card/problems-activity-card.component.scss
@@ -1,0 +1,99 @@
+.statistics-activity {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  &__icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 0.75rem;
+    background: rgba(115, 103, 240, 0.12);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--bs-primary);
+  }
+
+  &__label {
+    font-weight: 600;
+    font-size: 1.05rem;
+  }
+
+  &__sub {
+    font-size: 0.85rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__filters {
+    display: flex;
+    gap: 0.5rem;
+  }
+
+  &__body {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    gap: 1.5rem;
+    align-items: center;
+  }
+
+  &__overview {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+
+  &__count {
+    font-size: 2.75rem;
+    font-weight: 700;
+  }
+
+  &__hint {
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__chart {
+    min-height: 140px;
+  }
+
+  &__loading {
+    grid-column: 1 / -1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 160px;
+  }
+
+  &__empty {
+    grid-column: 1 / -1;
+    color: var(--bs-secondary-color);
+    font-size: 0.95rem;
+  }
+
+  @media (max-width: 768px) {
+    &__body {
+      grid-template-columns: 1fr;
+    }
+
+    &__overview {
+      flex-direction: row;
+      align-items: center;
+      gap: 0.75rem;
+    }
+  }
+}

--- a/src/app/modules/problems/models/statistics.models.ts
+++ b/src/app/modules/problems/models/statistics.models.ts
@@ -4,3 +4,122 @@ export interface GeneralInfo {
   rank: number;
   usersCount: number;
 }
+
+export interface LangInfo {
+  lang: string;
+  langFull: string;
+  solved: number;
+}
+
+export interface TagInfo {
+  name: string;
+  value: number;
+}
+
+export interface TopicInfo {
+  topic: string;
+  solved: number;
+  code: string;
+  id: number;
+  icon?: string;
+}
+
+export interface Difficulties {
+  beginner: number;
+  allBeginner: number;
+  basic: number;
+  allBasic: number;
+  normal: number;
+  allNormal: number;
+  medium: number;
+  allMedium: number;
+  advanced: number;
+  allAdvanced: number;
+  hard: number;
+  allHard: number;
+  extremal: number;
+  allExtremal: number;
+  totalSolved: number;
+  totalProblems: number;
+}
+
+export interface AttemptFact {
+  problemId: number;
+  problemTitle: string;
+  datetime: string;
+  verdict?: number;
+  verdictTitle?: string;
+  testCaseNumber?: number;
+  attemptsCount?: number;
+}
+
+export interface Facts {
+  firstAttempt: AttemptFact | null;
+  lastAttempt: AttemptFact | null;
+  firstAccepted: AttemptFact | null;
+  lastAccepted: AttemptFact | null;
+  mostAttemptedProblem: AttemptFact | null;
+  mostAttemptedForSolveProblem: AttemptFact | null;
+  solvedWithSingleAttempt: number;
+  solvedWithSingleAttemptPercentage: number;
+}
+
+export interface WeekdaySolved {
+  day: string;
+  solved: number;
+}
+
+export interface MonthSolved {
+  month: string;
+  solved: number;
+}
+
+export interface PeriodSolved {
+  period: string;
+  solved: number;
+}
+
+export interface LastDays {
+  series: number[];
+  solved: number;
+}
+
+export interface HeatmapEntry {
+  date: string;
+  solved: number;
+}
+
+export interface NumberOfAttemptsPoint {
+  attemptsCount: number;
+  value: number;
+}
+
+export interface NumberOfAttempts {
+  chartSeries: NumberOfAttemptsPoint[];
+}
+
+export interface ProblemsStatisticsMeta {
+  lastDays: number;
+  allowedLastDays: number[];
+  heatmapRange?: {
+    from: string;
+    to: string;
+  };
+}
+
+export interface ProblemsStatistics {
+  general: GeneralInfo;
+  byDifficulty: Difficulties;
+  byTopic: TopicInfo[];
+  facts: Facts;
+  byLang: LangInfo[];
+  byWeekday: WeekdaySolved[];
+  byMonth: MonthSolved[];
+  byPeriod: PeriodSolved[];
+  byTag: TagInfo[];
+  byVerdict?: any;
+  lastDays: LastDays;
+  heatmap: HeatmapEntry[];
+  numberOfAttempts: NumberOfAttempts;
+  meta: ProblemsStatisticsMeta;
+}

--- a/src/app/modules/problems/pages/statistics/section-attempts-for-solve/section-attempts-for-solve.component.html
+++ b/src/app/modules/problems/pages/statistics/section-attempts-for-solve/section-attempts-for-solve.component.html
@@ -1,14 +1,13 @@
-<div class="card">
-  <div
-    class="card-header d-flex flex-sm-row flex-column justify-content-md-between align-items-start justify-content-start">
-    <h4 class="card-title mb-sm-0 mb-1">{{ 'NumberAttemptsSolve' | translate }}</h4>
+<kep-card class="statistics-attempts">
+  <div class="statistics-attempts__header">
+    <div class="statistics-attempts__title">{{ 'NumberAttemptsSolve' | translate }}</div>
+    <div class="statistics-attempts__subtitle">{{ 'AttemptsDistribution' | translate }}</div>
   </div>
-  <div class="card-body">
-    @if (numberOfAttemptsForSolve) {
-      <div>
-        <apex-chart [options]="numberOfAttemptsForSolveChart">
-        </apex-chart>
-      </div>
+  <div class="statistics-attempts__body">
+    @if (numberOfAttemptsForSolveChart) {
+      <apex-chart [options]="numberOfAttemptsForSolveChart"></apex-chart>
+    } @else {
+      <div class="statistics-attempts__empty">{{ 'NoData' | translate }}</div>
     }
   </div>
-</div>
+</kep-card>

--- a/src/app/modules/problems/pages/statistics/section-attempts-for-solve/section-attempts-for-solve.component.scss
+++ b/src/app/modules/problems/pages/statistics/section-attempts-for-solve/section-attempts-for-solve.component.scss
@@ -1,3 +1,32 @@
-.card {
-  height: 410px;
+.statistics-attempts {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__title {
+    font-weight: 600;
+    font-size: 1.1rem;
+  }
+
+  &__subtitle {
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__body {
+    min-height: 320px;
+  }
+
+  &__empty {
+    color: var(--bs-secondary-color);
+    text-align: center;
+    margin-top: 2rem;
+  }
 }

--- a/src/app/modules/problems/pages/statistics/section-difficulties/section-difficulties.component.html
+++ b/src/app/modules/problems/pages/statistics/section-difficulties/section-difficulties.component.html
@@ -1,155 +1,31 @@
-<kep-card>
-  <div class="card-header">
-    <div class="card-title">
-      {{ 'Solved' | translate }}
-    </div>
+<kep-card customClass="statistics-difficulties">
+  <div class="statistics-difficulties__header">
+    <div class="statistics-difficulties__title">{{ 'DifficultyBreakdown' | translate }}</div>
+    <div class="statistics-difficulties__subtitle">{{ 'Solved' | translate }} · {{ completionRate }}%</div>
   </div>
-
-  <div class="card-body">
-    <div class="total">
-      <div class="chart">
-        @if (chartOptions) {
-          <apex-chart
-            [options]="chartOptions"
-          ></apex-chart>
-        }
-      </div>
+  <div class="statistics-difficulties__content">
+    <div class="statistics-difficulties__chart" *ngIf="chartOptions">
+      <apex-chart [options]="chartOptions"></apex-chart>
     </div>
-    <div class="difficulties">
-      <swiper [config]="swiperConfig" [height]="180">
-        <div class="swiper-slide">
-          <div class="difficulty">
-            <div class="d-flex justify-content-between info">
-              <div class="title">
-                {{ 'Beginner' | translate }}
-              </div>
-              <div class="solved">
-                <strong class="text-{{ 1 | problemDifficultyColor }}">{{ difficulties.beginner }}</strong>
-                /
-                {{ difficulties.allBeginner }}
-              </div>
+    <div class="statistics-difficulties__list">
+      @for (item of difficultyItems; track item.label) {
+        <div class="statistics-difficulties__item">
+          <div class="statistics-difficulties__item-header">
+            <div class="statistics-difficulties__item-title">
+              <span class="badge bg-light text-{{ item.level | problemDifficultyColor }}">{{ item.label | translate }}</span>
             </div>
-            <div class="mt-2 progress-wrapper">
-              <ngb-progressbar type="{{ 1 | problemDifficultyColor }}"
-                               [value]="100 * difficulties.beginner / difficulties.allBeginner"></ngb-progressbar>
+            <div class="statistics-difficulties__item-value">
+              <span class="text-{{ item.level | problemDifficultyColor }}">{{ item.solved }}</span>
+              <span class="statistics-difficulties__item-total">/ {{ item.total }}</span>
             </div>
           </div>
+          <ngb-progressbar
+            [value]="item.progress"
+            [type]="item.level | problemDifficultyColor"
+            class="statistics-difficulties__progress"
+          ></ngb-progressbar>
         </div>
-
-        <div class="swiper-slide">
-          <div class="difficulty">
-            <div class="d-flex justify-content-between info">
-              <div class="title">
-                {{ 'Basic' | translate }}
-              </div>
-              <div class="solved">
-                <strong class="text-{{ 2 | problemDifficultyColor }}">{{ difficulties.basic }}</strong>
-                /
-                {{ difficulties.allBasic }}
-              </div>
-            </div>
-            <div class="mt-2 progress-wrapper">
-              <ngb-progressbar type="{{ 2 | problemDifficultyColor }}"
-                               [value]="100 * difficulties.basic / difficulties.allBasic"></ngb-progressbar>
-            </div>
-          </div>
-        </div>
-
-        <div class="swiper-slide">
-          <div class="difficulty">
-            <div class="d-flex justify-content-between info">
-              <div class="title">
-                {{ 'Normal' | translate }}
-              </div>
-              <div class="solved">
-                <strong class="text-{{ 3 | problemDifficultyColor }}">{{ difficulties.normal }}</strong>
-                /
-                {{ difficulties.allNormal }}
-              </div>
-            </div>
-            <div class="mt-2 progress-wrapper">
-              <ngb-progressbar type="{{ 3 | problemDifficultyColor }}"
-                               [value]="100 * difficulties.normal / difficulties.allNormal"></ngb-progressbar>
-            </div>
-          </div>
-        </div>
-
-        <div class="swiper-slide">
-          <div class="difficulty">
-            <div class="d-flex justify-content-between info">
-              <div class="title">
-                {{ 'Medium' | translate }}
-              </div>
-              <div class="solved">
-                <strong class="text-{{ 4 | problemDifficultyColor }}">{{ difficulties.medium }}</strong>
-                /
-                {{ difficulties.allMedium }}
-              </div>
-            </div>
-            <div class="mt-2 progress-wrapper">
-              <ngb-progressbar type="{{ 4 | problemDifficultyColor }}"
-                               [value]="100 * difficulties.medium / difficulties.allMedium"></ngb-progressbar>
-            </div>
-          </div>
-        </div>
-
-        <div class="swiper-slide">
-          <div class="difficulty">
-            <div class="d-flex justify-content-between info">
-              <div class="title">
-                {{ 'Advanced' | translate }}
-              </div>
-              <div class="solved">
-                <strong class="text-{{ 5 | problemDifficultyColor }}">{{ difficulties.advanced }}</strong>
-                /
-                {{ difficulties.allAdvanced }}
-              </div>
-            </div>
-            <div class="mt-2 progress-wrapper">
-              <ngb-progressbar type="{{ 5 | problemDifficultyColor }}"
-                               [value]="100 * difficulties.advanced / difficulties.allAdvanced"></ngb-progressbar>
-            </div>
-          </div>
-        </div>
-
-        <div class="swiper-slide">
-          <div class="difficulty">
-            <div class="d-flex justify-content-between info">
-              <div class="title">
-                {{ 'Hard' | translate }}
-              </div>
-              <div class="solved">
-                <strong class="text-{{ 6 | problemDifficultyColor }}">{{ difficulties.hard }}</strong>
-                /
-                {{ difficulties.allHard }}
-              </div>
-            </div>
-            <div class="mt-2 progress-wrapper">
-              <ngb-progressbar type="{{ 6 | problemDifficultyColor }}"
-                               [value]="100 * difficulties.hard / difficulties.allHard"></ngb-progressbar>
-            </div>
-          </div>
-        </div>
-
-        <div class="swiper-slide">
-          <div class="difficulty">
-            <div class="d-flex justify-content-between info">
-              <div class="title">
-                {{ 'Extremal' | translate }}
-              </div>
-              <div class="solved">
-                <strong class="text-{{ 7 | problemDifficultyColor }}">{{ difficulties.extremal }}</strong>
-                /
-                {{ difficulties.allExtremal }}
-              </div>
-            </div>
-            <div class="mt-2 progress-wrapper">
-              <ngb-progressbar type="{{ 7 | problemDifficultyColor }}"
-                               [value]="100 * difficulties.extremal / difficulties.allExtremal"></ngb-progressbar>
-            </div>
-          </div>
-        </div>
-      </swiper>
+      }
     </div>
   </div>
 </kep-card>

--- a/src/app/modules/problems/pages/statistics/section-difficulties/section-difficulties.component.scss
+++ b/src/app/modules/problems/pages/statistics/section-difficulties/section-difficulties.component.scss
@@ -1,56 +1,77 @@
-.card {
-  height: 250px;
+.statistics-difficulties {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 
-  .card-body {
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__title {
+    font-weight: 600;
+    font-size: 1.1rem;
+  }
+
+  &__subtitle {
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__content {
     display: grid;
-    grid-template-columns: 2fr 3fr;
-  }
-}
-
-.difficulties {
-  .difficulty {
-    margin-bottom: 1rem;
-
-    .title {
-      font-weight: 400;
-    }
+    grid-template-columns: 220px 1fr;
+    gap: 1.25rem;
+    align-items: center;
   }
 
-  .swiper-slide {
-    &:nth-child(1) {
-      ::ng-deep .progress {
-        background-color: rgba(40, 199, 111, 0.12);
-      }
+  &__chart {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__item-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.5rem;
+  }
+
+  &__item-value {
+    font-weight: 600;
+    display: flex;
+    align-items: baseline;
+    gap: 0.25rem;
+  }
+
+  &__item-total {
+    color: var(--bs-secondary-color);
+    font-size: 0.85rem;
+    font-weight: 500;
+  }
+
+  &__progress {
+    height: 0.5rem;
+    border-radius: 999px;
+  }
+
+  @media (max-width: 992px) {
+    &__content {
+      grid-template-columns: 1fr;
     }
 
-    &:nth-child(2) {
-      ::ng-deep .progress {
-        background-color: rgba(0, 207, 232, 0.12);
-      }
-    }
-
-    &:nth-child(3) {
-      ::ng-deep .progress {
-        background-color: rgba(67, 97, 238, 0.12);
-      }
-    }
-
-    &:nth-child(5) {
-      ::ng-deep .progress {
-        background-color: rgba(255, 159, 67, 0.12);
-      }
-    }
-
-    &:nth-child(6) {
-      ::ng-deep .progress {
-        background-color: rgba(234, 84, 85, 0.12);
-      }
-    }
-
-    &:nth-child(7) {
-      ::ng-deep .progress {
-        background-color: rgba(75, 75, 75, 0.12);
-      }
+    &__chart {
+      justify-content: flex-start;
     }
   }
 }

--- a/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.html
+++ b/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.html
@@ -1,202 +1,35 @@
-<div class="card">
-  <div class="card-header">
-    <div class="card-title">
-      {{ 'Facts' | translate }}
-    </div>
+<kep-card customClass="statistics-facts">
+  <div class="statistics-facts__header">
+    <div class="statistics-facts__title">{{ 'Highlights' | translate }}</div>
+    <div class="statistics-facts__subtitle">{{ 'KeyMoments' | translate }}</div>
   </div>
 
-  <div class="card-body">
-    <div class="facts">
-      <div class="fact d-flex justify-content-between">
-        <div class="info d-flex">
-          <div class="avatar me-1 bg-primary-transparent rounded">
-            <div class="avatar-content">
-              <i [data-feather]="'attempt' | iconName"></i>
-            </div>
+  <div class="statistics-facts__list">
+    @if (factEntries.length) {
+      @for (fact of factEntries; track fact.key) {
+        <div class="statistics-facts__item">
+          <div class="statistics-facts__icon">
+            <kep-icon [name]="fact.icon"></kep-icon>
           </div>
-
-          <div class="title">
-            {{ 'FirstAttempt' | translate }}
-          </div>
-        </div>
-        <div class="attempt-info" *ngIf="facts?.firstAttempt">
-          <div [ngbTooltip]="tipContent" class="problem-title">
-            <a [routerLink]="Resources.Problem | resourceById:facts.firstAttempt.problemId" class="text-primary">
-              {{ facts.firstAttempt.problemId }}. {{ facts.firstAttempt.problemTitle }}
-            </a>
-          </div>
-
-          <ng-template #tipContent>
-            <div class="mb-50 datetime">
-              <span class="text-success">
-                {{ facts.firstAttempt.datetime | localizedDate:'medium' }}
-              </span>
-            </div>
-            <div class="attempt-verdict" [innerHTML]="facts.firstAttempt | attemptVerdictHTML"></div>
-          </ng-template>
-        </div>
-      </div>
-
-      <div class="fact d-flex justify-content-between">
-        <div class="info d-flex">
-          <div class="avatar me-1 bg-primary-transparent rounded">
-            <div class="avatar-content">
-              <i [data-feather]="'problem' | iconName"></i>
-            </div>
-          </div>
-
-          <div class="title">
-            {{ 'FirstSolvedProblem' | translate }}
+          <div class="statistics-facts__content">
+            <div class="statistics-facts__label">{{ fact.key | translate }}</div>
+            @if (fact.problemTitle) {
+              <div class="statistics-facts__value" ngbTooltip="{{ fact.problemTitle }}">{{ fact.problemTitle }}</div>
+            }
+            @if (fact.datetime) {
+              <div class="statistics-facts__meta">{{ fact.datetime | date: 'medium' }}</div>
+            }
+            @if (fact.attempts !== undefined) {
+              <div class="statistics-facts__meta">{{ fact.attempts }} × {{ 'Attempts' | translate }}</div>
+            }
+            @if (fact.meta && !fact.datetime && fact.attempts === undefined) {
+              <div class="statistics-facts__meta">{{ fact.meta }}</div>
+            }
           </div>
         </div>
-        <div class="attempt-info" *ngIf="facts?.firstAccepted">
-          <div [ngbTooltip]="tipContent" class="problem-title">
-            <a [routerLink]="Resources.Problem | resourceById:facts.firstAccepted.problemId" class="text-primary">
-              {{ facts.firstAccepted.problemId }}. {{ facts.firstAccepted.problemTitle }}
-            </a>
-          </div>
-
-          <ng-template #tipContent>
-            <div class="datetime">
-              <span class="text-success">
-                {{ facts.firstAccepted.datetime | localizedDate:'medium' }}
-              </span>
-            </div>
-          </ng-template>
-        </div>
-      </div>
-
-      <div class="fact d-flex justify-content-between">
-        <div class="info d-flex">
-          <div class="avatar me-1 bg-primary-transparent rounded">
-            <div class="avatar-content">
-              <i [data-feather]="'attempt' | iconName"></i>
-            </div>
-          </div>
-
-          <div class="title">
-            {{ 'LastAttempt' | translate }}
-          </div>
-        </div>
-        <div class="attempt-info" *ngIf="facts?.lastAttempt">
-          <div [ngbTooltip]="tipContent" class="problem-title">
-            <a [routerLink]="Resources.Problem | resourceById:facts.lastAttempt.problemId" class="text-primary">
-              {{ facts.lastAttempt.problemId }}. {{ facts.lastAttempt.problemTitle }}
-            </a>
-          </div>
-
-          <ng-template #tipContent>
-            <div class="mb-50 datetime">
-              <span class="text-success">
-                {{ facts.lastAttempt.datetime | localizedDate:'medium' }}
-              </span>
-            </div>
-            <div class="attempt-verdict" [innerHTML]="facts.lastAttempt | attemptVerdictHTML"></div>
-          </ng-template>
-        </div>
-      </div>
-
-      <div class="fact d-flex justify-content-between">
-        <div class="info d-flex">
-          <div class="avatar me-1 bg-primary-transparent rounded">
-            <div class="avatar-content">
-              <i [data-feather]="'problem' | iconName"></i>
-            </div>
-          </div>
-
-          <div class="title">
-            {{ 'LastSolvedProblem' | translate }}
-          </div>
-        </div>
-        <div class="attempt-info" *ngIf="facts?.lastAccepted">
-          <div [ngbTooltip]="tipContent" class="problem-title">
-            <a [routerLink]="Resources.Problem | resourceById:facts.lastAccepted.problemId" class="text-primary">
-              {{ facts.lastAccepted.problemId }}. {{ facts.lastAccepted.problemTitle }}
-            </a>
-          </div>
-
-          <ng-template #tipContent>
-            <div class="datetime">
-              <span class="text-success">
-                {{ facts.lastAccepted.datetime | localizedDate:'medium' }}
-              </span>
-            </div>
-          </ng-template>
-        </div>
-      </div>
-
-      <div class="fact d-flex justify-content-between">
-        <div class="info d-flex">
-          <div class="avatar me-1 bg-primary-transparent rounded">
-            <div class="avatar-content">
-              <i [data-feather]="'attempt' | iconName"></i>
-            </div>
-          </div>
-
-          <div class="title">
-            {{ 'MostAttemptedProblem' | translate }}
-          </div>
-        </div>
-        <div class="attempt-info" *ngIf="facts?.mostAttemptedProblem">
-          <div [ngbTooltip]="tipContent" class="problem-title">
-            <a [routerLink]="Resources.Problem | resourceById:facts.mostAttemptedProblem.problemId" class="text-primary">
-              {{ facts.mostAttemptedProblem.problemId }}. {{ facts.mostAttemptedProblem.problemTitle }}
-            </a>
-          </div>
-
-          <ng-template #tipContent>
-            {{ facts.mostAttemptedProblem.attemptsCount }}
-          </ng-template>
-        </div>
-      </div>
-
-      <div class="fact d-flex justify-content-between">
-        <div class="info d-flex">
-          <div class="avatar me-1 bg-primary-transparent rounded">
-            <div class="avatar-content">
-              <i [data-feather]="'problem' | iconName"></i>
-            </div>
-          </div>
-
-          <div class="title">
-            {{ 'MostAttemptedForSolveProblem' | translate }}
-          </div>
-        </div>
-        <div class="attempt-info" *ngIf="facts?.mostAttemptedForSolveProblem">
-          <div [ngbTooltip]="tipContent" class="problem-title">
-            <a [routerLink]="Resources.Problem | resourceById:facts.mostAttemptedForSolveProblem.problemId"
-               class="text-primary">
-              {{ facts.mostAttemptedForSolveProblem.problemId }}. {{ facts.mostAttemptedForSolveProblem.problemTitle }}
-            </a>
-          </div>
-
-          <ng-template #tipContent>
-            {{ facts.mostAttemptedForSolveProblem.attemptsCount }}
-          </ng-template>
-        </div>
-      </div>
-
-      <div class="fact d-flex justify-content-between">
-        <div class="info d-flex">
-          <div class="avatar me-1 bg-primary-transparent rounded">
-            <div class="avatar-content">
-              <i [data-feather]="'attempt' | iconName"></i>
-            </div>
-          </div>
-
-          <div class="title">
-            {{ 'SolvedWithSingleAttempt' | translate }}
-          </div>
-        </div>
-        <div [ngbTooltip]="tipContent" *ngIf="facts?.solvedWithSingleAttempt">
-          <span class="badge bg-primary">
-            {{ facts.solvedWithSingleAttempt }}
-          </span>
-        </div>
-        <ng-template #tipContent>
-          {{ facts.solvedWithSingleAttemptPercentage }}%
-        </ng-template>
-      </div>
-    </div>
+      }
+    } @else {
+      <div class="statistics-facts__empty">{{ 'NoData' | translate }}</div>
+    }
   </div>
-</div>
+</kep-card>

--- a/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.scss
+++ b/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.scss
@@ -1,32 +1,79 @@
-@import 'bootstrap/scss/mixins';
-@import 'bootstrap/scss/functions';
-@import 'bootstrap/scss/variables';
+.statistics-facts {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 
-.card {
-  height: 410px;
-
-  @include media-breakpoint-down(sm) {
-    height: inherit;
+  &__header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
   }
-}
 
-.facts {
-  .fact {
+  &__title {
+    font-weight: 600;
+    font-size: 1.1rem;
+  }
+
+  &__subtitle {
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+
+  &__item {
+    display: flex;
+    gap: 0.75rem;
+    padding: 1rem;
+    border-radius: 1rem;
+    border: 1px solid rgba(115, 103, 240, 0.1);
+    background: rgba(115, 103, 240, 0.04);
+  }
+
+  &__icon {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 0.75rem;
+    background: rgba(115, 103, 240, 0.12);
+    display: flex;
     align-items: center;
-    margin-bottom: 1rem;
+    justify-content: center;
+    color: var(--bs-primary);
+  }
 
-    .info {
-      align-items: center;
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 0;
+  }
 
-      .title {
-        font-weight: 500;
-      }
+  &__label {
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
 
-    }
+  &__value {
+    font-weight: 600;
+    color: var(--bs-body-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 
-    .problem-title {
-      font-weight: 500;
-      text-align: right;
-    }
+  &__meta {
+    font-size: 0.85rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__empty {
+    grid-column: 1 / -1;
+    color: var(--bs-secondary-color);
+    text-align: center;
   }
 }

--- a/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.ts
+++ b/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.ts
@@ -1,19 +1,17 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { ProblemsStatisticsService } from '../../../services/problems-statistics.service';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { CoreCommonModule } from '@core/common.module';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
-import { Resources } from '@app/resources';
-import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
+import { Facts } from '../../../models/statistics.models';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
 
-export interface Facts {
-  firstAttempt: any;
-  lastAttempt: any;
-  firstAccepted: any;
-  lastAccepted: any;
-  mostAttemptedProblem: any;
-  mostAttemptedForSolveProblem: any;
-  solvedWithSingleAttempt: number;
-  solvedWithSingleAttemptPercentage: number;
+interface FactEntry {
+  key: string;
+  icon: string;
+  problemTitle?: string;
+  datetime?: string;
+  attempts?: number;
+  meta?: string;
 }
 
 @Component({
@@ -21,25 +19,87 @@ export interface Facts {
   templateUrl: './section-facts.component.html',
   styleUrls: ['./section-facts.component.scss'],
   standalone: true,
-  imports: [CoreCommonModule, NgbTooltipModule, ResourceByIdPipe],
+  imports: [CoreCommonModule, NgbTooltipModule, KepCardComponent, KepIconComponent],
 })
-export class SectionFactsComponent implements OnInit {
+export class SectionFactsComponent implements OnChanges {
 
-  @Input() username: string;
+  @Input() facts: Facts | null = null;
 
-  public facts: Facts;
-  protected readonly Resources = Resources;
+  public factEntries: FactEntry[] = [];
 
-  constructor(
-    public statisticsService: ProblemsStatisticsService,
-  ) { }
-
-  ngOnInit(): void {
-    this.statisticsService.getFacts(this.username).subscribe(
-      (facts: Facts) => {
-        this.facts = facts;
-      }
-    );
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['facts']) {
+      this.buildFacts();
+    }
   }
 
+  private buildFacts() {
+    const factEntries: FactEntry[] = [];
+    if (!this.facts) {
+      this.factEntries = [];
+      return;
+    }
+
+    if (this.facts.firstAttempt) {
+      factEntries.push({
+        key: 'FirstAttempt',
+        icon: 'flag',
+        problemTitle: this.facts.firstAttempt.problemTitle,
+        datetime: this.facts.firstAttempt.datetime,
+      });
+    }
+
+    if (this.facts.firstAccepted) {
+      factEntries.push({
+        key: 'FirstAccepted',
+        icon: 'award',
+        problemTitle: this.facts.firstAccepted.problemTitle,
+        datetime: this.facts.firstAccepted.datetime,
+      });
+    }
+
+    if (this.facts.lastAttempt) {
+      factEntries.push({
+        key: 'LastAttempt',
+        icon: 'clock',
+        problemTitle: this.facts.lastAttempt.problemTitle,
+        datetime: this.facts.lastAttempt.datetime,
+      });
+    }
+
+    if (this.facts.lastAccepted) {
+      factEntries.push({
+        key: 'LastAccepted',
+        icon: 'check-circle',
+        problemTitle: this.facts.lastAccepted.problemTitle,
+        datetime: this.facts.lastAccepted.datetime,
+      });
+    }
+
+    if (this.facts.mostAttemptedProblem) {
+      factEntries.push({
+        key: 'MostAttemptedProblem',
+        icon: 'target',
+        problemTitle: this.facts.mostAttemptedProblem.problemTitle,
+        attempts: this.facts.mostAttemptedProblem.attemptsCount,
+      });
+    }
+
+    if (this.facts.mostAttemptedForSolveProblem) {
+      factEntries.push({
+        key: 'MostAttemptedForSolveProblem',
+        icon: 'activity',
+        problemTitle: this.facts.mostAttemptedForSolveProblem.problemTitle,
+        attempts: this.facts.mostAttemptedForSolveProblem.attemptsCount,
+      });
+    }
+
+    factEntries.push({
+      key: 'SolvedWithSingleAttempt',
+      icon: 'zap',
+      meta: `${this.facts.solvedWithSingleAttempt} (${this.facts.solvedWithSingleAttemptPercentage}%)`,
+    });
+
+    this.factEntries = factEntries;
+  }
 }

--- a/src/app/modules/problems/pages/statistics/section-heatmap/section-heatmap.component.html
+++ b/src/app/modules/problems/pages/statistics/section-heatmap/section-heatmap.component.html
@@ -1,42 +1,35 @@
-<div class="card heatmap">
-  <div
-    class="card-header d-flex flex-sm-row flex-column justify-content-md-between align-items-start justify-content-start">
-    <h4 class="card-title mb-sm-0 mb-1">{{ 'Heatmap' | translate }}</h4>
-
-    <div
-      class="btn-group btn-group-toggle mt-md-0 mt-1"
-      ngbRadioGroup
-      name="radioBasic"
-      [(ngModel)]="heatmapYear"
-    >
-      <label class="btn btn-outline-primary" ngbButtonLabel rippleEffect>
-        <input type="radio" (click)="heatmapUpdate(0)" name="radio_options" id="radio_option1" [value]="0" ngbButton/>
-        <span>365</span>
-      </label>
-      <label class="btn btn-outline-primary" ngbButtonLabel rippleEffect>
-        <input type="radio" (click)="heatmapUpdate(2021)" name="radio_options" id="radio_option2" ngbButton
-               [value]="2021"/>
-        <span>2021</span>
-      </label>
-      <label class="btn btn-outline-primary" ngbButtonLabel rippleEffect>
-        <input type="radio" (click)="heatmapUpdate(2022)" name="radio_options" id="radio_option3" ngbButton
-               [value]="2022"/>
-        <span>2022</span>
-      </label>
-      <label class="btn btn-outline-primary" ngbButtonLabel rippleEffect>
-        <input type="radio" (click)="heatmapUpdate(2023)" name="radio_options" id="radio_option4" ngbButton
-               [value]="2023"/>
-        <span>2023</span>
-      </label>
+<kep-card customClass="statistics-heatmap">
+  <div class="statistics-heatmap__header">
+    <div>
+      <div class="statistics-heatmap__title">{{ 'Heatmap' | translate }}</div>
+      <div class="statistics-heatmap__subtitle">{{ 'DailyProgress' | translate }}</div>
     </div>
-
-  </div>
-  <div class="card-body">
-    @if (heatmap) {
-      <div #heatmapChartRef>
-        <apex-chart [options]="heatmapChart">
-        </apex-chart>
+    @if (availableYears?.length) {
+      <div class="statistics-heatmap__filters">
+        @for (year of availableYears; track year) {
+          <button
+            type="button"
+            class="btn btn-sm"
+            [class.btn-primary]="year === selectedYear"
+            [class.btn-outline-primary]="year !== selectedYear"
+            (click)="onSelectYear(year)"
+          >
+            {{ year }}
+          </button>
+        }
       </div>
     }
   </div>
-</div>
+
+  <div class="statistics-heatmap__body">
+    @if (isLoading) {
+      <div class="statistics-heatmap__loading">
+        <spinner></spinner>
+      </div>
+    } @else if (heatmapChart && hasData) {
+      <apex-chart [options]="heatmapChart"></apex-chart>
+    } @else {
+      <div class="statistics-heatmap__empty">{{ 'NoData' | translate }}</div>
+    }
+  </div>
+</kep-card>

--- a/src/app/modules/problems/pages/statistics/section-heatmap/section-heatmap.component.scss
+++ b/src/app/modules/problems/pages/statistics/section-heatmap/section-heatmap.component.scss
@@ -1,0 +1,49 @@
+.statistics-heatmap {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  &__title {
+    font-weight: 600;
+    font-size: 1.1rem;
+  }
+
+  &__subtitle {
+    font-size: 0.9rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  &__body {
+    min-height: 320px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    min-height: 280px;
+  }
+
+  &__empty {
+    color: var(--bs-secondary-color);
+    font-size: 0.95rem;
+  }
+}

--- a/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.html
+++ b/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.html
@@ -1,109 +1,104 @@
-<div class="card">
-  <div class="card-body">
-    <div class="section-profile text-center">
-      <div class="avatar p-50 bg-primary">
-        <div class="avatar-content">
-          <i [data-feather]="'problem' | iconName" [size]="20"></i>
-        </div>
+<kep-card customClass="statistics-profile-card">
+  <div class="statistics-profile-card__header">
+    <div class="statistics-profile-card__title">
+      <div class="statistics-profile-card__icon">
+        <kep-icon name="problem" class="statistics-profile-card__icon-inner"></kep-icon>
       </div>
-      <div class="font-medium-5 mt-1">
-        {{ 'Problems' | translate }}
-        <br>
+      <div class="statistics-profile-card__heading">
+        <div class="statistics-profile-card__label">{{ 'Problems' | translate }}</div>
         <a
           [routerLink]="[Resources.Attempts, username]"
-          class="btn btn-outline-primary btn-sm mt-1 attempts-link">
+          class="btn btn-outline-primary btn-sm attempts-link"
+        >
           {{ 'Attempts' | translate }}
         </a>
-        <div class="font-medium-4 mt-2">
-          <span ngbTooltip="{{ 'Solved' | translate }}">
-            <i data-feather="check-circle"></i>
-            {{ general.solved }}
-          </span>
-
-          <span ngbTooltip="{{ 'Rating' | translate }}">
-            <i [data-feather]="'rating' | iconName" class="ms-1"></i>
-            {{ general.rating }}
-          </span>
-        </div>
-      </div>
-
-      <div class="font-medium-4 mt-1">
-        <span ngbTooltip="{{ 'Rank' | translate }}">
-          <i [data-feather]="'users'" class="ms-1"></i>
-          <span class="font-medium-3">
-            {{ general.rank }}({{ general.usersCount }})
-          </span>
-        </span>
       </div>
     </div>
-
-    <hr>
-
-    <div class="section-languages">
-      <div class="title">
-        {{ 'Languages' | translate }}
+    @if (username) {
+      <div class="statistics-profile-card__username">
+        @{{ username }}
       </div>
-
-      <div class="languages">
-        @for (data of langs; track data) {
-          <div class="d-flex language justify-content-between">
-            <div class="lang">
-              <span class="badge badge-{{ data.lang }}">
-                {{ data.langFull }}
-              </span>
-            </div>
-            <div class="result">
-              <strong>x{{ data.solved }}</strong>
-            </div>
-          </div>
-        }
-      </div>
-    </div>
-
-    <hr>
-
-    <div class="section-tags">
-      <div class="title">
-        {{ 'Tags' | translate }}
-      </div>
-
-      <div class="tags">
-        @for (tag of tags; track tag) {
-          <div class="tag">
-            <span class="badge badge-pill bg-primary">
-              {{ tag.name }}
-            </span>
-            x{{ tag.value }}
-          </div>
-        }
-      </div>
-    </div>
-
-    <hr>
-
-    <div class="section-topics">
-      <div class="title">
-        {{ 'Topics' | translate }}
-      </div>
-
-      <div class="topics">
-        @for (topic of topics; track topic) {
-          <div class="topic d-flex justify-content-between">
-            <div class="d-flex topic-info justify-content-start">
-              <div class="topic-icon">
-                <kep-icon [name]="topic.icon"></kep-icon>
-              </div>
-              <div class="topic-title">
-                {{ topic.topic }}
-              </div>
-            </div>
-            <div class="solved">
-              x{{ topic.solved }}
-            </div>
-          </div>
-        }
-      </div>
-    </div>
-
+    }
   </div>
-</div>
+
+  <div class="statistics-profile-card__stats">
+    <div class="statistics-profile-card__stat">
+      <div class="statistics-profile-card__stat-label">{{ 'Solved' | translate }}</div>
+      <div class="statistics-profile-card__stat-value">{{ general ? general.solved : 0 }}</div>
+    </div>
+    <div class="statistics-profile-card__stat">
+      <div class="statistics-profile-card__stat-label">{{ 'Rating' | translate }}</div>
+      <div class="statistics-profile-card__stat-value">{{ general ? general.rating : 0 }}</div>
+    </div>
+    <div class="statistics-profile-card__stat">
+      <div class="statistics-profile-card__stat-label">{{ 'Rank' | translate }}</div>
+      <div class="statistics-profile-card__stat-value">#{{ general ? general.rank : 0 }}</div>
+      <div class="statistics-profile-card__stat-sub">{{ general ? general.usersCount : 0 }} {{ 'Users' | translate }}</div>
+    </div>
+    <div class="statistics-profile-card__stat">
+      <div class="statistics-profile-card__stat-label">{{ 'SolvedWithSingleAttempt' | translate }}</div>
+      <div class="statistics-profile-card__stat-value">{{ singleAttemptSolved }}</div>
+      <div class="statistics-profile-card__stat-sub">{{ singleAttemptPercentage }}%</div>
+    </div>
+  </div>
+
+  @if (languages.length) {
+    <div class="statistics-profile-card__section">
+      <div class="statistics-profile-card__section-header">
+        <div class="statistics-profile-card__section-title">{{ 'Languages' | translate }}</div>
+        <div class="statistics-profile-card__section-subtitle">{{ 'MostUsedLanguages' | translate }}</div>
+      </div>
+      <div class="statistics-profile-card__languages">
+        @for (lang of languages; track lang.lang) {
+          <div class="statistics-profile-card__language">
+            <div class="statistics-profile-card__language-header">
+              <span class="statistics-profile-card__language-name badge badge-{{ lang.lang }}">{{ lang.langFull }}</span>
+              <span class="statistics-profile-card__language-value">×{{ lang.solved }}</span>
+            </div>
+            <div class="statistics-profile-card__language-bar">
+              <div class="statistics-profile-card__language-progress" [style.width.%]="lang.share"></div>
+            </div>
+          </div>
+        }
+      </div>
+    </div>
+  }
+
+  @if (topicsView.length) {
+    <div class="statistics-profile-card__section">
+      <div class="statistics-profile-card__section-header">
+        <div class="statistics-profile-card__section-title">{{ 'Topics' | translate }}</div>
+        <div class="statistics-profile-card__section-subtitle">{{ 'ProblemCategories' | translate }}</div>
+      </div>
+      <div class="statistics-profile-card__topics">
+        @for (topic of topicsView; track topic.code) {
+          <div class="statistics-profile-card__topic" ngbTooltip="{{ topic.topic }}">
+            <div class="statistics-profile-card__topic-icon">
+              <kep-icon [name]="topic.icon"></kep-icon>
+            </div>
+            <div class="statistics-profile-card__topic-body">
+              <div class="statistics-profile-card__topic-title">{{ topic.topic }}</div>
+              <div class="statistics-profile-card__topic-value">×{{ topic.solved }}</div>
+            </div>
+          </div>
+        }
+      </div>
+    </div>
+  }
+
+  @if (tagsView.length) {
+    <div class="statistics-profile-card__section statistics-profile-card__section--tags">
+      <div class="statistics-profile-card__section-header">
+        <div class="statistics-profile-card__section-title">{{ 'Tags' | translate }}</div>
+        <div class="statistics-profile-card__section-subtitle">{{ 'PopularTags' | translate }}</div>
+      </div>
+      <div class="statistics-profile-card__tags">
+        @for (tag of tagsView; track tag.name) {
+          <span class="statistics-profile-card__tag" ngbTooltip="{{ tag.value }} {{ 'Solved' | translate }}">
+            #{{ tag.name }}
+          </span>
+        }
+      </div>
+    </div>
+  }
+</kep-card>

--- a/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.scss
+++ b/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.scss
@@ -1,72 +1,211 @@
-.section-languages {
-  margin-top: 2rem;
+.statistics-profile-card {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 
-  .title {
-    font-size: 1.2rem;
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  &__icon {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 1rem;
+    background: rgba(115, 103, 240, 0.12);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__icon-inner {
+    font-size: 1.5rem;
+    color: var(--bs-primary);
+  }
+
+  &__heading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__label {
+    font-weight: 600;
+    font-size: 1.1rem;
+  }
+
+  &__username {
+    font-weight: 600;
+    font-size: 1rem;
+    color: var(--bs-body-color);
+    white-space: nowrap;
+  }
+
+  &__stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+  }
+
+  &__stat {
+    background: rgba(115, 103, 240, 0.05);
+    border-radius: 1rem;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__stat-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--bs-secondary-color);
+  }
+
+  &__stat-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+  }
+
+  &__stat-sub {
+    font-size: 0.85rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__section-header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__section-title {
+    font-weight: 600;
+    font-size: 1rem;
+  }
+
+  &__section-subtitle {
+    font-size: 0.85rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__languages {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  &__language-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__language-value {
     font-weight: 600;
   }
 
-  .languages {
-    margin-top: 1rem;
-
-    .language {
-      margin-bottom: 0.5rem;
-    }
+  &__language-bar {
+    position: relative;
+    height: 8px;
+    border-radius: 999px;
+    background: rgba(115, 103, 240, 0.08);
+    overflow: hidden;
+    margin-top: 0.5rem;
   }
-}
 
-.section-tags {
-  margin-top: 1rem;
+  &__language-progress {
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: linear-gradient(90deg, rgba(115, 103, 240, 1) 0%, rgba(40, 199, 111, 1) 100%);
+  }
 
-  .title {
-    font-size: 1.2rem;
+  &__topics {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 0.75rem;
+  }
+
+  &__topic {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    border-radius: 1rem;
+    border: 1px solid rgba(115, 103, 240, 0.1);
+    background: rgba(115, 103, 240, 0.04);
+  }
+
+  &__topic-icon {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 0.75rem;
+    background: rgba(115, 103, 240, 0.12);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__topic-title {
     font-weight: 600;
   }
 
-  .tags {
-    margin-top: 1rem;
+  &__topic-value {
+    font-size: 0.85rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__tags {
     display: flex;
     flex-wrap: wrap;
-
-    .tag {
-      display: inline-block;
-      margin-top: 0.5rem;
-      margin-right: 0.5rem;
-    }
+    gap: 0.5rem;
   }
-}
 
-.section-topics {
-  margin-top: 1rem;
-
-  .title {
-    font-size: 1.2rem;
+  &__tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(115, 103, 240, 0.08);
+    color: var(--bs-primary);
     font-weight: 600;
+    font-size: 0.85rem;
   }
 
-  .topics {
-    margin-top: 1rem;
+  &__section--tags {
+    gap: 0.75rem;
+  }
 
-    .topic {
-      margin-bottom: 0.2rem;
+  @media (max-width: 992px) {
+    padding: 1.25rem;
+    gap: 1.25rem;
+  }
 
-      .topic-info {
-        align-items: center;
-      }
+  @media (max-width: 576px) {
+    padding: 1rem;
+    &__header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
 
-      .topic-title {
-        font-weight: 500;
-        margin-left: 0.5rem;
-      }
-
-      .topic-image {
-        width: 48px;
-
-        img {
-          width: 100%;
-          object-fit: contain;
-        }
-      }
+    &__stats {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 }

--- a/src/app/modules/problems/pages/statistics/section-time/section-time.component.html
+++ b/src/app/modules/problems/pages/statistics/section-time/section-time.component.html
@@ -1,56 +1,34 @@
-<div class="row">
-  <div class="col-lg-4 col-12">
-    <div class="card">
-      <div class="card-header">
-        <div class="card-title">
-          {{ 'ByWeekday' | translate }}
-        </div>
-      </div>
-
-      <div class="card-body">
-        @if (byWeekdayChart) {
-          <apex-chart
-            [options]="byWeekdayChart"
-          ></apex-chart>
-        }
-      </div>
+<div class="statistics-time">
+  <kep-card class="statistics-time__card">
+    <div class="statistics-time__header">{{ 'ByWeekday' | translate }}</div>
+    <div class="statistics-time__body">
+      @if (byWeekdayChart) {
+        <apex-chart [options]="byWeekdayChart"></apex-chart>
+      } @else {
+        <div class="statistics-time__empty">{{ 'NoData' | translate }}</div>
+      }
     </div>
-  </div>
+  </kep-card>
 
-  <div class="col-lg-4 col-12">
-    <div class="card">
-      <div class="card-header">
-        <div class="card-title">
-          {{ 'ByMonth' | translate }}
-        </div>
-      </div>
-
-      <div class="card-body">
-        @if (byMonthChart) {
-          <apex-chart
-            [options]="byMonthChart"
-          ></apex-chart>
-        }
-      </div>
+  <kep-card class="statistics-time__card">
+    <div class="statistics-time__header">{{ 'ByMonth' | translate }}</div>
+    <div class="statistics-time__body">
+      @if (byMonthChart) {
+        <apex-chart [options]="byMonthChart"></apex-chart>
+      } @else {
+        <div class="statistics-time__empty">{{ 'NoData' | translate }}</div>
+      }
     </div>
-  </div>
+  </kep-card>
 
-  <div class="col-lg-4 col-12">
-    <div class="card">
-      <div class="card-header">
-        <div class="card-title">
-          {{ 'ByPeriod' | translate }}
-        </div>
-      </div>
-
-      <div class="card-body">
-        @if (byPeriodChart) {
-          <apex-chart
-            [options]="byPeriodChart"
-          ></apex-chart>
-        }
-      </div>
+  <kep-card class="statistics-time__card">
+    <div class="statistics-time__header">{{ 'ByPeriod' | translate }}</div>
+    <div class="statistics-time__body">
+      @if (byPeriodChart) {
+        <apex-chart [options]="byPeriodChart"></apex-chart>
+      } @else {
+        <div class="statistics-time__empty">{{ 'NoData' | translate }}</div>
+      }
     </div>
-
-  </div>
+  </kep-card>
 </div>

--- a/src/app/modules/problems/pages/statistics/section-time/section-time.component.scss
+++ b/src/app/modules/problems/pages/statistics/section-time/section-time.component.scss
@@ -1,0 +1,27 @@
+.statistics-time {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+
+  &__card {
+    padding: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  &__header {
+    font-weight: 600;
+    font-size: 1rem;
+  }
+
+  &__body {
+    min-height: 280px;
+  }
+
+  &__empty {
+    color: var(--bs-secondary-color);
+    text-align: center;
+    margin-top: 2rem;
+  }
+}

--- a/src/app/modules/problems/pages/statistics/section-time/section-time.component.ts
+++ b/src/app/modules/problems/pages/statistics/section-time/section-time.component.ts
@@ -1,8 +1,10 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { ProblemsStatisticsService } from '@problems/services/problems-statistics.service';
 import { CoreCommonModule } from '@core/common.module';
 import { ApexChartModule } from '@shared/third-part-modules/apex-chart/apex-chart.module';
+import { WeekdaySolved, MonthSolved, PeriodSolved } from '@problems/models/statistics.models';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { ChartOptions } from '@shared/third-part-modules/apex-chart/chart-options.type';
 
 @Component({
   selector: 'section-time',
@@ -12,124 +14,101 @@ import { ApexChartModule } from '@shared/third-part-modules/apex-chart/apex-char
   imports: [
     CoreCommonModule,
     ApexChartModule,
+    KepCardComponent,
   ]
 })
-export class SectionTimeComponent implements OnInit {
+export class SectionTimeComponent implements OnChanges {
 
-  @Input() username: string;
-  @Input() chartTheme: any;
+  @Input() byWeekday: WeekdaySolved[] = [];
+  @Input() byMonth: MonthSolved[] = [];
+  @Input() byPeriod: PeriodSolved[] = [];
 
-  public byWeekdayChart: any;
-  public byMonthChart: any;
-  public byPeriodChart: any;
+  public byWeekdayChart: ChartOptions | null = null;
+  public byMonthChart: ChartOptions | null = null;
+  public byPeriodChart: ChartOptions | null = null;
 
   constructor(
-    public statisticsService: ProblemsStatisticsService,
-    public translateService: TranslateService,
+    private translateService: TranslateService,
   ) { }
 
-  ngOnInit(): void {
-    this.statisticsService.getByWeekday(this.username).subscribe(
-      (result: any) => {
-        const values = [];
-        const labels = [];
-        for (const data of result) {
-          labels.push(this.translateService.instant(data.day));
-          values.push(data.solved);
-        }
-        this.byWeekdayChart = {
-          series: [
-            {
-              name: this.translateService.instant('Solved'),
-              data: values,
-            }
-          ],
-          chart: {
-            type: 'bar',
-            height: 350,
-          },
-          plotOptions: {
-            bar: {
-              horizontal: true
-            }
-          },
-          dataLabels: {
-            enabled: false
-          },
-          xaxis: {
-            categories: labels
-          }
-        };
-      }
-    );
-
-    this.statisticsService.getByMonth(this.username).subscribe(
-      (result: any) => {
-        const values = [];
-        const labels = [];
-        for (const data of result) {
-          labels.push(this.translateService.instant(data.month));
-          values.push(data.solved);
-        }
-        this.byMonthChart = {
-          series: [
-            {
-              name: this.translateService.instant('Solved'),
-              data: values,
-            }
-          ],
-          chart: {
-            type: 'bar',
-            height: 350,
-          },
-          plotOptions: {
-            bar: {
-              horizontal: true
-            }
-          },
-          dataLabels: {
-            enabled: false
-          },
-          xaxis: {
-            categories: labels
-          }
-        };
-      }
-    );
-
-    this.statisticsService.getByPeriod(this.username).subscribe(
-      (result: any) => {
-        const values = [];
-        const labels = [];
-        for (const data of result) {
-          labels.push(data.period);
-          values.push(data.solved);
-        }
-        this.byPeriodChart = {
-          series: [
-            {
-              name: this.translateService.instant('Solved'),
-              data: values,
-            }
-          ],
-          chart: {
-            type: 'bar',
-            height: 350,
-          },
-          plotOptions: {
-            bar: {
-              horizontal: true
-            }
-          },
-          dataLabels: {
-            enabled: false
-          },
-          xaxis: {
-            categories: labels
-          }
-        };
-      }
-    );
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['byWeekday']) {
+      this.buildWeekdayChart();
+    }
+    if (changes['byMonth']) {
+      this.buildMonthChart();
+    }
+    if (changes['byPeriod']) {
+      this.buildPeriodChart();
+    }
   }
 
+  private buildWeekdayChart() {
+    if (!this.byWeekday?.length) {
+      this.byWeekdayChart = null;
+      return;
+    }
+    const labels = this.byWeekday.map((item) => this.translateService.instant(item.day));
+    const values = this.byWeekday.map((item) => item.solved);
+    this.byWeekdayChart = this.createHorizontalBar(labels, values);
+  }
+
+  private buildMonthChart() {
+    if (!this.byMonth?.length) {
+      this.byMonthChart = null;
+      return;
+    }
+    const labels = this.byMonth.map((item) => this.translateService.instant(item.month));
+    const values = this.byMonth.map((item) => item.solved);
+    this.byMonthChart = this.createHorizontalBar(labels, values);
+  }
+
+  private buildPeriodChart() {
+    if (!this.byPeriod?.length) {
+      this.byPeriodChart = null;
+      return;
+    }
+    const labels = this.byPeriod.map((item) => item.period);
+    const values = this.byPeriod.map((item) => item.solved);
+    this.byPeriodChart = this.createHorizontalBar(labels, values);
+  }
+
+  private createHorizontalBar(labels: string[], values: number[]): ChartOptions {
+    return {
+      series: [
+        {
+          name: this.translateService.instant('Solved'),
+          data: values,
+        }
+      ],
+      chart: {
+        type: 'bar',
+        height: 320,
+        toolbar: { show: false },
+      },
+      plotOptions: {
+        bar: {
+          horizontal: true,
+          borderRadius: 8,
+        },
+      },
+      colors: ['#7367f0'],
+      dataLabels: {
+        enabled: false,
+      },
+      xaxis: {
+        categories: labels,
+      },
+      yaxis: {
+        labels: {
+          style: {
+            fontSize: '0.85rem',
+          }
+        }
+      },
+      grid: {
+        strokeDashArray: 5,
+      },
+    };
+  }
 }

--- a/src/app/modules/problems/pages/statistics/statistics.component.html
+++ b/src/app/modules/problems/pages/statistics/statistics.component.html
@@ -1,34 +1,85 @@
 @if (username) {
   <div class="content-wrapper container-xxl p-0">
     <div class="content-body">
-      <section class="mt-2">
-        <div class="row">
-          <div class="col-lg-3 col-md-6 col-sm-12">
-            <section-profile [username]="username"></section-profile>
-          </div>
-          <div class="col-lg-9 col-md-6 col-sm-12">
-            <div class="row">
-              <div class="col-lg-6 col-12">
-                <section-difficulties [username]="username"></section-difficulties>
-              </div>
-              <div class="col-lg-6 col-12">
-                <section-activity [username]="username"></section-activity>
-              </div>
-              <div class="col-12">
-                <section-heatmap [username]="username"></section-heatmap>
-              </div>
-              <div class="col-lg-6 col-12">
-                <section-facts [username]="username"></section-facts>
-              </div>
-              <div class="col-lg-6 col-12">
-                <section-attempts-for-solve [username]="username"></section-attempts-for-solve>
-              </div>
-              <div class="col-12">
-                <section-time [username]="username"></section-time>
-              </div>
-            </div>
+      <section class="problems-statistics">
+        <div class="problems-statistics__header">
+          <div>
+            <h2 class="problems-statistics__title">{{ 'Statistics' | translate }}</h2>
+            <p class="problems-statistics__subtitle">@{{ username }}</p>
           </div>
         </div>
+
+        @if (isLoading && !general) {
+          <div class="problems-statistics__loading">
+            <spinner></spinner>
+          </div>
+        } @else if (hasError) {
+          <div class="problems-statistics__error">
+            <kep-icon name="alert-triangle"></kep-icon>
+            <span>{{ 'SomethingWentWrong' | translate }}</span>
+          </div>
+        } @else {
+          <div class="problems-statistics__overview">
+            @for (card of overviewCards; track card.titleKey) {
+              <div class="problems-statistics__overview-card">
+                <div class="problems-statistics__overview-icon">
+                  <kep-icon [name]="card.icon"></kep-icon>
+                </div>
+                <div class="problems-statistics__overview-body">
+                  <div class="problems-statistics__overview-label">{{ card.titleKey | translate }}</div>
+                  <div class="problems-statistics__overview-value">{{ card.value }}</div>
+                  @if (card.description) {
+                    <div class="problems-statistics__overview-description">{{ card.description }}</div>
+                  }
+                </div>
+              </div>
+            }
+          </div>
+
+          <div class="problems-statistics__grid">
+            <div class="problems-statistics__left" *ngIf="general">
+              <section-profile
+                [username]="username"
+                [general]="general"
+                [langs]="langs"
+                [tags]="tags"
+                [topics]="topics"
+                [facts]="facts"
+              ></section-profile>
+            </div>
+            <div class="problems-statistics__right">
+              <div class="problems-statistics__row">
+                <section-difficulties [difficulties]="difficulties"></section-difficulties>
+                <problems-activity-card
+                  [lastDays]="lastDays"
+                  [selectedDays]="selectedDays"
+                  [daysOptions]="allowedDays"
+                  [isLoading]="isLoading"
+                  (daysChange)="onDaysChange($event)"
+                ></problems-activity-card>
+              </div>
+
+              <section-heatmap
+                [heatmap]="heatmap"
+                [availableYears]="availableYears"
+                [selectedYear]="selectedYear"
+                [isLoading]="isLoading"
+                (yearChange)="onYearChange($event)"
+              ></section-heatmap>
+
+              <div class="problems-statistics__row">
+                <section-facts [facts]="facts"></section-facts>
+                <section-attempts-for-solve [numberOfAttempts]="numberOfAttempts"></section-attempts-for-solve>
+              </div>
+
+              <section-time
+                [byWeekday]="byWeekday"
+                [byMonth]="byMonth"
+                [byPeriod]="byPeriod"
+              ></section-time>
+            </div>
+          </div>
+        }
       </section>
     </div>
   </div>

--- a/src/app/modules/problems/pages/statistics/statistics.component.scss
+++ b/src/app/modules/problems/pages/statistics/statistics.component.scss
@@ -1,0 +1,99 @@
+.problems-statistics {
+  padding: 1.5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  &__title {
+    font-weight: 700;
+    font-size: 1.75rem;
+  }
+
+  &__subtitle {
+    color: var(--bs-secondary-color);
+    margin-bottom: 0;
+  }
+
+  &__loading,
+  &__error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 320px;
+    gap: 0.75rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__overview {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+
+  &__overview-card {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.5rem;
+    border-radius: 1.25rem;
+    background: rgba(115, 103, 240, 0.08);
+  }
+
+  &__overview-icon {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 1rem;
+    background: rgba(115, 103, 240, 0.12);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--bs-primary);
+  }
+
+  &__overview-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__overview-label {
+    font-weight: 600;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  &__overview-value {
+    font-weight: 700;
+    font-size: 1.75rem;
+  }
+
+  &__overview-description {
+    color: var(--bs-secondary-color);
+    font-size: 0.85rem;
+  }
+
+  &__grid {
+    display: grid;
+    grid-template-columns: minmax(280px, 360px) 1fr;
+    gap: 1.5rem;
+  }
+
+  &__row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+  }
+
+  @media (max-width: 1200px) {
+    &__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+}

--- a/src/app/modules/problems/pages/statistics/statistics.component.ts
+++ b/src/app/modules/problems/pages/statistics/statistics.component.ts
@@ -4,7 +4,6 @@ import { SectionProfileComponent } from '@problems/pages/statistics/section-prof
 import {
   SectionDifficultiesComponent
 } from '@problems/pages/statistics/section-difficulties/section-difficulties.component';
-import { SectionActivityComponent } from '@problems/pages/statistics/section-activity/section-activity.component';
 import { SectionHeatmapComponent } from '@problems/pages/statistics/section-heatmap/section-heatmap.component';
 import { SectionFactsComponent } from '@problems/pages/statistics/section-facts/section-facts.component';
 import { SectionTimeComponent } from '@problems/pages/statistics/section-time/section-time.component';
@@ -13,6 +12,34 @@ import {
 } from '@problems/pages/statistics/section-attempts-for-solve/section-attempts-for-solve.component';
 import { BaseComponent } from '@core/common/classes/base.component';
 import { AuthUser } from '@auth';
+import { ProblemsStatisticsService } from '@problems/services/problems-statistics.service';
+import { ProblemsActivityCardComponent } from '@problems/components/problems-activity-card/problems-activity-card.component';
+import {
+  Difficulties,
+  Facts,
+  GeneralInfo,
+  LangInfo,
+  TagInfo,
+  TopicInfo,
+  ProblemsStatistics,
+  WeekdaySolved,
+  MonthSolved,
+  PeriodSolved,
+  LastDays,
+  HeatmapEntry,
+  NumberOfAttempts
+} from '@problems/models/statistics.models';
+import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
+import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
+import { TranslateService } from '@ngx-translate/core';
+import { CommonModule } from '@angular/common';
+
+interface OverviewCard {
+  titleKey: string;
+  value: string;
+  description?: string;
+  icon: string;
+}
 
 @Component({
   selector: 'app-statistics',
@@ -22,29 +49,212 @@ import { AuthUser } from '@auth';
   standalone: true,
   imports: [
     CoreCommonModule,
+    CommonModule,
     SectionProfileComponent,
     SectionDifficultiesComponent,
-    SectionActivityComponent,
     SectionHeatmapComponent,
     SectionFactsComponent,
     SectionTimeComponent,
-    SectionAttemptsForSolveComponent
+    SectionAttemptsForSolveComponent,
+    ProblemsActivityCardComponent,
+    SpinnerComponent,
+    KepIconComponent,
   ]
 })
 export class StatisticsComponent extends BaseComponent implements OnInit {
   public username: string;
 
+  public general: GeneralInfo | null = null;
+  public langs: LangInfo[] = [];
+  public tags: TagInfo[] = [];
+  public topics: TopicInfo[] = [];
+  public facts: Facts | null = null;
+  public difficulties: Difficulties | null = null;
+  public byWeekday: WeekdaySolved[] = [];
+  public byMonth: MonthSolved[] = [];
+  public byPeriod: PeriodSolved[] = [];
+  public lastDays: LastDays | null = null;
+  public heatmap: HeatmapEntry[] = [];
+  public numberOfAttempts: NumberOfAttempts | null = null;
+
+  public overviewCards: OverviewCard[] = [];
+
+  public allowedDays: number[] = [3, 7, 14, 30];
+  public selectedDays = 7;
+  public availableYears: number[] = [];
+  public selectedYear: number | null = null;
+
+  public isLoading = false;
+  public hasError = false;
+
+  constructor(
+    private statisticsService: ProblemsStatisticsService,
+    private translateService: TranslateService,
+  ) {
+    super();
+  }
+
   ngOnInit(): void {
     this.route.queryParams.subscribe(
       (params: any) => {
         if (params['username']) {
-          this.username = params['username'];
+          this.setUsername(params['username']);
+        } else if (!this.username) {
+          this.loadStatistics();
         }
       }
     );
   }
 
   afterChangeCurrentUser(currentUser: AuthUser) {
-    this.username = currentUser.username;
+    if (!this.username) {
+      this.setUsername(currentUser.username);
+    }
+  }
+
+  public onDaysChange(days: number) {
+    this.selectedDays = days;
+    this.loadStatistics({ days });
+  }
+
+  public onYearChange(year: number) {
+    this.selectedYear = year;
+    this.loadStatistics({ year });
+  }
+
+  private setUsername(username: string) {
+    if (username && username !== this.username) {
+      this.username = username;
+      this.loadStatistics({ reset: true });
+    }
+  }
+
+  private loadStatistics(options: { year?: number; days?: number; reset?: boolean } = {}) {
+    if (!this.username) {
+      return;
+    }
+
+    if (options.reset) {
+      this.selectedYear = null;
+      this.selectedDays = 7;
+    }
+
+    const query: { year?: number; days?: number } = {};
+    const year = options.year ?? this.selectedYear ?? new Date().getFullYear();
+    const days = options.days ?? this.selectedDays ?? 7;
+    if (year) {
+      query.year = year;
+    }
+    if (days) {
+      query.days = days;
+    }
+
+    this.isLoading = true;
+    this.hasError = false;
+
+    this.statisticsService.getStatistics(this.username, query).subscribe({
+      next: (statistics: ProblemsStatistics) => {
+        this.isLoading = false;
+        this.hasError = false;
+        this.applyStatistics(statistics, options);
+      },
+      error: () => {
+        this.isLoading = false;
+        this.hasError = true;
+      }
+    });
+  }
+
+  private applyStatistics(statistics: ProblemsStatistics, options: { year?: number; days?: number }) {
+    this.general = statistics.general;
+    this.langs = statistics.byLang || [];
+    this.tags = statistics.byTag || [];
+    this.topics = statistics.byTopic || [];
+    this.facts = statistics.facts;
+    this.difficulties = statistics.byDifficulty;
+    this.byWeekday = statistics.byWeekday || [];
+    this.byMonth = statistics.byMonth || [];
+    this.byPeriod = statistics.byPeriod || [];
+    this.lastDays = statistics.lastDays;
+    this.heatmap = statistics.heatmap || [];
+    this.numberOfAttempts = statistics.numberOfAttempts;
+
+    this.selectedDays = statistics.meta?.lastDays ?? options.days ?? this.selectedDays ?? 7;
+    this.allowedDays = statistics.meta?.allowedLastDays?.length ? statistics.meta.allowedLastDays : this.allowedDays;
+
+    const defaultYear = this.resolveDefaultYear(statistics);
+    this.availableYears = this.buildYearRange(statistics.meta?.heatmapRange, defaultYear);
+
+    if (options.year) {
+      this.selectedYear = options.year;
+    } else if (!this.selectedYear || !this.availableYears.includes(this.selectedYear)) {
+      this.selectedYear = defaultYear;
+    }
+
+    this.buildOverviewCards();
+  }
+
+  private buildOverviewCards() {
+    if (!this.general) {
+      this.overviewCards = [];
+      return;
+    }
+
+    const usersLabel = this.translateService.instant('Users');
+    const singleAttempt = this.facts?.solvedWithSingleAttempt ?? 0;
+    const singleAttemptPercentage = this.facts?.solvedWithSingleAttemptPercentage ?? 0;
+
+    this.overviewCards = [
+      {
+        titleKey: 'Solved',
+        value: this.formatNumber(this.general.solved),
+        icon: 'check-circle',
+      },
+      {
+        titleKey: 'Rating',
+        value: this.formatNumber(this.general.rating),
+        icon: 'rating',
+      },
+      {
+        titleKey: 'Rank',
+        value: `#${this.formatNumber(this.general.rank)}`,
+        description: `${this.formatNumber(this.general.usersCount)} ${usersLabel}`,
+        icon: 'users',
+      },
+      {
+        titleKey: 'SolvedWithSingleAttempt',
+        value: this.formatNumber(singleAttempt),
+        description: `${singleAttemptPercentage}%`,
+        icon: 'zap',
+      }
+    ];
+  }
+
+  private formatNumber(value: number): string {
+    return new Intl.NumberFormat().format(value);
+  }
+
+  private resolveDefaultYear(statistics: ProblemsStatistics): number {
+    const to = statistics.meta?.heatmapRange?.to;
+    if (to) {
+      return new Date(to).getFullYear();
+    }
+    return new Date().getFullYear();
+  }
+
+  private buildYearRange(range?: { from: string; to: string }, fallback?: number): number[] {
+    if (!range) {
+      return fallback ? [fallback] : [];
+    }
+    const fromYear = new Date(range.from).getFullYear();
+    const toYear = new Date(range.to).getFullYear();
+    const years: number[] = [];
+    for (let year = toYear; year >= fromYear; year--) {
+      years.push(year);
+    }
+    if (!years.length && fallback) {
+      years.push(fallback);
+    }
+    return years;
   }
 }

--- a/src/app/modules/problems/services/problems-statistics.service.ts
+++ b/src/app/modules/problems/services/problems-statistics.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ApiService } from '@core/data-access/api.service';
+import { ProblemsStatistics } from '@problems/models/statistics.models';
 
 @Injectable({
   providedIn: 'root'
@@ -10,58 +11,7 @@ export class ProblemsStatisticsService {
     public api: ApiService,
   ) { }
 
-  getGeneral(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-general/`);
+  getStatistics(username: string, params: { year?: number; days?: number } = {}) {
+    return this.api.get<ProblemsStatistics>(`problems-rating/${username}/statistics/`, params);
   }
-
-  getByDifficulty(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-difficulty/`);
-  }
-
-  getByTag(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-tag/`);
-  }
-
-  getByVerdict(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-verdict/`);
-  }
-
-  getByLang(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-lang/`);
-  }
-
-  getByTopic(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-topic/`);
-  }
-
-  getByWeekday(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-weekday/`);
-  }
-
-  getByPeriod(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-period/`);
-  }
-
-  getByMonth(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-month/`);
-  }
-
-  getFacts(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-facts/`);
-  }
-
-  getNumberOfAttemptsForSolve(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-number-of-attempts-for-solve/`);
-  }
-
-  getLastDays(username: string, days: number) {
-    let params = {days: days};
-    return this.api.get(`problems-rating/${username}/statistics-last-days/`, params);
-  }
-
-  getHeatmap(username: string, year: number) {
-    let params = {year: year};
-    return this.api.get(`problems-rating/${username}/statistics-heatmap/`, params);
-  }
-
 }


### PR DESCRIPTION
## Summary
- load the problems statistics page from the new unified `/statistics` endpoint and manage year/day filters in the container component
- refresh the statistics layout with overview cards, redesigned profile, activity, heatmap, and time-distribution sections that consume the aggregated payload
- refactor supporting section components to accept inputs, enrich visuals for languages/tags/difficulties, and render the new facts and attempts data

## Testing
- npm run lint *(fails: Angular CLI missing because dependencies cannot be installed; `npm install` is blocked by a peer dependency conflict with `@fullcalendar/angular@6.1.9` vs `@angular/common@19.2.1`)*

------
https://chatgpt.com/codex/tasks/task_e_68d1be961244832fbf59c8c4dc1af111