### PR TITLE
feat: add contests rating history chart

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -587,6 +587,7 @@ export const localeEn = {
       Participants: '{{ total }} participants',
       ContestRanks: 'Contest ranks',
       RatingChanges: 'Rating changes',
+      RatingChangesHistory: 'Rating history',
       Languages: 'Languages',
       Tags: 'Favorite tags',
       Symbols: 'Problem symbols',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -585,6 +585,7 @@ export const localeUz = {
       Participants: '{{ total }} ta ishtirokchi',
       ContestRanks: 'Kontestlardagi natijalar',
       RatingChanges: 'Reyting o‘zgarishlari',
+      RatingChangesHistory: 'Reyting o‘zgarishlari tarixi',
       Languages: 'Tillar',
       Tags: 'Taglar',
       Symbols: 'Masala belgilar',

--- a/src/app/modules/contests/pages/user-statistics/user-statistics.component.html
+++ b/src/app/modules/contests/pages/user-statistics/user-statistics.component.html
@@ -160,6 +160,23 @@
   </div>
 
   <div class="row g-2 g-lg-3 mb-3">
+    <div class="col-12">
+      <kep-card>
+        <div class="card-header">
+          <div class="card-title">{{ 'Contests.UserStatistics.RatingChangesHistory' | translate }}</div>
+        </div>
+        <div class="card-body p-2">
+          @if (ratingChangesChart) {
+            <apex-chart [options]="ratingChangesChart"></apex-chart>
+          } @else {
+            <div class="text-center text-muted py-4">{{ 'Contests.UserStatistics.NoData' | translate }}</div>
+          }
+        </div>
+      </kep-card>
+    </div>
+  </div>
+
+  <div class="row g-2 g-lg-3 mb-3">
     <div class="col-lg-8">
       <kep-card>
         <div class="card-header">


### PR DESCRIPTION
## Summary
- add an ApexCharts area chart that visualizes contest rating history on the contests user statistics page
- fetch contest rating changes via the existing contests service and render a custom tooltip with contest metadata
- expose translations for the new rating history section in English and Uzbek

## Testing
- npm run lint *(fails: ng not found in PATH because Angular CLI dependencies are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f4bb0dd0832f976ef21c74e9ef45