### PR TITLE
feat(contests): show opponent win stats

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -597,6 +597,8 @@ export const localeEn = {
       Unsolved: 'Unsolved',
       WorthyOpponents: 'Worthy opponents',
       SharedContests: 'shared contests',
+      UserWins: 'wins',
+      OpponentWins: 'losses',
       NoOpponents: 'No notable opponents yet',
       NoData: 'No data yet',
     },

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -591,6 +591,8 @@ export const localeRu = {
       Unsolved: 'Нерешена',
       WorthyOpponents: 'Достойные соперники',
       SharedContests: 'общих конкурсов',
+      UserWins: 'побед',
+      OpponentWins: 'поражений',
       NoOpponents: 'Пока нет соперников',
       NoData: 'Данных пока нет',
     },

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -595,6 +595,8 @@ export const localeUz = {
       Unsolved: 'Yechilmagan',
       WorthyOpponents: 'Kuchli raqiblar',
       SharedContests: 'ta umumiy musobaqa',
+      UserWins: 'ta g‘alaba',
+      OpponentWins: 'ta mag‘lubiyat',
       NoOpponents: 'Raqiblar hali yo‘q',
       NoData: 'Maʼlumotlar yo‘q',
     },

--- a/src/app/modules/contests/models/contest-user-statistics.ts
+++ b/src/app/modules/contests/models/contest-user-statistics.ts
@@ -114,6 +114,8 @@ export interface ContestUserStatisticsOpponent {
   opponent: string;
   type: string;
   sharedCount: number;
+  userWins: number;
+  opponentWins: number;
   contests: ContestUserStatisticsOpponentContest[];
 }
 

--- a/src/app/modules/contests/pages/user-statistics/widgets/worthy-opponents/worthy-opponents.component.html
+++ b/src/app/modules/contests/pages/user-statistics/widgets/worthy-opponents/worthy-opponents.component.html
@@ -9,9 +9,17 @@
           <kep-card [customClass]="'d-flex flex-column flex-fill opponent-card'" [cardHeight]="'500px'">
             <div class="card-header d-flex justify-content-between align-items-start gap-1 flex-wrap">
               <div class="card-title mb-0">{{ opponent.opponent }}</div>
-              <span class="badge bg-primary-transparent">
-                {{ opponent.sharedCount }} {{ 'Contests.UserStatistics.SharedContests' | translate }}
-              </span>
+              <div class="d-flex align-items-center justify-content-end gap-1 flex-wrap">
+                <span class="badge bg-primary-transparent">
+                  {{ opponent.sharedCount }} {{ 'Contests.UserStatistics.SharedContests' | translate }}
+                </span>
+                <span class="badge bg-success-transparent text-success">
+                  {{ opponent.userWins }} {{ 'Contests.UserStatistics.UserWins' | translate }}
+                </span>
+                <span class="badge bg-danger-transparent text-danger">
+                  {{ opponent.opponentWins }} {{ 'Contests.UserStatistics.OpponentWins' | translate }}
+                </span>
+              </div>
             </div>
             <div class="card-body flex-grow-1 overflow-auto opponent-card-body">
               <ul class="list-group">


### PR DESCRIPTION
## Summary
- expose new win counters on contest user statistics opponents
- surface user and opponent win totals in the worthy opponents widget
- translate the new labels in English, Russian, and Uzbek locales

## Testing
- npm run lint *(fails: Angular workspace has no "lint" target configured)*

------
https://chatgpt.com/codex/tasks/task_e_68d3adc7b8a0832fa13158a8c599c0f5