### PR TITLE
Add follow controls to user profile

### DIFF
--- a/src/app/modules/users/config/routes.ts
+++ b/src/app/modules/users/config/routes.ts
@@ -24,6 +24,10 @@ export default [
         loadComponent: () => import('../ui/pages/user-profile/tabs/ratings-tab/ratings-tab.component').then(c => c.UserRatingsTabComponent),
       },
       {
+        path: 'followers',
+        loadComponent: () => import('../ui/pages/user-profile/widgets/user-followers/user-followers.component').then(c => c.UserFollowersComponent),
+      },
+      {
         path: 'activity-history',
         loadComponent: () => import('../ui/pages/user-profile/tabs/activity-history-tab/activity-history-tab.component').then(c => c.UserActivityHistoryTabComponent),
       },

--- a/src/app/modules/users/data-access/api/users-api.service.ts
+++ b/src/app/modules/users/data-access/api/users-api.service.ts
@@ -74,6 +74,18 @@ export class UsersApiService {
     return this.api.get(`users/${username}/ratings`);
   }
 
+  getUserFollowers(username: string, params?: Partial<Pageable>) {
+    return this.api.get(`users/${username}/followers`, params);
+  }
+
+  followUser(username: string) {
+    return this.api.post(`users/${username}/follow`);
+  }
+
+  unfollowUser(username: string) {
+    return this.api.post(`users/${username}/unfollow`);
+  }
+
   getMostActiveUsers() {
     return this.api.get('users/most-active-users');
   }

--- a/src/app/modules/users/domain/entities/user.entity.ts
+++ b/src/app/modules/users/domain/entities/user.entity.ts
@@ -9,6 +9,7 @@ export interface User {
   balls: number;
   isOnline: boolean;
   lastSeen: string;
+  isFollowing: boolean;
   kepcoin: number;
   streak: number;
   maxStreak: number;

--- a/src/app/modules/users/ui/pages/user-profile/user-profile.component.html
+++ b/src/app/modules/users/ui/pages/user-profile/user-profile.component.html
@@ -14,17 +14,34 @@
         <span class="avatar avatar-xxl avatar-rounded bg-info">
           <img [src]="user.avatar" alt="">
         </span>
-        <div class="mt-4 mb-3 d-flex align-items-center flex-wrap gap-3 justify-content-between">
-          <div>
-            <h5 class="fw-semibold mb-1">
+        <div class="mt-4 mb-3 d-flex align-items-start flex-column gap-2">
+          <div class="d-flex align-items-center flex-wrap gap-2">
+            <h5 class="fw-semibold mb-1 d-flex align-items-center gap-2">
               {{ user.username }}
               @if (user.streak >= 7) {
                 <kep-badge [streak]="user.streak"></kep-badge>
               }
               <user-online-status [lastSeen]="user.lastSeen" [online]="user.isOnline"></user-online-status>
             </h5>
-            <span class="d-block fw-medium text-muted mb-1">{{ user.firstName }} {{ user.lastName }}</span>
+            @if (canFollow) {
+              <button
+                type="button"
+                class="btn btn-sm btn-icon"
+                [disabled]="followLoading"
+                [ngClass]="user.isFollowing ? 'btn-warning' : 'btn-outline-warning'"
+                (click)="toggleFollow()"
+                [ngbTooltip]="user.isFollowing ? ('Unfollow' | translate) : ('Follow' | translate)"
+                aria-live="polite"
+                [attr.aria-label]="user.isFollowing ? ('Unfollow' | translate) : ('Follow' | translate)">
+                @if (followLoading) {
+                  <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                } @else {
+                  <i class="ti" [ngClass]="user.isFollowing ? 'ti-star' : 'ti-star-off'"></i>
+                }
+              </button>
+            }
           </div>
+          <span class="d-block fw-medium text-muted mb-1">{{ user.firstName }} {{ user.lastName }}</span>
         </div>
 
         <ul class="nav nav-pills justify-content-start nav-style-3">

--- a/src/app/modules/users/ui/pages/user-profile/user-profile.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/user-profile.component.ts
@@ -48,6 +48,7 @@ export class UserProfileComponent extends BaseLoadComponent<User> {
   public user: User | null = null;
   public toggleMenu = true;
   override loadOnInit = false;
+  public followLoading = false;
 
   private readonly usersApi = inject(UsersApiService);
   private currentUsername: string | null = null;
@@ -71,6 +72,7 @@ export class UserProfileComponent extends BaseLoadComponent<User> {
 
         this.currentUsername = username;
         this.user = null;
+        this.followLoading = false;
         this.loadData();
       });
   }
