### PR TITLE
Refactor problems statistics to unified API

### DIFF
--- a/src/app/modules/problems/components/problems-activity-card/problems-activity-card.component.html
+++ b/src/app/modules/problems/components/problems-activity-card/problems-activity-card.component.html
@@ -1,30 +1,37 @@
 <kep-card>
-  @if (isLoading) {
-    <div [style.height.px]="200">
-      <spinner></spinner>
+  <div class="card-header">
+    <div class="card-title">
+      {{ 'Activity' | translate }}
     </div>
-  } @else {
-    <div class="card-header">
-      <div class="card-title">
-        {{ 'Activity' | translate }}
+    @if (allowedDays?.length) {
+      <div role="group" aria-label="{{ 'Activity' | translate }}" class="btn-group">
+        @for (option of allowedDays; track option) {
+          <input
+            type="radio"
+            class="btn-check"
+            [id]="'activity-days-' + option"
+            name="activity-days"
+            [checked]="activityDays === option"
+            (change)="onDaysChange(option)"
+          >
+          <label [for]="'activity-days-' + option" class="btn btn-outline-primary">{{ option }}</label>
+        }
       </div>
-      <div role="group" aria-label="Basic radio toggle button group" class="btn-group">
-        <input [(ngModel)]="activityDays" (click)="activityDataUpdate(7)"  [value]="7" type="radio" name="btnradio" id="btnradio1" checked="" class="btn-check">
-        <label for="btnradio1" class="btn btn-outline-primary">7</label>
-        <input [(ngModel)]="activityDays" (click)="activityDataUpdate(14)"  [value]="14" type="radio" name="btnradio" id="btnradio2" class="btn-check">
-        <label for="btnradio2" class="btn btn-outline-primary">14</label>
-        <input [(ngModel)]="activityDays" (click)="activityDataUpdate(30)"  [value]="30" type="radio" name="btnradio" id="btnradio3" class="btn-check">
-        <label for="btnradio3" class="btn btn-outline-primary">30</label>
-      </div>
-    </div>
+    }
+  </div>
 
-    <div class="card-body">
+  <div class="card-body">
+    @if (isLoading) {
+      <div [style.height.px]="200" class="d-flex align-items-center justify-content-center">
+        <spinner></spinner>
+      </div>
+    } @else {
       <div class="mt-2">
-        <div class="row">
+        <div class="row g-1">
           <div [ngClass]="{
-          'col-6': activitySolved > 0,
-          'col-12': activitySolved == 0
-        }">
+            'col-6': activitySolved > 0,
+            'col-12': activitySolved === 0
+          }">
             <div class="text-center">
               <div class="avatar bg-primary-transparent p-50 m-0 mb-1">
                 <div class="avatar-content">
@@ -43,6 +50,6 @@
           </div>
         </div>
       </div>
-    </div>
-  }
+    }
+  </div>
 </kep-card>

--- a/src/app/modules/problems/components/problems-activity-card/problems-activity-card.component.ts
+++ b/src/app/modules/problems/components/problems-activity-card/problems-activity-card.component.ts
@@ -1,12 +1,12 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { CoreCommonModule } from '@core/common.module';
 import { ApexChartModule } from '@shared/third-part-modules/apex-chart/apex-chart.module';
-import { ProblemsStatisticsService } from '@problems/services/problems-statistics.service';
 import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
 import { TranslateService } from '@ngx-translate/core';
 import { ChartOptions } from '@shared/third-part-modules/apex-chart/chart-options.type';
 import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { LastDaysStatistics } from '@problems/models/statistics.models';
 
 @Component({
   selector: 'problems-activity-card',
@@ -21,76 +21,96 @@ import { KepCardComponent } from '@shared/components/kep-card/kep-card.component
     KepCardComponent,
   ]
 })
