### PR TITLE
feat(user-profile): add activity history timeline

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -813,6 +813,58 @@ export const localeEn = {
   SpendItem7: 'Test function when editing code (completely)',
   SpendItem8: 'Double rating change in contest (even if negative, it doubles)',
   SpendItem9: 'Maintain rating in contest (not given if negative)',
+  UserActivityHistory: {
+    Title: 'Activity history',
+    Empty: 'There is no activity to display yet.',
+    More: 'More',
+    Loading: 'Loading...',
+    Types: {
+      ProblemAttemptSummary: {
+        Description: 'Solved {{accepted}} out of {{total}} problems.'
+      },
+      ChallengeSummary: {
+        Description: 'Challenge results summary.',
+        Wins: 'Wins: {{value}}',
+        Draws: 'Draws: {{value}}',
+        Losses: 'Losses: {{value}}'
+      },
+      ProjectAttemptSummary: {
+        Description: 'Checked {{checked}} of {{total}} project attempts.'
+      },
+      TestPassSummary: {
+        Description: 'Completed {{completed}} of {{total}} tests and solved {{solved}} tasks.'
+      },
+      ContestParticipation: {
+        Description: 'Participated in {{title}}.',
+        Rank: 'Rank: {{rank}}',
+        Rating: '{{before}} → {{after}} rating',
+        RatingChange: 'Δ {{delta}}',
+        Bonus: 'Bonus: {{bonus}}',
+        NoRank: 'N/A'
+      },
+      ArenaParticipation: {
+        Description: 'Joined arena {{title}}.',
+        Points: 'Points: {{points}}',
+        Rank: 'Rank: {{rank}}',
+        FinishTime: 'Finished at {{time}}'
+      },
+      DailyActivity: {
+        Description: 'Logged daily activity (+{{value}}).',
+        Note: 'Note: {{note}}'
+      },
+      HardProblemSolved: {
+        Description: 'Solved {{title}} ({{difficulty}}).',
+        Problem: 'Problem #{{id}}'
+      },
+      AchievementUnlocked: {
+        Description: '{{message}}'
+      },
+      DailyTaskCompleted: {
+        Description: 'Completed daily task ({{type}}).',
+        Task: '{{description}}'
+      }
+    }
+  },
   PageTitle: {
     Home: 'Home',
     Landing: 'KEP.uz - A platform for learning programming',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -806,6 +806,58 @@ export const localeRu = {
   SpendItem7: 'Функция тестирования при редактировании кода (полностью)',
   SpendItem8: 'Двойное изменение рейтинга на контесте (изменяется, даже если отрицательное)',
   SpendItem9: 'Сохранить рейтинг на контесте (не начисляется, если отрицательный)',
+  UserActivityHistory: {
+    Title: 'История активности',
+    Empty: 'Активность пока отсутствует.',
+    More: 'Ещё',
+    Loading: 'Загрузка...',
+    Types: {
+      ProblemAttemptSummary: {
+        Description: 'Решено {{accepted}} из {{total}} задач.'
+      },
+      ChallengeSummary: {
+        Description: 'Сводка по челленджам.',
+        Wins: 'Победы: {{value}}',
+        Draws: 'Ничьи: {{value}}',
+        Losses: 'Поражения: {{value}}'
+      },
+      ProjectAttemptSummary: {
+        Description: 'Проверено {{checked}} из {{total}} попыток по проектам.'
+      },
+      TestPassSummary: {
+        Description: 'Завершено {{completed}} из {{total}} тестов и решено {{solved}} задач.'
+      },
+      ContestParticipation: {
+        Description: 'Участие в {{title}}.',
+        Rank: 'Место: {{rank}}',
+        Rating: '{{before}} → {{after}} рейтинг',
+        RatingChange: 'Δ {{delta}}',
+        Bonus: 'Бонус: {{bonus}}',
+        NoRank: '—'
+      },
+      ArenaParticipation: {
+        Description: 'Участие в арене {{title}}.',
+        Points: 'Очки: {{points}}',
+        Rank: 'Место: {{rank}}',
+        FinishTime: 'Завершено {{time}}'
+      },
+      DailyActivity: {
+        Description: 'Ежедневная активность (+{{value}}).',
+        Note: 'Заметка: {{note}}'
+      },
+      HardProblemSolved: {
+        Description: 'Решена задача {{title}} ({{difficulty}}).',
+        Problem: 'Задача №{{id}}'
+      },
+      AchievementUnlocked: {
+        Description: '{{message}}'
+      },
+      DailyTaskCompleted: {
+        Description: 'Выполнено ежедневное задание ({{type}}).',
+        Task: '{{description}}'
+      }
+    }
+  },
   PageTitle: {
     Home: 'Главная',
     Landing: 'KEP.uz - Платформа для обучения программированию',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -809,6 +809,58 @@ export const localeUz = {
   SpendItem7: 'Kodni tahrirlashda testlash funksiyasi (butunlayga)',
   SpendItem8: 'Kontestda ikki barobar reyting o‘zgarishi (manfiy bo‘lsa ham ikki barobar bo‘lib o‘zgaradi)',
   SpendItem9: 'Kontestda reytingni saqlab qolish (agar manfiy bo‘lsa berilmaydi)',
+  UserActivityHistory: {
+    Title: 'Faoliyat tarixi',
+    Empty: 'Hozircha faoliyat maʼlumoti yo‘q.',
+    More: 'Yana',
+    Loading: 'Yuklanmoqda...',
+    Types: {
+      ProblemAttemptSummary: {
+        Description: 'Jami {{total}} ta masaladan {{accepted}} tasi yechildi.'
+      },
+      ChallengeSummary: {
+        Description: 'Chellenj natijalari.',
+        Wins: 'G‘alabalar: {{value}}',
+        Draws: 'Duranglar: {{value}}',
+        Losses: 'Mag‘lubiyatlar: {{value}}'
+      },
+      ProjectAttemptSummary: {
+        Description: 'Loyiha topshiriqlarining {{total}} tasidan {{checked}} tasi tekshirildi.'
+      },
+      TestPassSummary: {
+        Description: '{{total}} ta testdan {{completed}} tasi yakunlandi va {{solved}} ta topshiriq yechildi.'
+      },
+      ContestParticipation: {
+        Description: '{{title}} musobaqasida ishtirok etdi.',
+        Rank: 'O‘rin: {{rank}}',
+        Rating: '{{before}} → {{after}} reyting',
+        RatingChange: 'Δ {{delta}}',
+        Bonus: 'Bonus: {{bonus}}',
+        NoRank: '—'
+      },
+      ArenaParticipation: {
+        Description: '{{title}} arenasi ishtirokchisi.',
+        Points: 'Ballar: {{points}}',
+        Rank: 'O‘rin: {{rank}}',
+        FinishTime: 'Tugash vaqti: {{time}}'
+      },
+      DailyActivity: {
+        Description: 'Kunlik faollik (+{{value}}).',
+        Note: 'Eslatma: {{note}}'
+      },
+      HardProblemSolved: {
+        Description: '{{title}} ({{difficulty}}) masalasi yechildi.',
+        Problem: 'Masala №{{id}}'
+      },
+      AchievementUnlocked: {
+        Description: '{{message}}'
+      },
+      DailyTaskCompleted: {
+        Description: 'Kunlik topshiriq bajarildi ({{type}}).',
+        Task: '{{description}}'
+      }
+    }
+  },
   PageTitle: {
     Home: 'Bosh sahifa',
     Landing: 'KEP.uz - Dasturlashni oʻrganish uchun platforma',

--- a/src/app/modules/users/config/routes.ts
+++ b/src/app/modules/users/config/routes.ts
@@ -40,8 +40,12 @@ export default [
     },
     children: [
       {
-        path: '',
+        path: 'ratings',
         loadComponent: () => import('../ui/pages/user-profile/user-ratings/user-ratings.component').then(c => c.UserRatingsComponent),
+      },
+      {
+        path: 'activity-history',
+        loadComponent: () => import('../ui/pages/user-profile/user-activity-history/user-activity-history.component').then(c => c.UserActivityHistoryComponent),
       },
       {
         path: 'blog',

--- a/src/app/modules/users/data-access/api/users-api.service.ts
+++ b/src/app/modules/users/data-access/api/users-api.service.ts
@@ -3,7 +3,7 @@ import { ApiService } from '@core/data-access/api.service';
 import { Pageable } from '@core/common/classes/pageable';
 import { Observable } from "rxjs";
 import { PageResult } from "@shared/components/table";
-import { User } from "@users/domain";
+import { User, UserActivityHistoryItem } from "@users/domain";
 
 @Injectable({
   providedIn: 'root'
@@ -45,6 +45,10 @@ export class UsersApiService {
 
   getUserWorkExperiences(username: string) {
     return this.api.get(`users/${username}/work-experiences`);
+  }
+
+  getUserActivityHistory(username: string, params?: Partial<Pageable>): Observable<PageResult<UserActivityHistoryItem>> {
+    return this.api.get(`user-activity-history/${username}`, params);
   }
 
   getUserBlog(username: string, params?: Partial<Pageable>) {

--- a/src/app/modules/users/domain/entities/user-activity-history.entity.ts
+++ b/src/app/modules/users/domain/entities/user-activity-history.entity.ts
@@ -1,0 +1,129 @@
+export type UserActivityHistoryType =
+  | 'problem_attempt_summary'
+  | 'challenge_summary'
+  | 'project_attempt_summary'
+  | 'test_pass_summary'
+  | 'contest_participation'
+  | 'arena_participation'
+  | 'daily_activity'
+  | 'hard_problem_solved'
+  | 'achievement_unlocked'
+  | 'daily_task_completed';
+
+export interface UserActivityHistoryUser {
+  username: string;
+  avatar: string;
+}
+
+interface BaseUserActivityHistoryItem {
+  id: number;
+  user: UserActivityHistoryUser;
+  activityTypeDisplay: string;
+  recordedFor: string;
+  createdAt: string;
+}
+
+export type ProblemAttemptSummaryActivity = BaseUserActivityHistoryItem & {
+  activityType: 'problem_attempt_summary';
+  payload: {
+    total: number;
+    accepted: number;
+  };
+};
+
+export type ChallengeSummaryActivity = BaseUserActivityHistoryItem & {
+  activityType: 'challenge_summary';
+  payload: {
+    wins: number;
+    draws: number;
+    losses: number;
+  };
+};
+
+export type ProjectAttemptSummaryActivity = BaseUserActivityHistoryItem & {
+  activityType: 'project_attempt_summary';
+  payload: {
+    total: number;
+    checked: number;
+  };
+};
+
+export type TestPassSummaryActivity = BaseUserActivityHistoryItem & {
+  activityType: 'test_pass_summary';
+  payload: {
+    total: number;
+    solved: number;
+    completed: number;
+  };
+};
+
+export type ContestParticipationActivity = BaseUserActivityHistoryItem & {
+  activityType: 'contest_participation';
+  payload: {
+    rank: number | null;
+    bonus: number | null;
+    delta: number | null;
+    contestId: number;
+    finishTime: string | null;
+    ratingAfter: number | null;
+    contestTitle: string;
+    ratingBefore: number | null;
+  };
+};
+
+export type ArenaParticipationActivity = BaseUserActivityHistoryItem & {
+  activityType: 'arena_participation';
+  payload: {
+    rank: number | null;
+    points: number | null;
+    arenaId: number;
+    arenaTitle: string;
+    finishTime: string | null;
+  };
+};
+
+export type DailyActivityActivity = BaseUserActivityHistoryItem & {
+  activityType: 'daily_activity';
+  payload: {
+    note: string;
+    value: number;
+  };
+};
+
+export type HardProblemSolvedActivity = BaseUserActivityHistoryItem & {
+  activityType: 'hard_problem_solved';
+  payload: {
+    difficulty: string;
+    problemId: number;
+    problemTitle: string;
+  };
+};
+
+export type AchievementUnlockedActivity = BaseUserActivityHistoryItem & {
+  activityType: 'achievement_unlocked';
+  payload: {
+    message: string;
+  };
+};
+
+export type DailyTaskCompletedActivity = BaseUserActivityHistoryItem & {
+  activityType: 'daily_task_completed';
+  payload: {
+    taskId: number;
+    taskType: string;
+    description: string;
+    dailyTaskId: number;
+  };
+};
+
+export type UserActivityHistoryItem =
+  | ProblemAttemptSummaryActivity
+  | ChallengeSummaryActivity
+  | ProjectAttemptSummaryActivity
+  | TestPassSummaryActivity
+  | ContestParticipationActivity
+  | ArenaParticipationActivity
+  | DailyActivityActivity
+  | HardProblemSolvedActivity
+  | AchievementUnlockedActivity
+  | DailyTaskCompletedActivity;

--- a/src/app/modules/users/domain/index.ts
+++ b/src/app/modules/users/domain/index.ts
@@ -1,4 +1,5 @@
 export * from './entities/user.entity';
 export * from './entities/team.entity';
 export * from './entities/rating.entity';
-export * from './entities/achievement.entity'; 
+export * from './entities/achievement.entity';
+export * from './entities/user-activity-history.entity';

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/achievement-unlocked.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/achievement-unlocked.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { AchievementUnlockedActivity } from '@users/domain';
+
+@Component({
+  selector: 'user-activity-history-achievement-unlocked',
+  standalone: true,
+  imports: [TranslateModule],
+  template: `
+    <p class="mb-0 text-muted fs-14">
+      {{ 'UserActivityHistory.Types.AchievementUnlocked.Description' | translate: { message: activity.payload.message } }}
+    </p>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserActivityHistoryAchievementUnlockedComponent {
+  @Input({ required: true }) activity!: AchievementUnlockedActivity;
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/arena-participation.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/arena-participation.component.ts
@@ -1,0 +1,34 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+import { ArenaParticipationActivity } from '@users/domain';
+
+@Component({
+  selector: 'user-activity-history-arena-participation',
+  standalone: true,
+  imports: [CommonModule, TranslateModule],
+  template: `
+    <p class="mb-0 text-muted fs-14">
+      {{ 'UserActivityHistory.Types.ArenaParticipation.Description' | translate: {
+        title: activity.payload.arenaTitle
+      } }}
+    </p>
+    <div class="d-flex flex-wrap gap-2 mt-2">
+      <span class="badge bg-primary-transparent fw-medium">
+        {{ 'UserActivityHistory.Types.ArenaParticipation.Points' | translate: { points: activity.payload.points ?? 0 } }}
+      </span>
+      <span class="badge bg-secondary-transparent fw-medium">
+        {{ 'UserActivityHistory.Types.ArenaParticipation.Rank' | translate: { rank: activity.payload.rank ?? '-' } }}
+      </span>
+    </div>
+    <p class="mb-0 text-muted fs-13 mt-2" *ngIf="activity.payload.finishTime">
+      {{ 'UserActivityHistory.Types.ArenaParticipation.FinishTime' | translate: {
+        time: (activity.payload.finishTime | date:'medium')
+      } }}
+    </p>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserActivityHistoryArenaParticipationComponent {
+  @Input({ required: true }) activity!: ArenaParticipationActivity;
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/challenge-summary.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/challenge-summary.component.ts
@@ -1,0 +1,29 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { ChallengeSummaryActivity } from '@users/domain';
+
+@Component({
+  selector: 'user-activity-history-challenge-summary',
+  standalone: true,
+  imports: [TranslateModule],
+  template: `
+    <p class="mb-0 text-muted fs-14">
+      {{ 'UserActivityHistory.Types.ChallengeSummary.Description' | translate }}
+    </p>
+    <div class="d-flex flex-wrap gap-2 mt-2">
+      <span class="badge bg-success-transparent fw-medium">
+        {{ 'UserActivityHistory.Types.ChallengeSummary.Wins' | translate: { value: activity.payload.wins } }}
+      </span>
+      <span class="badge bg-secondary-transparent fw-medium">
+        {{ 'UserActivityHistory.Types.ChallengeSummary.Draws' | translate: { value: activity.payload.draws } }}
+      </span>
+      <span class="badge bg-danger-transparent fw-medium">
+        {{ 'UserActivityHistory.Types.ChallengeSummary.Losses' | translate: { value: activity.payload.losses } }}
+      </span>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserActivityHistoryChallengeSummaryComponent {
+  @Input({ required: true }) activity!: ChallengeSummaryActivity;
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/contest-participation.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/contest-participation.component.ts
@@ -1,0 +1,64 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+import { ContestParticipationActivity } from '@users/domain';
+
+@Component({
+  selector: 'user-activity-history-contest-participation',
+  standalone: true,
+  imports: [CommonModule, TranslateModule],
+  template: `
+    <p class="mb-0 text-muted fs-14">
+      {{ 'UserActivityHistory.Types.ContestParticipation.Description' | translate: {
+        title: activity.payload.contestTitle
+      } }}
+    </p>
+    <div class="d-flex flex-wrap gap-2 mt-2">
+      <span class="badge bg-primary-transparent fw-medium">
+        <ng-container *ngIf="activity.payload.rank !== null && activity.payload.rank !== undefined; else noRank">
+          {{ 'UserActivityHistory.Types.ContestParticipation.Rank' | translate: { rank: activity.payload.rank } }}
+        </ng-container>
+        <ng-template #noRank>
+          {{ 'UserActivityHistory.Types.ContestParticipation.Rank' | translate: { rank: ('UserActivityHistory.Types.ContestParticipation.NoRank' | translate) } }}
+        </ng-template>
+      </span>
+      <span class="badge fw-medium" [ngClass]="deltaBadgeClass">
+        {{ 'UserActivityHistory.Types.ContestParticipation.RatingChange' | translate: { delta: formattedDelta } }}
+      </span>
+      <span class="badge bg-info-transparent fw-medium"
+            *ngIf="activity.payload.ratingBefore !== null && activity.payload.ratingAfter !== null">
+        {{ 'UserActivityHistory.Types.ContestParticipation.Rating' | translate: {
+          before: activity.payload.ratingBefore,
+          after: activity.payload.ratingAfter
+        } }}
+      </span>
+      <span class="badge bg-warning-transparent fw-medium"
+            *ngIf="activity.payload.bonus">
+        {{ 'UserActivityHistory.Types.ContestParticipation.Bonus' | translate: { bonus: activity.payload.bonus } }}
+      </span>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserActivityHistoryContestParticipationComponent {
+  @Input({ required: true }) activity!: ContestParticipationActivity;
+
+  get formattedDelta(): string {
+    const delta = this.activity.payload.delta ?? 0;
+    if (delta > 0) {
+      return `+${delta}`;
+    }
+    return delta.toString();
+  }
+
+  get deltaBadgeClass(): string {
+    const delta = this.activity.payload.delta ?? 0;
+    if (delta > 0) {
+      return 'bg-success-transparent';
+    }
+    if (delta < 0) {
+      return 'bg-danger-transparent';
+    }
+    return 'bg-secondary-transparent';
+  }
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/daily-activity.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/daily-activity.component.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
+import { DailyActivityActivity } from '@users/domain';
+
+@Component({
+  selector: 'user-activity-history-daily-activity',
+  standalone: true,
+  imports: [CommonModule, TranslateModule],
+  template: `
+    <p class="mb-0 text-muted fs-14">
+      {{ 'UserActivityHistory.Types.DailyActivity.Description' | translate: { value: activity.payload.value } }}
+    </p>
+    <p class="mb-0 text-muted fs-13 mt-2" *ngIf="activity.payload.note">
+      {{ 'UserActivityHistory.Types.DailyActivity.Note' | translate: { note: activity.payload.note } }}
+    </p>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserActivityHistoryDailyActivityComponent {
+  @Input({ required: true }) activity!: DailyActivityActivity;
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/daily-task-completed.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/daily-task-completed.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { DailyTaskCompletedActivity } from '@users/domain';
+
+@Component({
+  selector: 'user-activity-history-daily-task-completed',
+  standalone: true,
+  imports: [TranslateModule],
+  template: `
+    <p class="mb-0 text-muted fs-14">
+      {{ 'UserActivityHistory.Types.DailyTaskCompleted.Description' | translate: { type: activity.payload.taskType } }}
+    </p>
+    <p class="mb-0 text-muted fs-13 mt-2">
+      {{ 'UserActivityHistory.Types.DailyTaskCompleted.Task' | translate: { description: activity.payload.description } }}
+    </p>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserActivityHistoryDailyTaskCompletedComponent {
+  @Input({ required: true }) activity!: DailyTaskCompletedActivity;
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/hard-problem-solved.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/hard-problem-solved.component.ts
@@ -1,0 +1,24 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { HardProblemSolvedActivity } from '@users/domain';
+
+@Component({
+  selector: 'user-activity-history-hard-problem-solved',
+  standalone: true,
+  imports: [TranslateModule],
+  template: `
+    <p class="mb-0 text-muted fs-14">
+      {{ 'UserActivityHistory.Types.HardProblemSolved.Description' | translate: {
+        title: activity.payload.problemTitle,
+        difficulty: activity.payload.difficulty
+      } }}
+    </p>
+    <p class="mb-0 text-muted fs-13 mt-2">
+      {{ 'UserActivityHistory.Types.HardProblemSolved.Problem' | translate: { id: activity.payload.problemId } }}
+    </p>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserActivityHistoryHardProblemSolvedComponent {
+  @Input({ required: true }) activity!: HardProblemSolvedActivity;
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/problem-attempt-summary.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/problem-attempt-summary.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { ProblemAttemptSummaryActivity } from '@users/domain';
+
+@Component({
+  selector: 'user-activity-history-problem-attempt-summary',
+  standalone: true,
+  imports: [TranslateModule],
+  template: `
+    <p class="mb-0 text-muted fs-14">
+      {{ 'UserActivityHistory.Types.ProblemAttemptSummary.Description' | translate: {
+        accepted: activity.payload.accepted,
+        total: activity.payload.total
+      } }}
+    </p>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserActivityHistoryProblemAttemptSummaryComponent {
+  @Input({ required: true }) activity!: ProblemAttemptSummaryActivity;
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/project-attempt-summary.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/project-attempt-summary.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { ProjectAttemptSummaryActivity } from '@users/domain';
+
+@Component({
+  selector: 'user-activity-history-project-attempt-summary',
+  standalone: true,
+  imports: [TranslateModule],
+  template: `
+    <p class="mb-0 text-muted fs-14">
+      {{ 'UserActivityHistory.Types.ProjectAttemptSummary.Description' | translate: {
+        checked: activity.payload.checked,
+        total: activity.payload.total
+      } }}
+    </p>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserActivityHistoryProjectAttemptSummaryComponent {
+  @Input({ required: true }) activity!: ProjectAttemptSummaryActivity;
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/test-pass-summary.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/components/test-pass-summary.component.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+import { TestPassSummaryActivity } from '@users/domain';
+
+@Component({
+  selector: 'user-activity-history-test-pass-summary',
+  standalone: true,
+  imports: [TranslateModule],
+  template: `
+    <p class="mb-0 text-muted fs-14">
+      {{ 'UserActivityHistory.Types.TestPassSummary.Description' | translate: {
+        completed: activity.payload.completed,
+        total: activity.payload.total,
+        solved: activity.payload.solved
+      } }}
+    </p>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserActivityHistoryTestPassSummaryComponent {
+  @Input({ required: true }) activity!: TestPassSummaryActivity;
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/user-activity-history.component.html
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/user-activity-history.component.html
@@ -1,0 +1,100 @@
+<kep-card customClass="user-activity-history-card">
+  <div class="card-body">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <h5 class="mb-0 fw-semibold">{{ 'UserActivityHistory.Title' | translate }}</h5>
+    </div>
+
+    <div class="position-relative">
+      <div class="d-flex justify-content-center py-4" *ngIf="loading && initialLoad">
+        <spinner></spinner>
+      </div>
+
+      <ng-container *ngIf="!initialLoad || activities.length">
+        <div class="timeline mb-0">
+          <div class="container px-0">
+            <ul class="timeline list-unstyled mb-0" *ngIf="activities.length; else emptyState">
+              <li *ngFor="let activity of activities; trackBy: trackById">
+                <div class="timeline-time text-end">
+                  <span class="time d-inline-block">{{ activity.recordedFor | date:'HH:mm' }}</span>
+                  <span class="date">{{ activity.recordedFor | date:'EEEE' }}</span>
+                </div>
+                <div class="timeline-icon">
+                  <a class="timeline-icon-label" href="javascript:void(0);">{{ getIconLabel(activity) }}</a>
+                </div>
+                <div class="timeline-body">
+                  <div class="text-muted fw-medium mb-2">
+                    {{ activity.recordedFor | date:'dd, MMM yyyy' }}
+                  </div>
+                  <kep-card [customClass]="getCardClass(activity)">
+                    <div class="card-body">
+                      <div class="d-flex align-items-top timeline-main-content flex-wrap flex-xl-nowrap mt-0">
+                        <div class="avatar avatar-md me-3 mt-sm-0 mt-4 flex-shrink-0">
+                          <img [alt]="activity.user.username" [src]="activity.user.avatar" class="rounded img-fluid" loading="lazy"/>
+                        </div>
+                        <div class="flex-fill">
+                          <div class="d-flex align-items-center">
+                            <div class="mt-sm-0 mt-2 w-100">
+                              <p class="mb-0 fs-14 fw-semibold">{{ activity.user.username }}</p>
+                              <p class="mb-1 text-muted fs-13 text-uppercase">{{ activity.activityTypeDisplay }}</p>
+                              <user-activity-history-problem-attempt-summary
+                                *ngIf="getActivityType(activity) === 'problem_attempt_summary'"
+                                [activity]="activity as ProblemAttemptSummaryActivity"></user-activity-history-problem-attempt-summary>
+                              <user-activity-history-challenge-summary
+                                *ngIf="getActivityType(activity) === 'challenge_summary'"
+                                [activity]="activity as ChallengeSummaryActivity"></user-activity-history-challenge-summary>
+                              <user-activity-history-project-attempt-summary
+                                *ngIf="getActivityType(activity) === 'project_attempt_summary'"
+                                [activity]="activity as ProjectAttemptSummaryActivity"></user-activity-history-project-attempt-summary>
+                              <user-activity-history-test-pass-summary
+                                *ngIf="getActivityType(activity) === 'test_pass_summary'"
+                                [activity]="activity as TestPassSummaryActivity"></user-activity-history-test-pass-summary>
+                              <user-activity-history-contest-participation
+                                *ngIf="getActivityType(activity) === 'contest_participation'"
+                                [activity]="activity as ContestParticipationActivity"></user-activity-history-contest-participation>
+                              <user-activity-history-arena-participation
+                                *ngIf="getActivityType(activity) === 'arena_participation'"
+                                [activity]="activity as ArenaParticipationActivity"></user-activity-history-arena-participation>
+                              <user-activity-history-daily-activity
+                                *ngIf="getActivityType(activity) === 'daily_activity'"
+                                [activity]="activity as DailyActivityActivity"></user-activity-history-daily-activity>
+                              <user-activity-history-hard-problem-solved
+                                *ngIf="getActivityType(activity) === 'hard_problem_solved'"
+                                [activity]="activity as HardProblemSolvedActivity"></user-activity-history-hard-problem-solved>
+                              <user-activity-history-achievement-unlocked
+                                *ngIf="getActivityType(activity) === 'achievement_unlocked'"
+                                [activity]="activity as AchievementUnlockedActivity"></user-activity-history-achievement-unlocked>
+                              <user-activity-history-daily-task-completed
+                                *ngIf="getActivityType(activity) === 'daily_task_completed'"
+                                [activity]="activity as DailyTaskCompletedActivity"></user-activity-history-daily-task-completed>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </kep-card>
+                </div>
+              </li>
+            </ul>
+            <ng-template #emptyState>
+              <p class="text-center text-muted mb-0 py-4">{{ 'UserActivityHistory.Empty' | translate }}</p>
+            </ng-template>
+
+            <div class="text-center timeline-loadmore-container" *ngIf="hasMore">
+              <button class="btn btn-outline-primary" (click)="loadMore()" [disabled]="loading" type="button">
+                <ng-container *ngIf="!loading; else loadingLabel">
+                  {{ 'UserActivityHistory.More' | translate }}
+                </ng-container>
+              </button>
+            </div>
+            <ng-template #loadingLabel>
+              <span class="d-inline-flex align-items-center gap-2">
+                <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                {{ 'UserActivityHistory.Loading' | translate }}
+              </span>
+            </ng-template>
+          </div>
+        </div>
+      </ng-container>
+    </div>
+  </div>
+</kep-card>

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/user-activity-history.component.html
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/user-activity-history.component.html
@@ -1,9 +1,10 @@
-<kep-card customClass="user-activity-history-card">
-  <div class="card-body">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-      <h5 class="mb-0 fw-semibold">{{ 'UserActivityHistory.Title' | translate }}</h5>
+<kep-card>
+  <div class="card-header">
+    <div class="card-title">
+      {{ 'UserActivityHistory.Title' | translate }}
     </div>
-
+  </div>
+  <div class="card-body">
     <div class="position-relative">
       <div class="d-flex justify-content-center py-4" *ngIf="loading && initialLoad">
         <spinner></spinner>
@@ -13,7 +14,7 @@
         <div class="timeline mb-0">
           <div class="container px-0">
             <ul class="timeline list-unstyled mb-0" *ngIf="activities.length; else emptyState">
-              <li *ngFor="let activity of activities; trackBy: trackById">
+              <li *ngFor="let activity of activities; trackBy: trackById" style="margin-inline-end: 0">
                 <div class="timeline-time text-end">
                   <span class="time d-inline-block">{{ activity.recordedFor | date:'HH:mm' }}</span>
                   <span class="date">{{ activity.recordedFor | date:'EEEE' }}</span>
@@ -28,9 +29,9 @@
                   <kep-card [customClass]="getCardClass(activity)">
                     <div class="card-body">
                       <div class="d-flex align-items-top timeline-main-content flex-wrap flex-xl-nowrap mt-0">
-                        <div class="avatar avatar-md me-3 mt-sm-0 mt-4 flex-shrink-0">
-                          <img [alt]="activity.user.username" [src]="activity.user.avatar" class="rounded img-fluid" loading="lazy"/>
-                        </div>
+<!--                        <div class="avatar avatar-md me-3 mt-sm-0 mt-4 flex-shrink-0">-->
+<!--                          <img [alt]="activity.user.username" [src]="activity.user.avatar" class="rounded img-fluid" loading="lazy"/>-->
+<!--                        </div>-->
                         <div class="flex-fill">
                           <div class="d-flex align-items-center">
                             <div class="mt-sm-0 mt-2 w-100">
@@ -38,34 +39,34 @@
                               <p class="mb-1 text-muted fs-13 text-uppercase">{{ activity.activityTypeDisplay }}</p>
                               <user-activity-history-problem-attempt-summary
                                 *ngIf="getActivityType(activity) === 'problem_attempt_summary'"
-                                [activity]="activity as ProblemAttemptSummaryActivity"></user-activity-history-problem-attempt-summary>
+                                [activity]="activity"></user-activity-history-problem-attempt-summary>
                               <user-activity-history-challenge-summary
                                 *ngIf="getActivityType(activity) === 'challenge_summary'"
-                                [activity]="activity as ChallengeSummaryActivity"></user-activity-history-challenge-summary>
+                                [activity]="activity"></user-activity-history-challenge-summary>
                               <user-activity-history-project-attempt-summary
                                 *ngIf="getActivityType(activity) === 'project_attempt_summary'"
-                                [activity]="activity as ProjectAttemptSummaryActivity"></user-activity-history-project-attempt-summary>
+                                [activity]="activity"></user-activity-history-project-attempt-summary>
                               <user-activity-history-test-pass-summary
                                 *ngIf="getActivityType(activity) === 'test_pass_summary'"
-                                [activity]="activity as TestPassSummaryActivity"></user-activity-history-test-pass-summary>
+                                [activity]="activity"></user-activity-history-test-pass-summary>
                               <user-activity-history-contest-participation
                                 *ngIf="getActivityType(activity) === 'contest_participation'"
-                                [activity]="activity as ContestParticipationActivity"></user-activity-history-contest-participation>
+                                [activity]="activity"></user-activity-history-contest-participation>
                               <user-activity-history-arena-participation
                                 *ngIf="getActivityType(activity) === 'arena_participation'"
-                                [activity]="activity as ArenaParticipationActivity"></user-activity-history-arena-participation>
+                                [activity]="activity"></user-activity-history-arena-participation>
                               <user-activity-history-daily-activity
                                 *ngIf="getActivityType(activity) === 'daily_activity'"
-                                [activity]="activity as DailyActivityActivity"></user-activity-history-daily-activity>
+                                [activity]="activity"></user-activity-history-daily-activity>
                               <user-activity-history-hard-problem-solved
                                 *ngIf="getActivityType(activity) === 'hard_problem_solved'"
-                                [activity]="activity as HardProblemSolvedActivity"></user-activity-history-hard-problem-solved>
+                                [activity]="activity"></user-activity-history-hard-problem-solved>
                               <user-activity-history-achievement-unlocked
                                 *ngIf="getActivityType(activity) === 'achievement_unlocked'"
-                                [activity]="activity as AchievementUnlockedActivity"></user-activity-history-achievement-unlocked>
+                                [activity]="activity"></user-activity-history-achievement-unlocked>
                               <user-activity-history-daily-task-completed
                                 *ngIf="getActivityType(activity) === 'daily_task_completed'"
-                                [activity]="activity as DailyTaskCompletedActivity"></user-activity-history-daily-task-completed>
+                                [activity]="activity"></user-activity-history-daily-task-completed>
                             </div>
                           </div>
                         </div>

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/user-activity-history.component.scss
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/user-activity-history.component.scss
@@ -1,0 +1,38 @@
+:host {
+  display: block;
+}
+
+.user-activity-history-card {
+  margin-bottom: 1.5rem;
+}
+
+.timeline-icon-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.timeline .timeline-body kep-card {
+  display: block;
+}
+
+.timeline .timeline-body .card-body {
+  padding: 1.25rem;
+}
+
+.timeline .avatar img {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+}
+
+.timeline .timeline-body .text-muted {
+  color: var(--text-muted) !important;
+}
+
+.timeline-loadmore-container button[disabled] {
+  cursor: not-allowed;
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/user-activity-history.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/user-activity-history.component.ts
@@ -1,0 +1,184 @@
+import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { CoreCommonModule } from '@core/common.module';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
+import { TranslateModule } from '@ngx-translate/core';
+import { UsersApiService } from '@app/modules/users';
+import {
+  AchievementUnlockedActivity,
+  ArenaParticipationActivity,
+  ChallengeSummaryActivity,
+  DailyActivityActivity,
+  DailyTaskCompletedActivity,
+  HardProblemSolvedActivity,
+  ProblemAttemptSummaryActivity,
+  ProjectAttemptSummaryActivity,
+  TestPassSummaryActivity,
+  ContestParticipationActivity,
+  UserActivityHistoryItem,
+  UserActivityHistoryType,
+} from '@users/domain';
+import { PageResult } from '@core/common/classes/page-result';
+import { UserActivityHistoryProblemAttemptSummaryComponent } from './components/problem-attempt-summary.component';
+import { UserActivityHistoryChallengeSummaryComponent } from './components/challenge-summary.component';
+import { UserActivityHistoryProjectAttemptSummaryComponent } from './components/project-attempt-summary.component';
+import { UserActivityHistoryTestPassSummaryComponent } from './components/test-pass-summary.component';
+import { UserActivityHistoryContestParticipationComponent } from './components/contest-participation.component';
+import { UserActivityHistoryArenaParticipationComponent } from './components/arena-participation.component';
+import { UserActivityHistoryDailyActivityComponent } from './components/daily-activity.component';
+import { UserActivityHistoryHardProblemSolvedComponent } from './components/hard-problem-solved.component';
+import { UserActivityHistoryAchievementUnlockedComponent } from './components/achievement-unlocked.component';
+import { UserActivityHistoryDailyTaskCompletedComponent } from './components/daily-task-completed.component';
+
+interface UserActivityHistoryTypeConfig {
+  cardClass: string;
+  iconLabel: string;
+}
+
+@Component({
+  selector: 'user-activity-history',
+  templateUrl: './user-activity-history.component.html',
+  styleUrl: './user-activity-history.component.scss',
+  standalone: true,
+  imports: [
+    CoreCommonModule,
+    TranslateModule,
+    KepCardComponent,
+    SpinnerComponent,
+    UserActivityHistoryProblemAttemptSummaryComponent,
+    UserActivityHistoryChallengeSummaryComponent,
+    UserActivityHistoryProjectAttemptSummaryComponent,
+    UserActivityHistoryTestPassSummaryComponent,
+    UserActivityHistoryContestParticipationComponent,
+    UserActivityHistoryArenaParticipationComponent,
+    UserActivityHistoryDailyActivityComponent,
+    UserActivityHistoryHardProblemSolvedComponent,
+    UserActivityHistoryAchievementUnlockedComponent,
+    UserActivityHistoryDailyTaskCompletedComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UserActivityHistoryComponent implements OnChanges {
+  @Input() username?: string | null;
+
+  protected activities: UserActivityHistoryItem[] = [];
+  protected loading = false;
+  protected hasMore = false;
+  protected initialLoad = true;
+
+  private readonly usersApi = inject(UsersApiService);
+  private readonly pageSize = 10;
+  private nextPage = 1;
+  private totalPages = 0;
+
+  private readonly typeConfig: Record<UserActivityHistoryType, UserActivityHistoryTypeConfig> = {
+    problem_attempt_summary: { cardClass: 'primary', iconLabel: 'PS' },
+    challenge_summary: { cardClass: 'secondary', iconLabel: 'CH' },
+    project_attempt_summary: { cardClass: 'info', iconLabel: 'PR' },
+    test_pass_summary: { cardClass: 'success', iconLabel: 'TS' },
+    contest_participation: { cardClass: 'warning', iconLabel: 'CT' },
+    arena_participation: { cardClass: 'danger', iconLabel: 'AR' },
+    daily_activity: { cardClass: 'primary', iconLabel: 'DA' },
+    hard_problem_solved: { cardClass: 'success', iconLabel: 'HP' },
+    achievement_unlocked: { cardClass: 'warning', iconLabel: 'AC' },
+    daily_task_completed: { cardClass: 'info', iconLabel: 'DT' },
+  };
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['username']) {
+      this.reset();
+      if (this.username) {
+        this.loadActivities();
+      }
+    }
+  }
+
+  protected loadMore(): void {
+    if (this.loading || !this.hasMore) {
+      return;
+    }
+
+    this.loadActivities();
+  }
+
+  protected trackById(_: number, activity: UserActivityHistoryItem): number {
+    return activity.id;
+  }
+
+  protected getCardClass(activity: UserActivityHistoryItem): string {
+    return `mt-0 ${this.typeConfig[activity.activityType]?.cardClass ?? 'primary'}`;
+  }
+
+  protected getIconLabel(activity: UserActivityHistoryItem): string {
+    return this.typeConfig[activity.activityType]?.iconLabel ?? this.buildAbbreviation(activity.activityTypeDisplay);
+  }
+
+  protected getActivityType(activity: UserActivityHistoryItem): UserActivityHistoryType {
+    return activity.activityType;
+  }
+
+  private loadActivities(): void {
+    if (!this.username) {
+      return;
+    }
+
+    const pageToLoad = this.nextPage;
+
+    this.loading = true;
+
+    this.usersApi
+      .getUserActivityHistory(this.username, { page: pageToLoad, pageSize: this.pageSize })
+      .pipe(takeUntilDestroyed())
+      .subscribe({
+        next: (response: PageResult<UserActivityHistoryItem>) => {
+          const data = response?.data ?? [];
+          this.activities = [...this.activities, ...data];
+
+          if (response?.pagesCount) {
+            this.totalPages = response.pagesCount;
+          } else if (response?.total !== undefined && response?.pageSize) {
+            this.totalPages = Math.max(1, Math.ceil(response.total / response.pageSize));
+          }
+
+          const currentPage = response?.page ?? pageToLoad;
+          this.nextPage = currentPage + 1;
+
+          if (this.totalPages > 0) {
+            this.hasMore = this.nextPage <= this.totalPages;
+          } else {
+            this.hasMore = data.length === this.pageSize;
+          }
+        },
+        error: () => {
+          this.loading = false;
+          this.hasMore = false;
+          this.initialLoad = false;
+        },
+        complete: () => {
+          this.loading = false;
+          this.initialLoad = false;
+        },
+      });
+  }
+
+  private reset(): void {
+    this.activities = [];
+    this.loading = false;
+    this.hasMore = false;
+    this.initialLoad = true;
+    this.nextPage = 1;
+    this.totalPages = 0;
+  }
+
+  private buildAbbreviation(display: string): string {
+    if (!display) {
+      return '••';
+    }
+
+    const words = display.split(' ').filter(Boolean);
+    const abbreviation = words.slice(0, 2).map(word => word.charAt(0).toUpperCase()).join('');
+
+    return abbreviation || display.slice(0, 2).toUpperCase();
+  }
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-activity-history/user-activity-history.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-activity-history/user-activity-history.component.ts
@@ -1,4 +1,12 @@
-import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  OnChanges,
+  SimpleChanges,
+  inject,
+  ChangeDetectorRef, OnInit
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CoreCommonModule } from '@core/common.module';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
@@ -30,6 +38,7 @@ import { UserActivityHistoryDailyActivityComponent } from './components/daily-ac
 import { UserActivityHistoryHardProblemSolvedComponent } from './components/hard-problem-solved.component';
 import { UserActivityHistoryAchievementUnlockedComponent } from './components/achievement-unlocked.component';
 import { UserActivityHistoryDailyTaskCompletedComponent } from './components/daily-task-completed.component';
+import { ActivatedRoute } from "@angular/router";
 
 interface UserActivityHistoryTypeConfig {
   cardClass: string;
@@ -59,13 +68,14 @@ interface UserActivityHistoryTypeConfig {
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class UserActivityHistoryComponent implements OnChanges {
-  @Input() username?: string | null;
+export class UserActivityHistoryComponent implements OnInit {
+  public username: string;
 
   protected activities: UserActivityHistoryItem[] = [];
   protected loading = false;
   protected hasMore = false;
   protected initialLoad = true;
+  protected route = inject(ActivatedRoute);
 
   private readonly usersApi = inject(UsersApiService);
   private readonly pageSize = 10;
@@ -85,13 +95,12 @@ export class UserActivityHistoryComponent implements OnChanges {
     daily_task_completed: { cardClass: 'info', iconLabel: 'DT' },
   };
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['username']) {
-      this.reset();
-      if (this.username) {
-        this.loadActivities();
-      }
-    }
+  private readonly cdr = inject(ChangeDetectorRef);
+
+  ngOnInit() {
+    this.username = this.route.snapshot.parent.params.username;
+    this.reset();
+    this.loadActivities();
   }
 
   protected loadMore(): void {
@@ -129,7 +138,6 @@ export class UserActivityHistoryComponent implements OnChanges {
 
     this.usersApi
       .getUserActivityHistory(this.username, { page: pageToLoad, pageSize: this.pageSize })
-      .pipe(takeUntilDestroyed())
       .subscribe({
         next: (response: PageResult<UserActivityHistoryItem>) => {
           const data = response?.data ?? [];
@@ -158,6 +166,7 @@ export class UserActivityHistoryComponent implements OnChanges {
         complete: () => {
           this.loading = false;
           this.initialLoad = false;
+          this.cdr.detectChanges();
         },
       });
   }

--- a/src/app/modules/users/ui/pages/user-profile/user-profile.component.html
+++ b/src/app/modules/users/ui/pages/user-profile/user-profile.component.html
@@ -91,6 +91,13 @@
 
         <div class="order-lg-3 order-2 col-lg-3 col-12">
           @defer (on viewport) {
+            <user-activity-history [username]="user?.username"></user-activity-history>
+          } @placeholder {
+            <div class="card" [style.height.px]="360">
+              <spinner></spinner>
+            </div>
+          }
+          @defer (on viewport) {
             <user-skills></user-skills>
           } @placeholder {
             <div class="card" [style.height.px]="400">

--- a/src/app/modules/users/ui/pages/user-profile/user-profile.component.html
+++ b/src/app/modules/users/ui/pages/user-profile/user-profile.component.html
@@ -1,111 +1,67 @@
-<div class="content-wrapper container-xxl p-0">
-  <div class="content-body" id="user-profile">
-    <kep-card customClass="profile-header">
-      <img [src]="user.coverPhoto" alt="User Profile Image" class="card-img-top" loading="lazy"/>
-
-      <div class="position-relative">
-        <div class="profile-img-container d-flex align-items-center">
-          <div class="profile-img">
-            <img [src]="user.avatar" alt="Card image" class="rounded img-fluid" loading="lazy"/>
-          </div>
-          <div class="profile-title ms-3">
-            <h2 class="text-fixed-white">
-              {{ user.firstName }} {{ user.lastName }}
-              @if (user.streak >= 7) {
-                <kep-badge [streak]="user.streak"></kep-badge>
-              }
-              <user-online-status [lastSeen]="user.lastSeen" [online]="user.isOnline"></user-online-status>
-            </h2>
-            <p class="text-fixed-white">{{ user.username }}</p>
-          </div>
-        </div>
-      </div>
-
-      <div class="profile-header-nav">
-        <nav class="navbar navbar-expand-md navbar-light justify-content-end justify-content-md-between w-100">
-          <button
-            (click)="toggleMenu = !toggleMenu"
-            aria-controls="navbarSupportedContent"
-            aria-expanded="false"
-            aria-label="Toggle navigation"
-            class="btn btn-icon navbar-toggler"
-            data-bs-target="#navbarSupportedContent"
-            rippleEffect
-            type="button">
-            <i class="font-medium-5" data-feather="align-justify"></i>
-          </button>
-
-
-          <div [ngbCollapse]="toggleMenu" class="collapse navbar-collapse" id="navbarSupportedContent">
-            <div class="profile-tabs d-flex justify-content-between flex-wrap mt-1 mt-md-0">
-              <ul class="nav nav-tabs">
-                <li class="nav-item">
-                  <a [routerLink]="[Resources.UserProfile | resourceByUsername:user.username]"
-                     [routerLinkActiveOptions]="{exact: true}"
-                     routerLinkActive="active"
-                     class="nav-link fw-medium">
-                    <span class="d-none d-md-block">{{ 'Ratings' | translate }}</span>
-                    <i [data-feather]="'rating' | iconName" class="d-block d-md-none"></i>
-                  </a>
-                </li>
-                <li class="nav-item">
-                  <a [routerLink]="[Resources.UserProfileBlog | resourceByUsername:user.username]"
-                     routerLinkActive="active"
-                     class="nav-link fw-medium">
-                    <span class="d-none d-md-block">{{ 'Blog' | translate }}</span>
-                    <i [data-feather]="'edit-3'" class="d-block d-md-none"></i>
-                  </a>
-                </li>
-                <li class="nav-item">
-                  <a [routerLink]="[Resources.UserProfileAchievements | resourceByUsername:user.username]"
-                     routerLinkActive="active"
-                     class="nav-link fw-medium">
-                    <span class="d-none d-md-block">{{ 'Achievements' | translate }}</span>
-                    <i [data-feather]="'achievement' | iconName" class="d-block d-md-none"></i>
-                  </a>
-                </li>
-              </ul>
-
-              @if (currentUser?.username == user.username) {
-                <a [routerLink]="[Resources.Settings]" class="btn btn-primary"
-                   rippleEffect>
-                  <i data-feather="edit" class="d-block d-md-none"></i>
-                  <span class="fw-medium d-none d-md-block">{{ 'Edit' | translate }}</span>
-                </a>
-              }
-            </div>
-          </div>
-        </nav>
-      </div>
-    </kep-card>
-
-    <section id="profile-info">
-      <div class="row">
-        <div class="col-12 order-1 col-lg-3 col-12">
-          <user-info></user-info>
-        </div>
-
-        <div class="col-lg-6 col-12 order-1 order-lg-2">
-          <router-outlet/>
-        </div>
-
-        <div class="order-lg-3 order-2 col-lg-3 col-12">
-          @defer (on viewport) {
-            <user-activity-history [username]="user?.username"></user-activity-history>
-          } @placeholder {
-            <div class="card" [style.height.px]="360">
-              <spinner></spinner>
-            </div>
+<div class="card custom-card profile-card overflow-hidden">
+  <div class="profile-image">
+    <img [src]="user.coverPhoto" alt="..." class="card-img-top">
+  </div>
+  <div class="card-body p-4 pb-0 position-relative">
+    <span class="avatar avatar-xxl avatar-rounded bg-info">
+      <img [src]="user.avatar" alt="">
+    </span>
+    <div class="mt-4 mb-3 d-flex align-items-center flex-wrap gap-3 justify-content-between">
+      <div>
+        <h5 class="fw-semibold mb-1">
+          {{ user.username }}
+          @if (user.streak >= 7) {
+            <kep-badge [streak]="user.streak"></kep-badge>
           }
-          @defer (on viewport) {
-            <user-skills></user-skills>
-          } @placeholder {
-            <div class="card" [style.height.px]="400">
-              <spinner></spinner>
-            </div>
-          }
-        </div>
+          <user-online-status [lastSeen]="user.lastSeen" [online]="user.isOnline"></user-online-status>
+        </h5>
+        <span class="d-block fw-medium text-muted mb-1">{{ user.firstName }} {{ user.lastName }}</span>
       </div>
-    </section>
+    </div>
+
+    <ul class="nav nav-pills justify-content-start nav-style-3">
+      <li class="nav-item">
+        <a [routerLinkActiveOptions]="{exact: true}"
+           [routerLink]="[Resources.UserProfile | resourceByUsername:user.username]"
+           class="nav-link fw-medium"
+           routerLinkActive="active">
+          <span>{{ 'About' | translate }}</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a [routerLink]="[Resources.UserProfileRatings | resourceByUsername:user.username]"
+           class="nav-link fw-medium"
+           routerLinkActive="active">
+          <span>{{ 'Ratings' | translate }}</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a [routerLink]="[Resources.UserProfileActivityHistory | resourceByUsername:user.username]"
+           class="nav-link fw-medium"
+           routerLinkActive="active">
+          <span>{{ 'UserActivityHistory.Title' | translate }}</span>
+        </a>
+      </li>
+      <li class="nav-item">
+        <a [routerLink]="[Resources.UserProfileAchievements | resourceByUsername:user.username]"
+           class="nav-link fw-medium"
+           routerLinkActive="active">
+          <span>{{ 'Achievements' | translate }}</span>
+        </a>
+      </li>
+    </ul>
   </div>
 </div>
+
+<section id="profile-info">
+  <div class="row">
+    <div class="col-lg-3">
+      <user-info></user-info>
+      <user-skills></user-skills>
+    </div>
+
+    <div class="col-lg-9">
+      <router-outlet/>
+    </div>
+  </div>
+</section>

--- a/src/app/modules/users/ui/pages/user-profile/user-profile.component.scss
+++ b/src/app/modules/users/ui/pages/user-profile/user-profile.component.scss
@@ -174,3 +174,8 @@
     }
   }
 }
+
+.profile-card .avatar.avatar-xxl {
+  position: absolute;
+  inset-block-start: -2.5rem;
+}

--- a/src/app/modules/users/ui/pages/user-profile/user-profile.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-profile.component.ts
@@ -10,6 +10,7 @@ import { KepCardComponent } from '@shared/components/kep-card/kep-card.component
 import { ResourceByUsernamePipe } from '@shared/pipes/resource-by-username.pipe';
 import { UserSkillsComponent } from "@users/ui/pages/user-profile/user-skills/user-skills.component";
 import { UserInfoComponent } from "@users/ui/pages/user-profile/user-info/user-info.component";
+import { UserActivityHistoryComponent } from "@users/ui/pages/user-profile/user-activity-history/user-activity-history.component";
 import { User } from "@users/domain";
 
 
@@ -26,6 +27,7 @@ import { User } from "@users/domain";
     NgbCollapseModule,
     UserInfoComponent,
     UserSkillsComponent,
+    UserActivityHistoryComponent,
     KepBadgeComponent,
     UserOnlineStatusComponent,
     SpinnerComponent,

--- a/src/app/modules/users/ui/pages/user-profile/user-profile.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-profile.component.ts
@@ -1,7 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { BaseComponent } from '@core/common/classes/base.component';
 import { CoreCommonModule } from '@core/common.module';
-import { NgbCollapseModule, NgbProgressbarModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import {
+  NgbCollapseModule, NgbNav,
+  NgbNavItem,
+  NgbNavOutlet,
+  NgbProgressbarModule,
+  NgbTooltipModule
+} from '@ng-bootstrap/ng-bootstrap';
 import { NgxCountriesModule } from '@shared/third-part-modules/ngx-countries/ngx-countries.module';
 import { KepBadgeComponent } from '@shared/components/kep-badge/kep-badge.component';
 import { UserOnlineStatusComponent } from '@shared/components/user-online-status/user-online-status.component';
@@ -33,6 +39,9 @@ import { User } from "@users/domain";
     SpinnerComponent,
     KepCardComponent,
     ResourceByUsernamePipe,
+    NgbNavOutlet,
+    NgbNavItem,
+    NgbNav,
   ]
 })
 export class UserProfileComponent extends BaseComponent implements OnInit {

--- a/src/app/resources.ts
+++ b/src/app/resources.ts
@@ -60,6 +60,7 @@ export enum Resources {
   Users = '/users',
   UserProfile = `${Users}/user/:username`,
   UserProfileRatings = `${UserProfile}/ratings`,
+  UserProfileActivityHistory = `${UserProfile}/activity-history`,
   UserProfileBlog = `${UserProfile}/blog`,
   UserProfileAchievements = `${UserProfile}/achievements`,
 


### PR DESCRIPTION
## Summary
- add a user activity history entity and API method to retrieve timeline data
- build a standalone timeline widget with per-activity components for each history type
- integrate the widget into the user profile sidebar and localize the new copy

## Testing
- `npm run lint` *(fails: Cannot find "lint" target for the specified project)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d99e9490832faada24051c190769