@@ -82,8 +84,58 @@ export class UserProfileComponent extends BaseLoadComponent<User> {
   }
 
   override afterLoadData(user: User): void {
-    this.user = user;
+    this.user = {
+      ...user,
+      isFollowing: user.isFollowing ?? false,
+    };
+    this.followLoading = false;
     this.currentUsername = user.username;
     this.titleService.updateTitle(this.route, {username: user.username});
+  }
+
+  get canFollow(): boolean {
+    if (!this.user || !this.isAuthenticated) {
+      return false;
+    }
+
+    return this.currentUser?.username !== this.user.username;
+  }
+
+  toggleFollow(): void {
+    if (!this.user || this.followLoading) {
+      return;
+    }
+
+    if (!this.canFollow) {
+      return;
+    }
+
+    const username = this.user.username;
+    const request$ = this.user.isFollowing
+      ? this.usersApi.unfollowUser(username)
+      : this.usersApi.followUser(username);
+
+    this.followLoading = true;
+
+    request$
+      .pipe(takeUntil(this._unsubscribeAll))
+      .subscribe({
+        next: () => {
+          if (!this.user) {
+            return;
+          }
+
+          this.user = {
+            ...this.user,
+            isFollowing: !this.user.isFollowing,
+          };
+          this.followLoading = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.followLoading = false;
+          this.cdr.markForCheck();
+        }
+      });
   }
 }

--- a/src/app/modules/users/ui/pages/user-profile/widgets/user-about/user-about.component.html
+++ b/src/app/modules/users/ui/pages/user-profile/widgets/user-about/user-about.component.html
@@ -14,4 +14,7 @@
   <div class="col-12">
     <user-social></user-social>
   </div>
+  <div class="col-12">
+    <user-followers-preview></user-followers-preview>
+  </div>
 </div>

--- a/src/app/modules/users/ui/pages/user-profile/widgets/user-about/user-about.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/widgets/user-about/user-about.component.ts
@@ -6,6 +6,7 @@ import { UserTechnologiesComponent } from '../user-technologies/user-technologie
 import { UserEducationsComponent } from '../user-educations/user-educations.component';
 import { UserWorkExperiencesComponent } from '../user-work-experiences/user-work-experiences.component';
 import { UserSocialComponent } from '../user-social/user-social.component';