-export class ProblemsActivityCardComponent implements OnInit {
+export class ProblemsActivityCardComponent implements OnChanges {
 
-  @Input() username: string;
+  @Input() days = 7;
+  @Input() allowedDays: number[] = [];
+  @Input() activity: LastDaysStatistics;
 
-  public activityDays = 7;
-  public activitySolved = 0;
+  @Output() daysChange = new EventEmitter<number>();
+
   public activityChart: ChartOptions;
-
+  public activitySolved = 0;
+  public activityDays = 7;
   public isLoading = true;
 
   constructor(
-    public statisticsService: ProblemsStatisticsService,
     public translateService: TranslateService,
   ) { }
 
-  ngOnInit(): void {
-    this.activityDataUpdate(this.activityDays);
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['days']) {
+      this.activityDays = this.days;
+    }
+
+    if (changes['activity']) {
+      this.updateActivity(this.activity);
+    }
   }
 
-  activityDataUpdate(days: number) {
-    this.isLoading = true;
-    const username = this.username;
-    this.activityDays = days;
-    this.statisticsService.getLastDays(username, days).subscribe((result: any) => {
-      this.isLoading = false;
-      this.activitySolved = result.solved;
-      const data = [];
-      let days = 0;
-      for (const y of result.series) {
-        const dt = new Date();
-        dt.setDate(dt.getDate() - days);
-        data.push({
-          x: dt,
-          y: y,
-        });
-        days++;
-      }
-      this.activityChart = {
-        chart: {
-          type: 'line',
-          sparkline: {
-            enabled: true
-          },
-        },
-        dataLabels: {
-          enabled: false
-        },
-        xaxis: {
-          type: 'datetime',
-        },
-        stroke: {
-          curve: 'smooth',
-          width: 2
-        },
-        yaxis: {
-          labels: {
-            show: false,
-            formatter(val: number): string {
-              return val.toFixed(0);
-            }
-          }
-        },
-        series: [
-          {
-            name: this.translateService.instant('Solved'),
-            data: data,
-          }
-        ],
-      };
-    });
+  onDaysChange(value: number) {
+    if (this.activityDays === value) {
+      return;
+    }
+
+    this.activityDays = value;
+    this.daysChange.emit(value);
   }
 
+  private updateActivity(activity: LastDaysStatistics) {
+    if (!activity) {
+      this.isLoading = true;
+      this.activityChart = undefined;
+      this.activitySolved = 0;
+      return;
+    }
+
+    this.isLoading = false;
+    this.activitySolved = activity.solved;
+
+    const data = [];
+    const now = new Date();
+    const series = activity.series ?? [];
+
+    for (let index = 0; index < series.length; index++) {
+      const dayOffset = series.length - index - 1;
+      const date = new Date(now);
+      date.setDate(now.getDate() - dayOffset);
+      data.push({
+        x: date,
+        y: series[index],
+      });
+    }
+
+    this.activityChart = {
+      chart: {
+        type: 'line',
+        sparkline: {
+          enabled: true
+        },
+      },
+      dataLabels: {
+        enabled: false
+      },
+      xaxis: {
+        type: 'datetime',
+      },
+      stroke: {
+        curve: 'smooth',
+        width: 2
+      },
+      yaxis: {
+        labels: {
+          show: false,
+          formatter: (val: number) => val.toFixed(0),
+        }
+      },
+      series: [
+        {
+          name: this.translateService.instant('Solved'),
+          data,
+        }
+      ],
+    };
+  }
 }

--- a/src/app/modules/problems/models/statistics.models.ts
+++ b/src/app/modules/problems/models/statistics.models.ts
@@ -4,3 +4,110 @@ export interface GeneralInfo {
   rank: number;
   usersCount: number;
 }
+
+export interface DifficultyStatistics {
+  beginner: number;
+  allBeginner: number;
+  basic: number;
+  allBasic: number;
+  normal: number;
+  allNormal: number;
+  medium: number;
+  allMedium: number;
+  advanced: number;
+  allAdvanced: number;
+  hard: number;
+  allHard: number;
+  extremal: number;
+  allExtremal: number;
+  totalSolved: number;
+  totalProblems: number;
+}
+
+export interface LangStatistics {
+  lang: string;
+  langFull: string;
+  solved: number;
+}
+
+export interface TagStatistics {
+  name: string;
+  value: number;
+}
+
+export interface TopicStatistics {
+  topic: string;
+  solved: number;
+  code: string;
+  id: number;
+}
+
+export interface WeekdayStatistics {
+  day: string;
+  solved: number;
+}
+
+export interface MonthStatistics {
+  month: string;
+  solved: number;
+}
+
+export interface PeriodStatistics {
+  period: string;
+  solved: number;
+}
+
+export interface ProblemsFacts {
+  firstAttempt: any;
+  lastAttempt: any;
+  firstAccepted: any;
+  lastAccepted: any;
+  mostAttemptedProblem: any;
+  mostAttemptedForSolveProblem: any;
+  solvedWithSingleAttempt: number;
+  solvedWithSingleAttemptPercentage: number;
+}
+
+export interface LastDaysStatistics {
+  series: number[];
+  solved: number;
+}
+
+export interface HeatmapEntry {
+  date: string;
+  solved: number;
+}
+
+export interface NumberOfAttemptsEntry {
+  attemptsCount: number;
+  value: number;
+}
+
+export interface NumberOfAttemptsStatistics {
+  chartSeries: NumberOfAttemptsEntry[];
+}
+
+export interface ProblemsStatisticsMeta {
+  lastDays: number;
+  allowedLastDays: number[];
+  heatmapRange?: {
+    from: string;
+    to: string;
+  };
+}
+
+export interface ProblemsStatisticsResponse {
+  general: GeneralInfo;
+  byDifficulty: DifficultyStatistics;
+  byTopic: TopicStatistics[];
+  byLang: LangStatistics[];
+  byTag: TagStatistics[];
+  byWeekday: WeekdayStatistics[];
+  byMonth: MonthStatistics[];
+  byPeriod: PeriodStatistics[];
+  facts: ProblemsFacts;
+  lastDays: LastDaysStatistics;
+  heatmap: HeatmapEntry[];
+  numberOfAttempts: NumberOfAttemptsStatistics;
+  meta: ProblemsStatisticsMeta;
+}

--- a/src/app/modules/problems/pages/statistics/section-activity/section-activity.component.html
+++ b/src/app/modules/problems/pages/statistics/section-activity/section-activity.component.html
@@ -1,1 +1,6 @@
-<problems-activity-card [username]="username"></problems-activity-card>
+<problems-activity-card
+  [activity]="activity"
+  [allowedDays]="allowedDays"
+  [days]="days"
+  (daysChange)="daysChange.emit($event)"
+></problems-activity-card>

--- a/src/app/modules/problems/pages/statistics/section-activity/section-activity.component.ts
+++ b/src/app/modules/problems/pages/statistics/section-activity/section-activity.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { CoreCommonModule } from '@core/common.module';
 import {
   ProblemsActivityCardComponent
 } from '@problems/components/problems-activity-card/problems-activity-card.component';
+import { LastDaysStatistics } from '@problems/models/statistics.models';
 
 @Component({
   selector: 'section-activity',
@@ -15,5 +16,8 @@ import {
   ]
 })
 export class SectionActivityComponent {
-  @Input() username: string;
+  @Input() activity: LastDaysStatistics;
+  @Input() allowedDays: number[] = [];
+  @Input() days = 7;
+  @Output() daysChange = new EventEmitter<number>();
 }

--- a/src/app/modules/problems/pages/statistics/section-difficulties/section-difficulties.component.ts
+++ b/src/app/modules/problems/pages/statistics/section-difficulties/section-difficulties.component.ts
@@ -1,6 +1,5 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { ProblemsStatisticsService } from '@problems/services/problems-statistics.service';
 import { SwiperOptions } from 'swiper/types/swiper-options';
 import { CoreCommonModule } from '@core/common.module';
 import { ApexChartModule } from '@shared/third-part-modules/apex-chart/apex-chart.module';
@@ -9,25 +8,7 @@ import { NgbProgressbarModule } from '@ng-bootstrap/ng-bootstrap';
 import { ProblemsPipesModule } from '@problems/pipes/problems-pipes.module';
 import { ChartOptions } from '@shared/third-part-modules/apex-chart/chart-options.type';
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
-
-export interface Difficulties {
-  beginner: number;
-  allBeginner: number;
-  basic: number;
-  allBasic: number;
-  normal: number;
-  allNormal: number;
-  medium: number;
-  allMedium: number;
-  advanced: number;
-  allAdvanced: number;
-  hard: number;
-  allHard: number;
-  extremal: number;
-  allExtremal: number;
-  totalSolved: number;
-  totalProblems: number;
-}
+import { DifficultyStatistics } from '@problems/models/statistics.models';
 
 @Component({
   selector: 'section-difficulties',
@@ -43,9 +24,9 @@ export interface Difficulties {
     KepCardComponent,
   ]
 })
-export class SectionDifficultiesComponent implements OnInit {
+export class SectionDifficultiesComponent implements OnChanges {
 
-  @Input() username: string;
+  @Input() data: DifficultyStatistics;
 
   public difficulties: Difficulties = {
     beginner: 0,
@@ -76,91 +57,91 @@ export class SectionDifficultiesComponent implements OnInit {
   };
 
   constructor(
-    public statisticsService: ProblemsStatisticsService,
     public translateService: TranslateService,
   ) {}
 
-  ngOnInit(): void {
-    this.statisticsService.getByDifficulty(this.username).subscribe(
-      (difficulties: Difficulties) => {
-        this.difficulties = difficulties;
-        this.chartOptions = {
-          series: [100 * difficulties.totalSolved / difficulties.totalProblems],
-          chart: {
-            height: '200px',
-            type: 'radialBar',
-            toolbar: {
-              show: false,
-            }
-          },
-          plotOptions: {
-            radialBar: {
-              startAngle: -135,
-              endAngle: 225,
-              hollow: {
-                margin: 0,
-                size: '70%',
-                image: undefined,
-                position: 'front',
-                dropShadow: {
-                  enabled: true,
-                  top: 3,
-                  left: 0,
-                  blur: 4,
-                  opacity: 0.24
-                }
-              },
-              track: {
-                strokeWidth: '67%',
-                margin: 0, // margin is in pixels
-                dropShadow: {
-                  enabled: true,
-                  top: -3,
-                  left: 0,
-                  blur: 4,
-                  opacity: 0.35
-                }
-              },
-
-              dataLabels: {
-                show: true,
-                name: {
-                  offsetY: -10,
-                  show: true,
-                  color: '#888',
-                  fontSize: '17px'
-                },
-                value: {
-                  formatter: function (val) {
-                    return parseInt(val.toString(), 10).toString();
-                  },
-                  color: '#111',
-                  fontSize: '36px',
-                  show: true
-                }
-              }
-            }
-          },
-          fill: {
-            type: 'gradient',
-            gradient: {
-              shade: 'dark',
-              type: 'horizontal',
-              shadeIntensity: 0.5,
-              gradientToColors: ['#ABE5A1'],
-              inverseColors: true,
-              opacityFrom: 1,
-              opacityTo: 1,
-              stops: [0, 100]
-            }
-          },
-          stroke: {
-            lineCap: 'round'
-          },
-          labels: [this.translateService.instant('Percent')]
-        };
-      }
-    );
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['data'] && this.data) {
+      this.updateDifficulties(this.data);
+    }
   }
 
+  private updateDifficulties(difficulties: DifficultyStatistics) {
+    this.difficulties = difficulties;
+    const completion = difficulties.totalProblems ? (100 * difficulties.totalSolved / difficulties.totalProblems) : 0;
+    this.chartOptions = {
+      series: [completion],
+      chart: {
+        height: '200px',
+        type: 'radialBar',
+        toolbar: {
+          show: false,
+        }
+      },
+      plotOptions: {
+        radialBar: {
+          startAngle: -135,
+          endAngle: 225,
+          hollow: {
+            margin: 0,
+            size: '70%',
+            position: 'front',
+            dropShadow: {
+              enabled: true,
+              top: 3,
+              left: 0,
+              blur: 4,
+              opacity: 0.24
+            }
+          },
+          track: {
+            strokeWidth: '67%',
+            margin: 0,
+            dropShadow: {
+              enabled: true,
+              top: -3,
+              left: 0,
+              blur: 4,
+              opacity: 0.35
+            }
+          },
+
+          dataLabels: {
+            show: true,
+            name: {
+              offsetY: -10,
+              show: true,
+              color: '#888',
+              fontSize: '17px'
+            },
+            value: {
+              formatter: (val: number) => parseInt(val.toString(), 10).toString(),
+              color: '#111',
+              fontSize: '36px',
+              show: true
+            }
+          }
+        }
+      },
+      fill: {
+        type: 'gradient',
+        gradient: {
+          shade: 'dark',
+          type: 'horizontal',
+          shadeIntensity: 0.5,
+          gradientToColors: ['#ABE5A1'],
+          inverseColors: true,
+          opacityFrom: 1,
+          opacityTo: 1,
+          stops: [0, 100]
+        }
+      },
+      stroke: {
+        lineCap: 'round'
+      },
+      labels: [this.translateService.instant('Percent')]
+    };
+  }
 }
+
+interface Difficulties extends DifficultyStatistics {}

--- a/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.ts
+++ b/src/app/modules/problems/pages/statistics/section-facts/section-facts.component.ts
@@ -1,20 +1,9 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { ProblemsStatisticsService } from '../../../services/problems-statistics.service';
+import { Component, Input } from '@angular/core';
 import { CoreCommonModule } from '@core/common.module';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { Resources } from '@app/resources';
 import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
-
-export interface Facts {
-  firstAttempt: any;
-  lastAttempt: any;
-  firstAccepted: any;
-  lastAccepted: any;
-  mostAttemptedProblem: any;
-  mostAttemptedForSolveProblem: any;
-  solvedWithSingleAttempt: number;
-  solvedWithSingleAttemptPercentage: number;
-}
+import { ProblemsFacts } from '@problems/models/statistics.models';
 
 @Component({
   selector: 'section-facts',
@@ -23,23 +12,8 @@ export interface Facts {
   standalone: true,
   imports: [CoreCommonModule, NgbTooltipModule, ResourceByIdPipe],
 })
-export class SectionFactsComponent implements OnInit {
+export class SectionFactsComponent {
 
-  @Input() username: string;
-
-  public facts: Facts;
+  @Input() facts: ProblemsFacts;
   protected readonly Resources = Resources;
-
-  constructor(
-    public statisticsService: ProblemsStatisticsService,
-  ) { }
-
-  ngOnInit(): void {
-    this.statisticsService.getFacts(this.username).subscribe(
-      (facts: Facts) => {
-        this.facts = facts;
-      }
-    );
-  }
-
 }

--- a/src/app/modules/problems/pages/statistics/section-heatmap/section-heatmap.component.html
+++ b/src/app/modules/problems/pages/statistics/section-heatmap/section-heatmap.component.html
@@ -1,34 +1,24 @@
 <div class="card heatmap">
-  <div
-    class="card-header d-flex flex-sm-row flex-column justify-content-md-between align-items-start justify-content-start">
+  <div class="card-header d-flex flex-sm-row flex-column justify-content-md-between align-items-start justify-content-start">
     <h4 class="card-title mb-sm-0 mb-1">{{ 'Heatmap' | translate }}</h4>
 
-    <div
-      class="btn-group btn-group-toggle mt-md-0 mt-1"
-      ngbRadioGroup
-      name="radioBasic"
-      [(ngModel)]="heatmapYear"
-    >
-      <label class="btn btn-outline-primary" ngbButtonLabel rippleEffect>
-        <input type="radio" (click)="heatmapUpdate(0)" name="radio_options" id="radio_option1" [value]="0" ngbButton/>
-        <span>365</span>
-      </label>
-      <label class="btn btn-outline-primary" ngbButtonLabel rippleEffect>
-        <input type="radio" (click)="heatmapUpdate(2021)" name="radio_options" id="radio_option2" ngbButton
-               [value]="2021"/>
-        <span>2021</span>
-      </label>
-      <label class="btn btn-outline-primary" ngbButtonLabel rippleEffect>
-        <input type="radio" (click)="heatmapUpdate(2022)" name="radio_options" id="radio_option3" ngbButton
-               [value]="2022"/>
-        <span>2022</span>
-      </label>
-      <label class="btn btn-outline-primary" ngbButtonLabel rippleEffect>
-        <input type="radio" (click)="heatmapUpdate(2023)" name="radio_options" id="radio_option4" ngbButton
-               [value]="2023"/>
-        <span>2023</span>
-      </label>
-    </div>
+    @if (years?.length) {
+      <div class="btn-group btn-group-toggle mt-md-0 mt-1">
+        @for (year of years; track year) {
+          <label class="btn btn-outline-primary" [class.active]="heatmapYear === year">
+            <input
+              type="radio"
+              [name]="'heatmap-year'"
+              class="btn-check"
+              [value]="year"
+              [checked]="heatmapYear === year"
+              (change)="onYearChange(year)"
+            />
+            <span>{{ year }}</span>
+          </label>
+        }
+      </div>
+    }
 
   </div>
   <div class="card-body">

--- a/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.ts
+++ b/src/app/modules/problems/pages/statistics/section-profile/section-profile.component.ts
@@ -1,30 +1,14 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { AuthService } from '@auth';
-import { ProblemsStatisticsService } from '@problems/services/problems-statistics.service';
+import { Component, Input } from '@angular/core';
 import { CoreCommonModule } from '@core/common.module';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
-import { GeneralInfo } from '@problems/models/statistics.models';
+import {
+  GeneralInfo,
+  LangStatistics,
+  TagStatistics,
+  TopicStatistics,
+} from '@problems/models/statistics.models';
 import { getCategoryIcon } from '@problems/utils/category';
 import { Resources } from "@app/resources";
-
-interface LangInfo {
-  lang: string;
-  langFull: string;
-  solved: number;
-}
-
-interface TagInfo {
-  name: string;
-  value: number;
-}
-
-interface TopicInfo {
-  topic: string;
-  solved: number;
-  code: string;
-  id: number;
-  icon: string;
-}
 
 @Component({
   selector: 'section-profile',
@@ -36,56 +20,55 @@ interface TopicInfo {
     NgbTooltipModule,
   ]
 })
-export class SectionProfileComponent implements OnInit {
+export class SectionProfileComponent {
 
   @Input() username: string;
 
+  @Input() set general(value: GeneralInfo) {
+    this._general = value ?? this._general;
+  }
+
+  get general() {
+    return this._general;
+  }
+
+  @Input() set langs(value: LangStatistics[]) {
+    this._langs = [...(value ?? [])].sort((a, b) => b.solved - a.solved);
+  }
+
+  get langs() {
+    return this._langs;
+  }
+
+  @Input() set tags(value: TagStatistics[]) {
+    this._tags = [...(value ?? [])].sort((a, b) => b.value - a.value);
+  }
+
+  get tags() {
+    return this._tags;
+  }
+
+  @Input() set topics(value: TopicStatistics[]) {
+    this._topics = (value ?? []).map((topic) => ({
+      ...topic,
+      icon: getCategoryIcon(topic.id),
+    }));
+  }
+
+  get topics() {
+    return this._topics;
+  }
+
   public readonly Resources = Resources;
 
-  public general: GeneralInfo = {
+  private _general: GeneralInfo = {
     solved: 0,
     rating: 0,
     rank: 0,
     usersCount: 0,
   };
 
-  public langs: Array<LangInfo> = [];
-  public tags: Array<TagInfo> = [];
-  public topics: Array<TopicInfo> = [];
-
-  constructor(
-    public authService: AuthService,
-    public statisticsService: ProblemsStatisticsService,
-  ) {
-  }
-
-  ngOnInit(): void {
-    this.statisticsService.getGeneral(this.username).subscribe(
-      (general: GeneralInfo) => {
-        this.general = general;
-      }
-    );
-
-    this.statisticsService.getByLang(this.username).subscribe(
-      (langs: Array<LangInfo>) => {
-        this.langs = langs.sort((a, b) => b.solved - a.solved);
-      }
-    );
-
-    this.statisticsService.getByTag(this.username).subscribe(
-      (tags: Array<TagInfo>) => {
-        this.tags = tags.sort((a, b) => b.value - a.value);
-      }
-    );
-
-    this.statisticsService.getByTopic(this.username).subscribe(
-      (topics: Array<TopicInfo>) => {
-        this.topics = topics.map((topic) => {
-          topic.icon = getCategoryIcon(topic.id);
-          return topic;
-        });
-      }
-    );
-  }
-
+  private _langs: LangStatistics[] = [];
+  private _tags: TagStatistics[] = [];
+  private _topics: Array<TopicStatistics & { icon: string }> = [];
 }

--- a/src/app/modules/problems/pages/statistics/section-time/section-time.component.ts
+++ b/src/app/modules/problems/pages/statistics/section-time/section-time.component.ts
@@ -1,8 +1,12 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { ProblemsStatisticsService } from '@problems/services/problems-statistics.service';
 import { CoreCommonModule } from '@core/common.module';
 import { ApexChartModule } from '@shared/third-part-modules/apex-chart/apex-chart.module';
+import {
+  WeekdayStatistics,
+  MonthStatistics,
+  PeriodStatistics,
+} from '@problems/models/statistics.models';
 
 @Component({
   selector: 'section-time',
@@ -14,122 +18,93 @@ import { ApexChartModule } from '@shared/third-part-modules/apex-chart/apex-char
     ApexChartModule,
   ]
 })
-export class SectionTimeComponent implements OnInit {
+export class SectionTimeComponent implements OnChanges {
 
-  @Input() username: string;
-  @Input() chartTheme: any;
+  @Input() weekdays: WeekdayStatistics[] = [];
+  @Input() months: MonthStatistics[] = [];
+  @Input() periods: PeriodStatistics[] = [];
 
   public byWeekdayChart: any;
   public byMonthChart: any;
   public byPeriodChart: any;
 
   constructor(
-    public statisticsService: ProblemsStatisticsService,
     public translateService: TranslateService,
   ) { }
 
-  ngOnInit(): void {
-    this.statisticsService.getByWeekday(this.username).subscribe(
-      (result: any) => {
-        const values = [];
-        const labels = [];
-        for (const data of result) {
-          labels.push(this.translateService.instant(data.day));
-          values.push(data.solved);
-        }
-        this.byWeekdayChart = {
-          series: [
-            {
-              name: this.translateService.instant('Solved'),
-              data: values,
-            }
-          ],
-          chart: {
-            type: 'bar',
-            height: 350,
-          },
-          plotOptions: {
-            bar: {
-              horizontal: true
-            }
-          },
-          dataLabels: {
-            enabled: false
-          },
-          xaxis: {
-            categories: labels
-          }
-        };
-      }
-    );
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['weekdays']) {
+      this.buildWeekdayChart();
+    }
 
-    this.statisticsService.getByMonth(this.username).subscribe(
-      (result: any) => {
-        const values = [];
-        const labels = [];
-        for (const data of result) {
-          labels.push(this.translateService.instant(data.month));
-          values.push(data.solved);
-        }
-        this.byMonthChart = {
-          series: [
-            {
-              name: this.translateService.instant('Solved'),
-              data: values,
-            }
-          ],
-          chart: {
-            type: 'bar',
-            height: 350,
-          },
-          plotOptions: {
-            bar: {
-              horizontal: true
-            }
-          },
-          dataLabels: {
-            enabled: false
-          },
-          xaxis: {
-            categories: labels
-          }
-        };
-      }
-    );
+    if (changes['months']) {
+      this.buildMonthChart();
+    }
 
-    this.statisticsService.getByPeriod(this.username).subscribe(
-      (result: any) => {
-        const values = [];
-        const labels = [];
-        for (const data of result) {
-          labels.push(data.period);
-          values.push(data.solved);
-        }
-        this.byPeriodChart = {
-          series: [
-            {
-              name: this.translateService.instant('Solved'),
-              data: values,
-            }
-          ],
-          chart: {
-            type: 'bar',
-            height: 350,
-          },
-          plotOptions: {
-            bar: {
-              horizontal: true
-            }
-          },
-          dataLabels: {
-            enabled: false
-          },
-          xaxis: {
-            categories: labels
-          }
-        };
-      }
-    );
+    if (changes['periods']) {
+      this.buildPeriodChart();
+    }
   }
 
+  private buildWeekdayChart() {
+    if (!this.weekdays) {
+      this.byWeekdayChart = null;
+      return;
+    }
+
+    const labels = this.weekdays.map((item) => this.translateService.instant(item.day));
+    const values = this.weekdays.map((item) => item.solved);
+
+    this.byWeekdayChart = this.createHorizontalBarChart(labels, values);
+  }
+
+  private buildMonthChart() {
+    if (!this.months) {
+      this.byMonthChart = null;
+      return;
+    }
+
+    const labels = this.months.map((item) => this.translateService.instant(item.month));
+    const values = this.months.map((item) => item.solved);
+
+    this.byMonthChart = this.createHorizontalBarChart(labels, values);
+  }
+
+  private buildPeriodChart() {
+    if (!this.periods) {
+      this.byPeriodChart = null;
+      return;
+    }
+
+    const labels = this.periods.map((item) => item.period);
+    const values = this.periods.map((item) => item.solved);
+
+    this.byPeriodChart = this.createHorizontalBarChart(labels, values);
+  }
+
+  private createHorizontalBarChart(labels: string[], values: number[]) {
+    return {
+      series: [
+        {
+          name: this.translateService.instant('Solved'),
+          data: values,
+        }
+      ],
+      chart: {
+        type: 'bar',
+        height: 350,
+      },
+      plotOptions: {
+        bar: {
+          horizontal: true
+        }
+      },
+      dataLabels: {
+        enabled: false
+      },
+      xaxis: {
+        categories: labels
+      }
+    };
+  }
 }

--- a/src/app/modules/problems/pages/statistics/statistics.component.html
+++ b/src/app/modules/problems/pages/statistics/statistics.component.html
@@ -1,35 +1,95 @@
 @if (username) {
   <div class="content-wrapper container-xxl p-0">
-    <div class="content-body">
-      <section class="mt-2">
-        <div class="row">
-          <div class="col-lg-3 col-md-6 col-sm-12">
-            <section-profile [username]="username"></section-profile>
-          </div>
-          <div class="col-lg-9 col-md-6 col-sm-12">
-            <div class="row">
-              <div class="col-lg-6 col-12">
-                <section-difficulties [username]="username"></section-difficulties>
+    <div class="content-body problems-statistics">
+      @if (!statistics && isLoading) {
+        <div class="statistics-spinner">
+          <spinner></spinner>
+        </div>
+      }
+
+      @if (statistics) {
+        <div class="statistics-layout">
+          <div class="row g-2">
+            <div class="col-12">
+              <div class="row g-2">
+                @for (card of overviewCards; track card.key) {
+                  <div class="col-sm-6 col-xl-3">
+                    <kep-card class="overview-card">
+                      <div class="card-body d-flex align-items-center justify-content-between">
+                        <div>
+                          <p class="card-label mb-25">{{ card.label | translate }}</p>
+                          <h3 class="card-value mb-0">{{ card.value }}</h3>
+                          @if (card.subtitle) {
+                            <p class="card-subtitle mb-0 text-muted">{{ card.subtitle }}</p>
+                          }
+                        </div>
+                        <div class="avatar bg-{{ card.iconColor }}-transparent p-50">
+                          <div class="avatar-content">
+                            <kep-icon [name]="card.icon"></kep-icon>
+                          </div>
+                        </div>
+                      </div>
+                    </kep-card>
+                  </div>
+                }
               </div>
-              <div class="col-lg-6 col-12">
-                <section-activity [username]="username"></section-activity>
-              </div>
-              <div class="col-12">
-                <section-heatmap [username]="username"></section-heatmap>
-              </div>
-              <div class="col-lg-6 col-12">
-                <section-facts [username]="username"></section-facts>
-              </div>
-              <div class="col-lg-6 col-12">
-                <section-attempts-for-solve [username]="username"></section-attempts-for-solve>
-              </div>
-              <div class="col-12">
-                <section-time [username]="username"></section-time>
+            </div>
+
+            <div class="col-xl-3 col-lg-4 col-md-6">
+              <section-profile
+                [username]="username"
+                [general]="statistics.general"
+                [langs]="statistics.byLang"
+                [tags]="statistics.byTag"
+                [topics]="statistics.byTopic"
+              ></section-profile>
+            </div>
+
+            <div class="col-xl-9 col-lg-8">
+              <div class="row g-2">
+                <div class="col-xl-6 col-lg-12">
+                  <section-activity
+                    [activity]="statistics.lastDays"
+                    [allowedDays]="allowedDays"
+                    [days]="selectedDays"
+                    (daysChange)="onActivityRangeChange($event)"
+                  ></section-activity>
+                </div>
+                <div class="col-xl-6 col-lg-12">
+                  <section-difficulties [data]="statistics.byDifficulty"></section-difficulties>
+                </div>
+                <div class="col-12">
+                  <section-heatmap
+                    [heatmap]="statistics.heatmap"
+                    [years]="availableYears"
+                    [selectedYear]="selectedYear"
+                    (yearChange)="onHeatmapYearChange($event)"
+                  ></section-heatmap>
+                </div>
+                <div class="col-xl-6 col-lg-12">
+                  <section-facts [facts]="statistics.facts"></section-facts>
+                </div>
+                <div class="col-xl-6 col-lg-12">
+                  <section-attempts-for-solve [data]="statistics.numberOfAttempts"></section-attempts-for-solve>
+                </div>
+                <div class="col-12">
+                  <section-time
+                    [weekdays]="statistics.byWeekday"
+                    [months]="statistics.byMonth"
+                    [periods]="statistics.byPeriod"
+                  ></section-time>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </section>
+      }
+
+      @if (isLoading && statistics) {
+        <div class="statistics-overlay">
+          <spinner></spinner>
+        </div>
+      }
     </div>
   </div>
 }

--- a/src/app/modules/problems/pages/statistics/statistics.component.scss
+++ b/src/app/modules/problems/pages/statistics/statistics.component.scss
@@ -1,0 +1,46 @@
+.problems-statistics {
+  position: relative;
+
+  .statistics-spinner {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 320px;
+  }
+
+  .statistics-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(255, 255, 255, 0.75);
+    z-index: 5;
+
+    .dark-layout & {
+      background-color: rgba(34, 34, 34, 0.8);
+    }
+  }
+
+  .overview-card {
+    height: 100%;
+
+    .card-label {
+      font-size: 0.95rem;
+      font-weight: 600;
+    }
+
+    .card-value {
+      font-size: 2rem;
+      font-weight: 700;
+    }
+
+    .card-subtitle {
+      font-size: 0.85rem;
+    }
+
+    .avatar {
+      border-radius: 50%;
+    }
+  }
+}

--- a/src/app/modules/problems/pages/statistics/statistics.component.ts
+++ b/src/app/modules/problems/pages/statistics/statistics.component.ts
@@ -1,18 +1,24 @@
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { CoreCommonModule } from '@core/common.module';
 import { SectionProfileComponent } from '@problems/pages/statistics/section-profile/section-profile.component';
-import {
-  SectionDifficultiesComponent
-} from '@problems/pages/statistics/section-difficulties/section-difficulties.component';
+import { SectionDifficultiesComponent } from '@problems/pages/statistics/section-difficulties/section-difficulties.component';
 import { SectionActivityComponent } from '@problems/pages/statistics/section-activity/section-activity.component';
 import { SectionHeatmapComponent } from '@problems/pages/statistics/section-heatmap/section-heatmap.component';
 import { SectionFactsComponent } from '@problems/pages/statistics/section-facts/section-facts.component';
 import { SectionTimeComponent } from '@problems/pages/statistics/section-time/section-time.component';
-import {
-  SectionAttemptsForSolveComponent
-} from '@problems/pages/statistics/section-attempts-for-solve/section-attempts-for-solve.component';
+import { SectionAttemptsForSolveComponent } from '@problems/pages/statistics/section-attempts-for-solve/section-attempts-for-solve.component';
 import { BaseComponent } from '@core/common/classes/base.component';
 import { AuthUser } from '@auth';
+import { ProblemsStatisticsService } from '@problems/services/problems-statistics.service';
+import { takeUntil } from 'rxjs/operators';
+import {
+  ProblemsStatisticsResponse,
+  ProblemsStatisticsMeta,
+  HeatmapEntry,
+} from '@problems/models/statistics.models';
+import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
 
 @Component({
   selector: 'app-statistics',
@@ -28,23 +34,174 @@ import { AuthUser } from '@auth';
     SectionHeatmapComponent,
     SectionFactsComponent,
     SectionTimeComponent,
-    SectionAttemptsForSolveComponent
+    SectionAttemptsForSolveComponent,
+    SpinnerComponent,
+    KepCardComponent,
+    KepIconComponent,
   ]
 })
 export class StatisticsComponent extends BaseComponent implements OnInit {
   public username: string;
 
+  public isLoading = false;
+  public statistics: ProblemsStatisticsResponse;
+  public overviewCards: StatisticsOverviewCard[] = [];
+  public allowedDays: number[] = [];
+  public selectedDays = 7;
+  public availableYears: number[] = [];
+  public selectedYear = new Date().getFullYear();
+
+  private queryUsername: string;
+
+  constructor(
+    private statisticsService: ProblemsStatisticsService,
+  ) {
+    super();
+  }
+
   ngOnInit(): void {
     this.route.queryParams.subscribe(
       (params: any) => {
-        if (params['username']) {
-          this.username = params['username'];
-        }
+        this.queryUsername = params['username'];
+        this.applyUsername();
       }
     );
   }
 
   afterChangeCurrentUser(currentUser: AuthUser) {
-    this.username = currentUser.username;
+    this.applyUsername();
   }
+
+  onActivityRangeChange(days: number) {
+    this.selectedDays = days;
+    this.fetchStatistics();
+  }
+
+  onHeatmapYearChange(year: number) {
+    this.selectedYear = year;
+    this.fetchStatistics();
+  }
+
+  private applyUsername() {
+    const targetUsername = this.queryUsername || this.currentUser?.username;
+
+    if (!targetUsername || targetUsername === this.username) {
+      return;
+    }
+
+    if (this.username && this.username !== targetUsername) {
+      this.statisticsService.clearCache(this.username);
+    }
+
+    this.username = targetUsername;
+    this.fetchStatistics();
+  }
+
+  private fetchStatistics() {
+    if (!this.username) {
+      return;
+    }
+
+    this.isLoading = true;
+
+    this.statisticsService.getStatistics(this.username, {
+      days: this.selectedDays,
+      year: this.selectedYear,
+    }).pipe(takeUntil(this._unsubscribeAll))
+      .subscribe({
+        next: (response) => {
+          this.statistics = response;
+          this.updateMeta(response.meta, response.heatmap);
+          this.buildOverviewCards(response);
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.isLoading = false;
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  private updateMeta(meta: ProblemsStatisticsMeta, heatmap: HeatmapEntry[]) {
+    this.allowedDays = (meta?.allowedLastDays || []).slice().sort((a, b) => a - b);
+
+    if (meta?.lastDays && meta.lastDays !== this.selectedDays) {
+      this.selectedDays = meta.lastDays;
+    } else if (this.allowedDays.length && !this.allowedDays.includes(this.selectedDays)) {
+      this.selectedDays = this.allowedDays[0];
+    }
+
+    const yearsFromRange = this.buildYears(meta?.heatmapRange);
+    const yearsFromHeatmap = Array.from(new Set((heatmap || []).map((entry) => new Date(entry.date).getFullYear())));
+    const combinedYears = Array.from(new Set([...yearsFromRange, ...yearsFromHeatmap]));
+
+    this.availableYears = combinedYears.sort((a, b) => b - a);
+
+    if (this.availableYears.length && !this.availableYears.includes(this.selectedYear)) {
+      this.selectedYear = this.availableYears[0];
+    }
+  }
+
+  private buildOverviewCards(statistics: ProblemsStatisticsResponse) {
+    this.overviewCards = [
+      {
+        key: 'solved',
+        label: 'Solved',
+        value: statistics.general?.solved ?? 0,
+        icon: 'check-circle',
+        iconColor: 'success',
+      },
+      {
+        key: 'rating',
+        label: 'Rating',
+        value: statistics.general?.rating ?? 0,
+        icon: 'rating',
+        iconColor: 'warning',
+      },
+      {
+        key: 'rank',
+        label: 'Rank',
+        value: statistics.general?.rank ?? 0,
+        subtitle: statistics.general?.usersCount ? this.translateService.instant('Users') + ': ' + statistics.general.usersCount : '',
+        icon: 'users',
+        iconColor: 'primary',
+      },
+      {
+        key: 'singleAttempt',
+        label: 'SolvedWithSingleAttempt',
+        value: statistics.facts?.solvedWithSingleAttempt ?? 0,
+        subtitle: statistics.facts?.solvedWithSingleAttemptPercentage !== undefined
+          ? statistics.facts.solvedWithSingleAttemptPercentage + '%'
+          : '',
+        icon: 'zap',
+        iconColor: 'info',
+      },
+    ];
+  }
+
+  private buildYears(range?: { from: string; to: string }): number[] {
+    if (!range?.from || !range?.to) {
+      return [];
+    }
+
+    const startYear = new Date(range.from).getFullYear();
+    const endYear = new Date(range.to).getFullYear();
+
+    const years: number[] = [];
+    for (let year = endYear; year >= startYear; year--) {
+      years.push(year);
+    }
+
+    return years;
+  }
+}
+
+interface StatisticsOverviewCard {
+  key: string;
+  label: string;
+  value: string | number;
+  subtitle?: string;
+  icon: string;
+  iconColor: 'primary' | 'success' | 'warning' | 'info';
 }

--- a/src/app/modules/problems/services/problems-statistics.service.ts
+++ b/src/app/modules/problems/services/problems-statistics.service.ts
@@ -1,67 +1,126 @@
 import { Injectable } from '@angular/core';
 import { ApiService } from '@core/data-access/api.service';
+import { map, shareReplay, tap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import {
+  LastDaysStatistics,
+  ProblemsFacts,
+  ProblemsStatisticsResponse,
+  DifficultyStatistics,
+  LangStatistics,
+  TagStatistics,
+  TopicStatistics,
+  WeekdayStatistics,
+  MonthStatistics,
+  PeriodStatistics,
+  NumberOfAttemptsStatistics,
+  GeneralInfo,
+  HeatmapEntry,
+} from '@problems/models/statistics.models';
+
+export interface ProblemsStatisticsParams {
+  year?: number;
+  days?: number;
+}
 
 @Injectable({
   providedIn: 'root'
 })
 export class ProblemsStatisticsService {
 
+  private cache = new Map<string, Observable<ProblemsStatisticsResponse>>();
+
   constructor(
     public api: ApiService,
   ) { }
 
-  getGeneral(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-general/`);
+  getStatistics(username: string, params: ProblemsStatisticsParams = {}): Observable<ProblemsStatisticsResponse> {
+    const query = this.buildQuery(params);
+    const cacheKey = this.buildCacheKey(username, query.year, query.days);
+
+    if (!this.cache.has(cacheKey)) {
+      const request$ = this.api.get<ProblemsStatisticsResponse>(`problems-rating/${username}/statistics`, query).pipe(
+        tap({
+          error: () => this.cache.delete(cacheKey),
+        }),
+        shareReplay(1),
+      );
+
+      this.cache.set(cacheKey, request$);
+    }
+
+    return this.cache.get(cacheKey);
   }
 
-  getByDifficulty(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-difficulty/`);
+  clearCache(username?: string) {
+    if (!username) {
+      this.cache.clear();
+      return;
+    }
+
+    Array.from(this.cache.keys())
+      .filter((key) => key.startsWith(`${username}|`))
+      .forEach((key) => this.cache.delete(key));
   }
 
-  getByTag(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-tag/`);
+  getGeneral(username: string, params: ProblemsStatisticsParams = {}) {
+    return this.getStatistics(username, params).pipe(map((response) => response.general as GeneralInfo));
   }
 
-  getByVerdict(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-verdict/`);
+  getByDifficulty(username: string, params: ProblemsStatisticsParams = {}) {
+    return this.getStatistics(username, params).pipe(map((response) => response.byDifficulty as DifficultyStatistics));
   }
 
-  getByLang(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-lang/`);
+  getByTag(username: string, params: ProblemsStatisticsParams = {}) {
+    return this.getStatistics(username, params).pipe(map((response) => response.byTag as TagStatistics[]));
   }
 
-  getByTopic(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-topic/`);
+  getByLang(username: string, params: ProblemsStatisticsParams = {}) {
+    return this.getStatistics(username, params).pipe(map((response) => response.byLang as LangStatistics[]));
   }
 
-  getByWeekday(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-weekday/`);
+  getByTopic(username: string, params: ProblemsStatisticsParams = {}) {
+    return this.getStatistics(username, params).pipe(map((response) => response.byTopic as TopicStatistics[]));
   }
 
-  getByPeriod(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-period/`);
+  getByWeekday(username: string, params: ProblemsStatisticsParams = {}) {
+    return this.getStatistics(username, params).pipe(map((response) => response.byWeekday as WeekdayStatistics[]));
   }
 
-  getByMonth(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-by-month/`);
+  getByPeriod(username: string, params: ProblemsStatisticsParams = {}) {
+    return this.getStatistics(username, params).pipe(map((response) => response.byPeriod as PeriodStatistics[]));
   }
 
-  getFacts(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-facts/`);
+  getByMonth(username: string, params: ProblemsStatisticsParams = {}) {
+    return this.getStatistics(username, params).pipe(map((response) => response.byMonth as MonthStatistics[]));
   }
 
-  getNumberOfAttemptsForSolve(username: string) {
-    return this.api.get(`problems-rating/${username}/statistics-number-of-attempts-for-solve/`);
+  getFacts(username: string, params: ProblemsStatisticsParams = {}) {
+    return this.getStatistics(username, params).pipe(map((response) => response.facts as ProblemsFacts));
   }
 
-  getLastDays(username: string, days: number) {
-    let params = {days: days};
-    return this.api.get(`problems-rating/${username}/statistics-last-days/`, params);
+  getNumberOfAttemptsForSolve(username: string, params: ProblemsStatisticsParams = {}) {
+    return this.getStatistics(username, params).pipe(map((response) => response.numberOfAttempts as NumberOfAttemptsStatistics));
   }
 
-  getHeatmap(username: string, year: number) {
-    let params = {year: year};
-    return this.api.get(`problems-rating/${username}/statistics-heatmap/`, params);
+  getLastDays(username: string, days: number, year?: number) {
+    return this.getStatistics(username, { days, year }).pipe(map((response) => response.lastDays as LastDaysStatistics));
   }
 
+  getHeatmap(username: string, year?: number) {
+    return this.getStatistics(username, { year }).pipe(map((response) => response.heatmap as HeatmapEntry[]));
+  }
+
+  private buildQuery(params: ProblemsStatisticsParams) {
+    const currentYear = new Date().getFullYear();
+
+    return {
+      year: params.year ?? currentYear,
+      days: params.days ?? 7,
+    };
+  }
+
+  private buildCacheKey(username: string, year: number, days: number) {
+    return `${username}|${year}|${days}`;
+  }
 }


### PR DESCRIPTION
## Summary
- switch problems statistics service to the new unified statistics endpoint with basic caching helpers
- refactor statistics page components to consume the shared response and deliver a refreshed dashboard-style layout
- update activity, heatmap, and attempts widgets to rely on parent-provided data and expose dynamic filters

## Testing
- npm run lint *(fails: ng CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1be961244832fbf59c8c4dc1af111