### PR TITLE
Add following-only filter toggle to contest standings

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -534,6 +534,7 @@ export const localeEn = {
     Registered: 'Registered',
     RegisterIndividual: 'Register as an individual',
     FilterContests: 'Filtering contests',
+    FollowingOnly: 'Following only',
     Participated: 'Participated',
     NotParticipated: 'Did not participated',
     Problems: 'Contest problems',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -529,6 +529,7 @@ export const localeRu = {
     Registered: 'Зарегистрирован',
     RegisterIndividual: 'В качестве индивидуального участника',
     FilterContests: 'Фильтрация контестов',
+    FollowingOnly: 'Только отслеживаемые',
     Participated: 'Принял участие',
     NotParticipated: 'Не участвовал',
     Problems: 'Задачи контеста',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -532,6 +532,7 @@ export const localeUz = {
     Registered: 'Roʻyhatdan oʻtilgan',
     RegisterIndividual: 'Individual qatnashchi boʻlib',
     FilterContests: 'Kontestlarni filterlash',
+    FollowingOnly: 'Faqat kuzatayotganlar',
     Participated: 'Qatnashilgan',
     NotParticipated: 'Qatnashilmagan',
     Problems: 'Kontest masalalari',

--- a/src/app/modules/contests/pages/contest/contest-standings/contest-standings.component.html
+++ b/src/app/modules/contests/pages/contest/contest-standings/contest-standings.component.html
@@ -10,18 +10,33 @@
         {{ contest.title }}
       </div>
 
-      <ng-select
-        (change)="filterChange()"
-        [(ngModel)]="selectedFilter"
-        [clearable]="true"
-        [items]="contestFilters"
-        [ngClass.lt-md]="'d-none'"
-        [searchable]="true"
-        bindLabel="name"
-        bindValue="id"
-        placeholder="{{ 'All' | translate }}"
-        style="width: 300px;"
-      />
+      <div class="d-flex flex-wrap align-items-center justify-content-end gap-2">
+        <div class="form-check form-switch m-0 text-nowrap">
+          <input
+            (change)="onFollowingToggle($event.target.checked)"
+            [checked]="followingOnly"
+            class="form-check-input"
+            id="contest-following-only"
+            type="checkbox"
+          >
+          <label class="form-check-label" for="contest-following-only">
+            {{ 'Contests.FollowingOnly' | translate }}
+          </label>
+        </div>
+
+        <ng-select
+          (change)="filterChange()"
+          [(ngModel)]="selectedFilter"
+          [clearable]="true"
+          [items]="contestFilters"
+          [ngClass.lt-md]="'d-none'"
+          [searchable]="true"
+          bindLabel="name"
+          bindValue="id"
+          placeholder="{{ 'All' | translate }}"
+          style="width: 300px;"
+        />
+      </div>
     </div>
     <contest-tab [contest]="contest"/>
   </div>

--- a/src/app/modules/contests/pages/contest/contest-standings/contest-standings.component.ts
+++ b/src/app/modules/contests/pages/contest/contest-standings/contest-standings.component.ts
@@ -52,6 +52,7 @@ export class ContestStandingsComponent extends BaseTablePageComponent<Contestant
   public firstLoad = true;
   public contestFilters = [];
   public selectedFilter: number;
+  public followingOnly = false;
 
   constructor(
     public service: ContestsService,
@@ -88,17 +89,19 @@ export class ContestStandingsComponent extends BaseTablePageComponent<Contestant
   }
 
   getPage() {
+    const params = this.buildContestantsParams();
+
     if (this.isAuthenticated &&
       this.pageNumber === this.defaultPageNumber &&
       this.pageSize === this.defaultPageSize &&
       this.firstLoad) {
       this.firstLoad = false;
-      return this.service.getNewContestants(this.contest.id, {filter: this.selectedFilter});
+      return this.service.getNewContestants(this.contest.id, params);
     }
     this.firstLoad = false;
     return this.service.getNewContestants(this.contest.id, {
       ...this.pageable,
-      filter: this.selectedFilter,
+      ...params,
     });
   }
 
@@ -110,8 +113,26 @@ export class ContestStandingsComponent extends BaseTablePageComponent<Contestant
     );
   }
 
+  onFollowingToggle(checked: boolean) {
+    this.followingOnly = checked;
+    this.pageNumber = 1;
+    this.reloadPage();
+  }
+
   filterChange() {
     this.pageNumber = 1;
     this.reloadPage();
+  }
+
+  private buildContestantsParams() {
+    const params: Record<string, any> = {
+      filter: this.selectedFilter,
+    };
+
+    if (this.followingOnly) {
+      params.following = true;
+    }
+
+    return params;
   }
 }


### PR DESCRIPTION
## Summary
- add a "Following only" switch to the contest standings header
- reuse the toggle state when fetching data so that the following=true flag is only sent when enabled
- localize the new toggle label in English, Russian, and Uzbek copies

## Testing
- npm run lint *(fails: ng not found in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea4d8aa810832fa9587ca02d947d1e