### PR TITLE
feat(problem): show statistics modal with unified data

### DIFF
--- a/src/app/modules/problems/pages/problem/problem-sidebar/problem-sidebar-statistics/problem-sidebar-statistics.component.ts
+++ b/src/app/modules/problems/pages/problem/problem-sidebar/problem-sidebar-statistics/problem-sidebar-statistics.component.ts
@@ -1,12 +1,12 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { Problem } from 'app/modules/problems/models/problems.models';
-import { ProblemsApiService } from '@problems/services/problems-api.service';
 import { colors as Colors } from '@core/config/colors';
 import { CoreCommonModule } from '@core/common.module';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { ApexChartModule } from '@shared/third-part-modules/apex-chart/apex-chart.module';
 import { ChartOptions } from '@shared/third-part-modules/apex-chart/chart-options.type';
+import { ProblemStatistics } from '../problem-statistics.model';
 
 @Component({
   selector: 'problem-sidebar-statistics',
@@ -19,188 +19,223 @@ import { ChartOptions } from '@shared/third-part-modules/apex-chart/chart-option
     ApexChartModule,
   ]
 })
-export class ProblemSidebarStatisticsComponent implements OnInit {
+export class ProblemSidebarStatisticsComponent implements OnChanges {
   @Input() problem: Problem;
+  @Input() statistics: ProblemStatistics | null = null;
 
-  public attemptStatisticsChart: ChartOptions;
-  public langStatisticsChart: ChartOptions;
-  public attemptsForSolveChart: ChartOptions;
+  public attemptStatisticsChart: ChartOptions | null = null;
+  public langStatisticsChart: ChartOptions | null = null;
+  public attemptsForSolveChart: ChartOptions | null = null;
 
   constructor(
-    public service: ProblemsApiService,
     public translate: TranslateService,
   ) { }
 
-  ngOnInit(): void {
-    this.service.getProblemVerdictStatistics(this.problem.id).subscribe((result: any) => {
-      const series = [];
-      const labels = [];
-      const colors = [];
-      for (const data of result) {
-        series.push(data.value);
-        colors.push(Colors.solid[data.color]);
-        labels.push(data.verdictTitle);
-      }
-      this.attemptStatisticsChart = {
-        series: series,
-        colors: colors,
-        labels: labels,
-        chart: {
-          type: 'donut',
-          height: 500,
-        },
-        legend: {
-          show: true,
-          position: 'bottom',
-          horizontalAlign: 'center'
-        },
-        plotOptions: {
-          pie: {
-            donut: {
-              labels: {
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['statistics']) {
+      this.buildCharts();
+    }
+  }
+
+  private buildCharts(): void {
+    if (!this.statistics) {
+      this.attemptStatisticsChart = null;
+      this.langStatisticsChart = null;
+      this.attemptsForSolveChart = null;
+      return;
+    }
+
+    this.buildAttemptStatisticsChart();
+    this.buildLanguageStatisticsChart();
+    this.buildAttemptsForSolveChart();
+  }
+
+  private buildAttemptStatisticsChart(): void {
+    const attemptStatistics = this.statistics?.attemptStatistics ?? [];
+
+    if (!attemptStatistics.length) {
+      this.attemptStatisticsChart = null;
+      return;
+    }
+
+    const series = [];
+    const labels = [];
+    const colors = [];
+
+    for (const data of attemptStatistics) {
+      series.push(data.value);
+      const color = Colors.solid[data.color] ?? Colors.solid.primary;
+      colors.push(color);
+      labels.push(data.verdictTitle);
+    }
+
+    this.attemptStatisticsChart = {
+      series,
+      colors,
+      labels,
+      chart: {
+        type: 'donut',
+        height: 500,
+      },
+      legend: {
+        show: true,
+        position: 'bottom',
+        horizontalAlign: 'center'
+      },
+      plotOptions: {
+        pie: {
+          donut: {
+            labels: {
+              show: true,
+              name: {
                 show: true,
-                name: {
-                  show: true,
-                  fontSize: '20px',
-                },
-                value: {
-                  show: true,
-                  fontSize: '26px',
-                },
-                total: {
-                  label: this.translate.instant('Attempts'),
-                  show: true,
-                },
-              }
+                fontSize: '20px',
+              },
+              value: {
+                show: true,
+                fontSize: '26px',
+              },
+              total: {
+                label: this.translate.instant('Attempts'),
+                show: true,
+              },
             }
           }
         }
-      };
-    });
-
-    this.service.getProblemLangStatistics(this.problem.id).subscribe((result: any) => {
-      const series = [];
-      const labels = [];
-      const colors = [];
-      for (const data of result) {
-        series.push(data.value);
-        colors.push(Colors.lang[data.lang]);
-        labels.push(data.langFull);
       }
-      let languagesText = '';
-      this.translate.get('Languages').subscribe((text: string) => languagesText = text);
-      this.langStatisticsChart = {
-        series: series,
-        labels: labels,
-        colors: colors,
-        chart: {
-          type: 'pie',
-          height: 500,
-        },
-        legend: {
-          show: true,
-          position: 'bottom',
-        },
-        plotOptions: {
-          pie: {
-            donut: {
-              labels: {
+    };
+  }
+
+  private buildLanguageStatisticsChart(): void {
+    const languageStatistics = this.statistics?.languageStatistics ?? [];
+
+    if (!languageStatistics.length) {
+      this.langStatisticsChart = null;
+      return;
+    }
+
+    const series = [];
+    const labels = [];
+    const colors = [];
+
+    for (const data of languageStatistics) {
+      series.push(data.value);
+      labels.push(data.langFull);
+      const color = Colors.lang[data.lang] ?? Colors.solid.primary;
+      colors.push(color);
+    }
+
+    const languagesText = this.translate.instant('Languages');
+
+    this.langStatisticsChart = {
+      series,
+      labels,
+      colors,
+      chart: {
+        type: 'pie',
+        height: 500,
+      },
+      legend: {
+        show: true,
+        position: 'bottom',
+      },
+      plotOptions: {
+        pie: {
+          donut: {
+            labels: {
+              show: true,
+              name: {
                 show: true,
-                name: {
-                  show: true,
-                  fontSize: '20px',
-                },
-                value: {
-                  show: true,
-                  fontSize: '26px',
-                  formatter: function (val) {
-                    return val + '';
-                  }
-                },
-                total: {
-                  label: languagesText,
-                  color: '#ffffff',
-                  show: true,
-                },
-              }
+                fontSize: '20px',
+              },
+              value: {
+                show: true,
+                fontSize: '26px',
+                formatter: function (val) {
+                  return `${val}`;
+                }
+              },
+              total: {
+                label: languagesText,
+                color: '#ffffff',
+                show: true,
+              },
             }
           }
         }
-      };
-    });
-
-    let numberOfAttemptsText: string;
-    this.translate.get('NumberOfAttempts').subscribe(
-      (text: string) => {
-        numberOfAttemptsText = text;
       }
-    );
+    };
+  }
 
-    let percentageText: string;
-    this.translate.get('Percent').subscribe(
-      (text: string) => {
-        percentageText = text;
-      }
-    );
+  private buildAttemptsForSolveChart(): void {
+    const attemptsForSolveStatistics = this.statistics?.attemptsForSolveStatistics ?? [];
 
-    this.service.getAttemptsForSolveStatistics(this.problem.id).subscribe((result: any) => {
-      const labels = [];
-      const data = [];
-      for (const A of result) {
-        labels.push(A.attempts);
-        data.push({
-          'x': numberOfAttemptsText + ': ' + A.attempts,
-          'y': A.value,
-        });
-      }
-      this.attemptsForSolveChart = {
-        series: [{
-          name: percentageText,
-          data: data,
-        }],
-        colors: [Colors.solid.primary],
-        chart: {
-          type: 'area',
-        },
-        labels: labels,
-        dataLabels: {
-          enabled: false
-        },
-        stroke: {
-          curve: 'straight'
-        },
-        xaxis: {
-          labels: {
-            show: false,
-          }
-        },
-        grid: {
+    if (!attemptsForSolveStatistics.length) {
+      this.attemptsForSolveChart = null;
+      return;
+    }
+
+    const labels = [];
+    const data = [];
+
+    const numberOfAttemptsText = this.translate.instant('NumberOfAttempts');
+    const percentageText = this.translate.instant('Percent');
+
+    for (const entry of attemptsForSolveStatistics) {
+      labels.push(entry.attempts);
+      data.push({
+        x: `${numberOfAttemptsText}: ${entry.attempts}`,
+        y: entry.value,
+      });
+    }
+
+    this.attemptsForSolveChart = {
+      series: [{
+        name: percentageText,
+        data,
+      }],
+      colors: [Colors.solid.primary],
+      chart: {
+        type: 'area',
+      },
+      labels,
+      dataLabels: {
+        enabled: false
+      },
+      stroke: {
+        curve: 'straight'
+      },
+      xaxis: {
+        labels: {
           show: false,
-          padding: {
-            left: 0,
-            right: 0
-          }
-        },
-        yaxis: {
-          axisBorder: {
-            show: false
-          },
-          axisTicks: {
-            show: false
-          },
-          labels: {
-            show: false,
-            formatter: function (val) {
-              return Math.trunc(val) + '%';
-            },
-          },
-          min: 50,
-          max: 100,
-        },
-        legend: {
-          horizontalAlign: 'left'
         }
-      };
-    });
+      },
+      grid: {
+        show: false,
+        padding: {
+          left: 0,
+          right: 0
+        }
+      },
+      yaxis: {
+        axisBorder: {
+          show: false
+        },
+        axisTicks: {
+          show: false
+        },
+        labels: {
+          show: false,
+          formatter: function (val) {
+            return `${Math.trunc(val)}%`;
+          },
+        },
+        min: 0,
+        max: 100,
+      },
+      legend: {
+        horizontalAlign: 'left'
+      }
+    };
   }
 }

--- a/src/app/modules/problems/pages/problem/problem-sidebar/problem-sidebar-top-attempts/problem-sidebar-top-attempts.component.html
+++ b/src/app/modules/problems/pages/problem/problem-sidebar/problem-sidebar-top-attempts/problem-sidebar-top-attempts.component.html
@@ -6,10 +6,10 @@
       </div>
     </div>
 
-    <ng-select appendTo="body" [clearable]="false" (change)="topAttemptsLoad($event)" [(ngModel)]="topAttemptsOrdering">
+    <ng-select appendTo="body" [clearable]="false" (change)="changeOrdering($event)" [(ngModel)]="topAttemptsOrdering">
       <ng-option [value]="'time'">{{ 'Time' | translate }}</ng-option>
       <ng-option [value]="'memory'">{{ 'Memory' | translate }}</ng-option>
-      <ng-option [value]="'source_code_size'">{{ 'Size' | translate }}</ng-option>
+      <ng-option [value]="'sourceCodeSize'">{{ 'Size' | translate }}</ng-option>
     </ng-select>
   </div>
 
@@ -22,7 +22,7 @@
       </tr>
       </thead>
       <tbody>
-        @for (attempt of topAttempts; track $index) {
+        @for (attempt of topAttemptsList; track $index) {
           <tr>
             <td class="text-nowrap">
               <contestant-view [imgSize]="28" [user]="attempt"></contestant-view>
@@ -40,7 +40,7 @@
                       {{ attempt.memory }}
                     </span>
                   }
-                  @case ('source_code_size') {
+                  @case ('sourceCodeSize') {
                     <span class="badge bg-dark">
                       {{ attempt.sourceCodeSize }}
                     </span>
@@ -50,6 +50,11 @@
             </td>
           </tr>
         } @empty {
+          <tr>
+            <td class="text-center text-muted" colspan="2">
+              {{ 'NoData' | translate }}
+            </td>
+          </tr>
         }
       </tbody>
     </table>

--- a/src/app/modules/problems/pages/problem/problem-sidebar/problem-sidebar.component.html
+++ b/src/app/modules/problems/pages/problem/problem-sidebar/problem-sidebar.component.html
@@ -2,36 +2,49 @@
   <kep-card>
     <div class="card-header">
       <div class="card-title">
-        @if (sidebarType == SidebarType.INFO) {
-          <span><i data-feather="info"></i></span>
-          {{ 'Info' | translate }}
-        } @else {
-          <span><i data-feather="bar-chart"></i></span>
-          {{ 'Statistics' | translate }}
-        }
+        <span><i data-feather="info"></i></span>
+        {{ 'Info' | translate }}
       </div>
 
       <div class="sidebar-type">
         <button
           rippleEffect
           class="btn btn-sm btn-primary bg-primary"
-          (click)="sidebarType=(sidebarType == SidebarType.INFO ? SidebarType.STATISTICS : SidebarType.INFO)">
-          @if (sidebarType == SidebarType.INFO) {
-            {{ 'Statistics' | translate }}
-          } @else {
-            {{ 'Info' | translate }}
-          }
+          (click)="openStatisticsModal(statisticsModal)">
+          {{ 'Statistics' | translate }}
         </button>
       </div>
     </div>
     <div class="card-body">
-      @if (sidebarType == SidebarType.INFO) {
-        <problem-info-card [problem]="problem"></problem-info-card>
-      } @else {
-        <problem-sidebar-statistics [problem]="problem"></problem-sidebar-statistics>
-      }
+      <problem-info-card [problem]="problem"></problem-info-card>
     </div>
   </kep-card>
-
-  <problem-sidebar-top-attempts [problem]="problem"></problem-sidebar-top-attempts>
 </div>
+
+<ng-template #statisticsModal let-modal>
+  <div class="modal-header">
+    <h4 class="modal-title">{{ 'Statistics' | translate }}</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss()"></button>
+  </div>
+  <div class="modal-body">
+    @if (isStatisticsLoading) {
+      <div class="d-flex justify-content-center py-4">
+        <div class="spinner-border text-primary" role="status">
+          <span class="visually-hidden">{{ 'Loading' | translate }}</span>
+        </div>
+      </div>
+    } @else if (statistics) {
+      <problem-sidebar-statistics
+        [problem]="problem"
+        [statistics]="statistics"
+      ></problem-sidebar-statistics>
+      <div class="mt-3">
+        <problem-sidebar-top-attempts [topAttempts]="statistics.topAttempts"></problem-sidebar-top-attempts>
+      </div>
+    } @else {
+      <div class="text-center text-muted py-4">
+        {{ 'NoData' | translate }}
+      </div>
+    }
+  </div>
+</ng-template>

--- a/src/app/modules/problems/pages/problem/problem-sidebar/problem-sidebar.component.ts
+++ b/src/app/modules/problems/pages/problem/problem-sidebar/problem-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, TemplateRef } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, TemplateRef } from '@angular/core';
 import { Problem } from '@problems/models/problems.models';
 import { CoreCommonModule } from '@core/common.module';
 import { ProblemInfoCardComponent } from '../../../components/problem-info-card/problem-info-card.component';
@@ -36,6 +36,7 @@ export class ProblemSidebarComponent {
   constructor(
     private readonly modalService: NgbModal,
     private readonly problemsService: ProblemsApiService,
+    private readonly cdr: ChangeDetectorRef,
   ) {}
 
   openStatisticsModal(content: TemplateRef<unknown>) {
@@ -43,17 +44,16 @@ export class ProblemSidebarComponent {
     this.statistics = null;
 
     this.modalService.open(content, {
-      size: 'xl',
+      size: 'md',
       scrollable: true,
     });
 
     this.problemsService.getProblemStatistics(this.problem.id)
-      .pipe(finalize(() => {
-        this.isStatisticsLoading = false;
-      }))
       .subscribe({
         next: (result: ProblemStatistics) => {
           this.statistics = result;
+          this.isStatisticsLoading = false;
+          this.cdr.detectChanges();
         },
         error: () => {
           this.statistics = null;

--- a/src/app/modules/problems/pages/problem/problem-sidebar/problem-sidebar.component.ts
+++ b/src/app/modules/problems/pages/problem/problem-sidebar/problem-sidebar.component.ts
@@ -1,6 +1,5 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, TemplateRef } from '@angular/core';
 import { Problem } from '@problems/models/problems.models';
-import { SidebarType } from 'app/modules/problems/constants/sidebar-type';
 import { CoreCommonModule } from '@core/common.module';
 import { ProblemInfoCardComponent } from '../../../components/problem-info-card/problem-info-card.component';
 import { ProblemSidebarStatisticsComponent } from './problem-sidebar-statistics/problem-sidebar-statistics.component';
@@ -8,6 +7,10 @@ import {
   ProblemSidebarTopAttemptsComponent
 } from './problem-sidebar-top-attempts/problem-sidebar-top-attempts.component';
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
+import { NgbModal, NgbModalModule } from '@ng-bootstrap/ng-bootstrap';
+import { ProblemsApiService } from '@problems/services/problems-api.service';
+import { finalize } from 'rxjs/operators';
+import { ProblemStatistics } from './problem-statistics.model';
 
 @Component({
   selector: 'problem-sidebar',
@@ -20,13 +23,42 @@ import { KepCardComponent } from "@shared/components/kep-card/kep-card.component
     ProblemSidebarStatisticsComponent,
     ProblemSidebarTopAttemptsComponent,
     KepCardComponent,
+    NgbModalModule,
   ],
 })
 export class ProblemSidebarComponent {
 
   @Input() problem: Problem;
 
-  public SidebarType = SidebarType;
-  public sidebarType = SidebarType.INFO;
+  public statistics: ProblemStatistics | null = null;
+  public isStatisticsLoading = false;
+
+  constructor(
+    private readonly modalService: NgbModal,
+    private readonly problemsService: ProblemsApiService,
+  ) {}
+
+  openStatisticsModal(content: TemplateRef<unknown>) {
+    this.isStatisticsLoading = true;
+    this.statistics = null;
+
+    this.modalService.open(content, {
+      size: 'xl',
+      scrollable: true,
+    });
+
+    this.problemsService.getProblemStatistics(this.problem.id)
+      .pipe(finalize(() => {
+        this.isStatisticsLoading = false;
+      }))
+      .subscribe({
+        next: (result: ProblemStatistics) => {
+          this.statistics = result;
+        },
+        error: () => {
+          this.statistics = null;
+        }
+      });
+  }
 
 }

--- a/src/app/modules/problems/pages/problem/problem-sidebar/problem-statistics.model.ts
+++ b/src/app/modules/problems/pages/problem/problem-sidebar/problem-statistics.model.ts
@@ -1,0 +1,38 @@
+export interface ProblemAttemptStatistic {
+  verdict: number;
+  verdictTitle: string;
+  value: number;
+  color: string;
+}
+
+export interface ProblemLanguageStatistic {
+  langFull: string;
+  lang: string;
+  value: number;
+}
+
+export interface ProblemTopAttempt {
+  username: string;
+  ratingTitle: string;
+  time: number;
+  memory: number;
+  sourceCodeSize: number;
+}
+
+export interface ProblemTopAttempts {
+  time: ProblemTopAttempt[];
+  memory: ProblemTopAttempt[];
+  sourceCodeSize: ProblemTopAttempt[];
+}
+
+export interface ProblemAttemptsForSolveStatistic {
+  attempts: number;
+  value: number;
+}
+
+export interface ProblemStatistics {
+  attemptStatistics: ProblemAttemptStatistic[];
+  languageStatistics: ProblemLanguageStatistic[];
+  topAttempts: ProblemTopAttempts;
+  attemptsForSolveStatistics: ProblemAttemptsForSolveStatistic[];
+}

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -122,6 +122,8 @@
         </div>
 
         <div class="col-lg-3 col-md-12 col-sm-12">
+          <problem-sidebar [problem]="problem"></problem-sidebar>
+
           @if (isAuthenticated) {
             <problem-submit-card
               [availableLanguages]="problem.availableLanguages"
@@ -129,8 +131,6 @@
               (submitted)="onSubmit()"
             />
           }
-
-          <problem-sidebar [problem]="problem"></problem-sidebar>
         </div>
 
       </div>

--- a/src/app/modules/problems/services/problems-api.service.ts
+++ b/src/app/modules/problems/services/problems-api.service.ts
@@ -97,21 +97,8 @@ export class ProblemsApiService {
     return this.api.get(`problems-rating/${username}`);
   }
 
-  getProblemVerdictStatistics(problemId: number) {
-    return this.api.get(`problems/${problemId}/attempt-statistics/`);
-  }
-
-  getProblemLangStatistics(problemId: number) {
-    return this.api.get(`problems/${problemId}/lang-statistics/`);
-  }
-
-  getProblemTopAttempts(problemId: number, ordering: string, lang = null, page: number = 1, pageSize: number = 10) {
-    const params = {ordering, lang};
-    return this.api.get(`problems/${problemId}/top-attempts/`, params);
-  }
-
-  getAttemptsForSolveStatistics(problemId: number) {
-    return this.api.get(`problems/${problemId}/attempts-for-solve-statistics/`);
+  getProblemStatistics(problemId: number) {
+    return this.api.get(`problems/${problemId}/statistics/`);
   }
 
   getProblemSolution(problemId: number) {


### PR DESCRIPTION
## Summary
- add a problem statistics model and unified API call for the new endpoint
- render the sidebar info card with a button that opens a modal containing statistics and top attempts
- update statistics and top attempts components to consume the combined response and refresh their UIs

## Testing
- npm run lint *(fails: ng command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2e4b239c4832fad7debdbfb448be2