+import { UserFollowersPreviewComponent } from '../user-followers-preview/user-followers-preview.component';
 
 @Component({
   selector: 'user-about',
@@ -18,6 +19,7 @@ import { UserSocialComponent } from '../user-social/user-social.component';
     UserEducationsComponent,
     UserWorkExperiencesComponent,
     UserSocialComponent,
+    UserFollowersPreviewComponent,
   ],
   templateUrl: './user-about.component.html',
   styleUrl: './user-about.component.scss'

--- a/src/app/modules/users/ui/pages/user-profile/widgets/user-followers-preview/user-followers-preview.component.html
+++ b/src/app/modules/users/ui/pages/user-profile/widgets/user-followers-preview/user-followers-preview.component.html
@@ -1,0 +1,43 @@
+<kep-card>
+  <div class="card-header d-flex align-items-center justify-content-between">
+    <h5 class="card-title mb-0">{{ 'Followers' | translate }}</h5>
+    @if (total > 0) {
+      <span class="badge bg-primary-transparent text-primary fw-semibold">{{ total }}</span>
+    }
+  </div>
+  <div class="card-body p-0">
+    @if (isLoading && followers.length === 0) {
+      <div class="py-5 text-center">
+        <spinner></spinner>
+      </div>
+    } @else if (followers.length > 0) {
+      <ul class="followers-list list-unstyled mb-0">
+        @for (follower of followers; track follower.username) {
+          <li class="follower-item d-flex align-items-center gap-3 px-4 py-3">
+            <span class="avatar avatar-md avatar-rounded bg-light followers-avatar">
+              <img [src]="follower.avatar" alt="{{ follower.username }} avatar">
+            </span>
+            <div class="flex-grow-1">
+              <a
+                class="fw-semibold text-body"
+                [routerLink]="[Resources.UserProfile | resourceByUsername:follower.username]">
+                {{ follower.username }}
+              </a>
+              <div class="text-muted small">{{ follower.firstName }} {{ follower.lastName }}</div>
+            </div>
+          </li>
+        }
+      </ul>
+    } @else {
+      <empty-result></empty-result>
+    }
+  </div>
+  @if (canViewAll && username) {
+    <div class="card-footer border-top-0 pt-0 text-end">
+      <a class="btn btn-sm btn-primary"
+         [routerLink]="[Resources.UserProfileFollowers | resourceByUsername:username]">
+        View all followers
+      </a>
+    </div>
+  }
+</kep-card>

--- a/src/app/modules/users/ui/pages/user-profile/widgets/user-followers-preview/user-followers-preview.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/widgets/user-followers-preview/user-followers-preview.component.ts
@@ -1,0 +1,86 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BaseLoadComponent } from '@core/common';
+import { PageResult } from '@core/common/classes/page-result';
+import { UsersApiService } from '@users/data-access';
+import { User } from '@users/domain';
+import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { EmptyResultComponent } from '@shared/components/empty-result/empty-result.component';
+import { RouterLink } from '@angular/router';
+import { ResourceByUsernamePipe } from '@shared/pipes/resource-by-username.pipe';
+import { TranslateModule } from '@ngx-translate/core';
+import { Observable, combineLatest, of } from 'rxjs';
+import { distinctUntilChanged, filter, map, takeUntil } from 'rxjs/operators';
+import { Resources } from '@app/resources';
+
+@Component({
+  selector: 'user-followers-preview',
+  standalone: true,
+  imports: [
+    CommonModule,
+    SpinnerComponent,
+    KepCardComponent,
+    EmptyResultComponent,
+    RouterLink,
+    ResourceByUsernamePipe,
+    TranslateModule,
+  ],
+  templateUrl: './user-followers-preview.component.html',
+  styleUrls: ['../user-followers/user-followers.component.scss']
+})
+export class UserFollowersPreviewComponent extends BaseLoadComponent<PageResult<User>> {
+  public readonly Resources = Resources;
+  public followers: User[] = [];
+  public total = 0;
+  public username: string | null = null;
+
+  private readonly usersApi = inject(UsersApiService);
+
+  override ngOnInit(): void {
+    this.username = this.getUsernameFromRoute();
+    super.ngOnInit();
+
+    const parentParams$ = this.route.parent?.params ?? of({});
+
+    combineLatest([this.route.params, parentParams$])
+      .pipe(
+        takeUntil(this._unsubscribeAll),
+        map(([params, parentParams]) => params?.['username'] ?? parentParams?.['username'] ?? this.getUsernameFromRoute()),
+        filter((username): username is string => !!username),
+        distinctUntilChanged(),
+      )
+      .subscribe(username => {
+        const usernameChanged = username !== this.username;
+        this.username = username;
+
+        if (usernameChanged) {
+          this.followers = [];
+          this.total = 0;
+          this.loadData();
+        }
+      });
+  }
+
+  getData(): Observable<PageResult<User>> {
+    const username = this.username ?? this.getUsernameFromRoute();
+
+    return this.usersApi.getUserFollowers(username!, {
+      page: 1,
+      pageSize: 5,
+    });
+  }
+
+  override afterLoadData(result: PageResult<User>): void {
+    this.followers = (result.data ?? []).slice(0, 5);
+    this.total = result.total ?? result.count ?? this.followers.length;
+  }
+
+  get canViewAll(): boolean {
+    return this.total > this.followers.length;
+  }
+
+  private getUsernameFromRoute(): string | null {
+    return this.route.snapshot.paramMap.get('username') ?? this.route.parent?.snapshot.paramMap.get('username') ?? null;
+  }
+}

--- a/src/app/modules/users/ui/pages/user-profile/widgets/user-followers/user-followers.component.html
+++ b/src/app/modules/users/ui/pages/user-profile/widgets/user-followers/user-followers.component.html
@@ -1,0 +1,48 @@
+<kep-card>
+  <div class="card-header d-flex align-items-center justify-content-between">
+    <h5 class="card-title mb-0">{{ 'Followers' | translate }}</h5>
+    @if (total > 0) {
+      <span class="badge bg-primary-transparent text-primary fw-semibold">{{ total }}</span>
+    }
+  </div>
+  <div class="card-body p-0">
+    @if (isLoading && followers.length === 0) {
+      <div class="py-5 text-center">
+        <spinner></spinner>
+      </div>
+    } @else if (followers.length > 0) {
+      <ul class="followers-list list-unstyled mb-0">
+        @for (follower of followers; track follower.username) {
+          <li class="follower-item d-flex align-items-center gap-3 px-4 py-3">
+            <span class="avatar avatar-md avatar-rounded bg-light followers-avatar">
+              <img [src]="follower.avatar" alt="{{ follower.username }} avatar">
+            </span>
+            <div class="flex-grow-1">
+              <a
+                class="fw-semibold text-body"
+                [routerLink]="[Resources.UserProfile | resourceByUsername:follower.username]">
+                {{ follower.username }}
+              </a>
+              <div class="text-muted small">{{ follower.firstName }} {{ follower.lastName }}</div>
+            </div>
+          </li>
+        }
+      </ul>
+    } @else {
+      <empty-result></empty-result>
+    }
+  </div>
+  @if (!isLoading && (pageResult?.pagesCount ?? 0) > 1) {
+    <div class="card-footer border-top-0 pt-0">
+      <kep-pagination
+        [collectionSize]="total"
+        [pageSize]="pageSize"
+        [page]="pageNumber"
+        [maxSize]="3"
+        [ellipses]="false"
+        [disabled]="isLoading"
+        (pageChange)="pageChange($event)">
+      </kep-pagination>
+    </div>
+  }
+</kep-card>

--- a/src/app/modules/users/ui/pages/user-profile/widgets/user-followers/user-followers.component.scss
+++ b/src/app/modules/users/ui/pages/user-profile/widgets/user-followers/user-followers.component.scss
@@ -1,0 +1,29 @@
+:host {
+  display: block;
+}
+
+.followers-list {
+  .follower-item {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    .followers-avatar {
+      width: 48px;
+      height: 48px;
+      overflow: hidden;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+    }
+  }
+}
+
+.card-footer {
+  background-color: transparent;
+}

--- a/src/app/modules/users/ui/pages/user-profile/widgets/user-followers/user-followers.component.ts
+++ b/src/app/modules/users/ui/pages/user-profile/widgets/user-followers/user-followers.component.ts
@@ -1,0 +1,86 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BaseTablePageComponent } from '@core/common';
+import { PageResult } from '@core/common/classes/page-result';
+import { UsersApiService } from '@users/data-access';
+import { User } from '@users/domain';
+import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { EmptyResultComponent } from '@shared/components/empty-result/empty-result.component';
+import { KepPaginationComponent } from '@shared/components/kep-pagination/kep-pagination.component';
+import { RouterLink } from '@angular/router';
+import { ResourceByUsernamePipe } from '@shared/pipes/resource-by-username.pipe';
+import { TranslateModule } from '@ngx-translate/core';
+import { Observable, combineLatest, of } from 'rxjs';
+import { distinctUntilChanged, filter, map, takeUntil } from 'rxjs/operators';
+
+@Component({
+  selector: 'user-followers',
+  standalone: true,
+  imports: [
+    CommonModule,
+    SpinnerComponent,
+    KepCardComponent,
+    EmptyResultComponent,
+    KepPaginationComponent,
+    RouterLink,
+    ResourceByUsernamePipe,
+    TranslateModule,
+  ],
+  templateUrl: './user-followers.component.html',
+  styleUrls: ['./user-followers.component.scss']
+})
+export class UserFollowersComponent extends BaseTablePageComponent<User> {
+  public followers: User[] = [];
+  override defaultPageSize = 12;
+  override maxSize = 3;
+
+  private readonly usersApi = inject(UsersApiService);
+  private currentUsername: string | null = null;
+
+  constructor() {
+    super();
+  }
+
+  override ngOnInit(): void {
+    this.currentUsername = this.getUsernameFromRoute();
+    super.ngOnInit();
+
+    const parentParams$ = this.route.parent?.params ?? of({});
+
+    combineLatest([this.route.params, parentParams$])
+      .pipe(
+        takeUntil(this._unsubscribeAll),
+        map(([params, parentParams]) => params?.['username'] ?? parentParams?.['username'] ?? this.getUsernameFromRoute()),
+        filter((username): username is string => !!username),
+        distinctUntilChanged(),
+      )
+      .subscribe(username => {
+        const usernameChanged = username !== this.currentUsername;
+        this.currentUsername = username;
+
+        if (usernameChanged) {
+          this.pageNumber = this.defaultPageNumber;
+          this.reloadPage();
+        }
+      });
+  }
+
+  override getPage(): Observable<PageResult<User>> {
+    const username = this.currentUsername ?? this.getUsernameFromRoute();
+
+    return this.usersApi.getUserFollowers(username!, {
+      page: this.pageNumber,
+      pageSize: this.pageSize,
+    });
+  }
+
+  override afterLoadPage(pageResult: PageResult<User>): void {
+    pageResult.data = pageResult.data ?? [];
+    this.followers = pageResult.data;
+  }
+
+  private getUsernameFromRoute(): string | null {
+    return this.route.snapshot.paramMap.get('username') ?? this.route.parent?.snapshot.paramMap.get('username') ?? null;
+  }
+}

--- a/src/app/resources.ts
+++ b/src/app/resources.ts
@@ -59,6 +59,7 @@ export enum Resources {
 
   Users = '/users',
   UserProfile = `${Users}/user/:username`,
+  UserProfileFollowers = `${UserProfile}/followers`,
   UserProfileRatings = `${UserProfile}/ratings`,
   UserProfileActivityHistory = `${UserProfile}/activity-history`,
   UserProfileBlog = `${UserProfile}/blog`,


### PR DESCRIPTION
## Summary
- expose follow/unfollow endpoints on the users API client and track the new `isFollowing` flag
- add a follow toggle button to the profile header that reflects follow state and prevents duplicate requests
- refactor the followers list to use `BaseTablePageComponent`, add a dedicated followers route, and surface a five-user preview with a "View all" link in the About tab

## Testing
- npm run lint *(fails: Angular CLI (`ng`) is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea15d4bf14832f928d28d4f294b467