### PR TITLE
Refine header notifications handling and localization

### DIFF
--- a/src/@core/layouts/components/header/notifications/header-notifications.component.html
+++ b/src/@core/layouts/components/header/notifications/header-notifications.component.html
@@ -12,14 +12,14 @@
   <div class="main-header-dropdown dropdown-menu dropdown-menu-end" data-popper-placement="none" ngbDropdownMenu>
     <div class="p-3">
       <div class="d-flex align-items-center justify-content-between">
-        <p class="mb-0 fs-16">Notifications</p>
-        <span class="badge bg-primary" id="notifiation-data">{{ notifications.length }} Unread</span>
+        <p class="mb-0 fs-16">{{ 'Notifications' | translate }}</p>
+        <span class="badge bg-primary" id="notifiation-data">{{ notifications.length }} {{ 'Unread' | translate }}</span>
       </div>
     </div>
     <div class="dropdown-divider"></div>
     <ngx-simplebar>
       <ul class="list-unstyled mb-0" id="header-notification-scroll">
-        @for (notification of notifications; track notification) {
+        @for (notification of notifications; track notification.id) {
           <li class="dropdown-item">
             <div class="d-flex align-items-center">
               <div class="pe-2 lh-1">
@@ -31,10 +31,10 @@
                 <div>
                   <p class="mb-0 fw-medium">
                     @switch (notification.type) {
-                      @case (1) {
+                      @case (NotificationType.System) {
                         {{ notification.message }}
                       }
-                      @case (2) {
+                      @case (NotificationType.ContestRatingChanges) {
                         <a [routerLink]="Resources.ContestStandings | resourceById:notification.content.contestId">
                           <strong>{{ notification.content.contestTitle }}</strong>
                           | {{ 'ContestFinishedNotification' | translate }}
@@ -42,14 +42,14 @@
                             class="ms-1 badge"
                             [ngClass]="{
                             'badge-light-success': notification.content.delta > 0,
-                            'badge-light-dark': notification.content.delta == 0,
+                            'badge-light-dark': notification.content.delta === 0,
                             'bg-danger-transparent': notification.content.delta < 0
                           }">
                             <span *ngIf="notification.content.delta > 0">+</span>{{ notification.content.delta }}
                           </span>
                         </a>
                       }
-                      @case (3) {
+                      @case (NotificationType.KepcoinEarn) {
                         <span [ngSwitch]="notification.content.earnType" class="me-1 text-dark">
                           <span *ngSwitchCase="4">
                             {{ 'BonusFromAdmin' | translate }}
@@ -66,28 +66,28 @@
                         </span>
                         <img height="18" src="assets/images/icons/kepcoin.png"> {{ notification.content.kepcoin }}
                       }
-                      @case (4) {
+                      @case (NotificationType.ChallengeCallAccept) {
                         <a [routerLink]="Resources.Challenge | resourceById:notification.content?.challengeId">
                           {{ 'ChallengeCallAcceptedNotification' | translate }}
                         </a>
                       }
-                      @case (5) {
+                      @case (NotificationType.ChallengeFinished) {
                         <a [routerLink]="Resources.Challenge | resourceById:notification.content?.challengeId">
                           {{ 'ChallengeFinishedNotification' | translate }}
                         </a>
                       }
-                      @case (6) {
+                      @case (NotificationType.ArenaFinished) {
                         <a [routerLink]="Resources.ArenaTournament | resourceById:notification.content?.arena?.id">
                           <strong>{{ notification.content?.arena?.title }}</strong>
                           | {{ 'ArenaFinishedNotification' | translate }}
                         </a>
                       }
-                      @case (7) {
+                      @case (NotificationType.DuelStarts) {
                         <a [routerLink]="Resources.Duel | resourceById:notification.content?.duel?.id">
                           {{ 'DuelStarts' | translate }}
                         </a>
                       }
-                      @case (8) {
+                      @case (NotificationType.NewAchievement) {
                         <a [routerLink]="Resources.UserProfileAchievements | resourceByUsername:currentUser?.username">
                           {{ 'NewAchievement' | translate }}
                         </a>
@@ -126,7 +126,7 @@
             <span class="avatar avatar-xl avatar-rounded bg-secondary-transparent">
               <i class="bi bi-bell-slash fs-2"></i>
             </span>
-            <h6 class="fw-medium mt-3">No New Notifications</h6>
+            <h6 class="fw-medium mt-3">{{ 'NoNotifications' | translate }}</h6>
           </div>
         </div>
       }

--- a/src/@core/layouts/components/header/notifications/header-notifications.component.ts
+++ b/src/@core/layouts/components/header/notifications/header-notifications.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { bounceAnimation } from 'angular-animations';
 import { AuthService, AuthUser } from '@auth';
 
@@ -17,10 +17,22 @@ import { SimplebarAngularModule } from "simplebar-angular";
 import { Resources } from '@app/resources';
 import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 import { ResourceByUsernamePipe } from '@shared/pipes/resource-by-username.pipe';
+import { TranslateService } from '@ngx-translate/core';
+
+export enum NotificationType {
+  System = 1,
+  ContestRatingChanges = 2,
+  KepcoinEarn = 3,
+  ChallengeCallAccept = 4,
+  ChallengeFinished = 5,
+  ArenaFinished = 6,
+  DuelStarts = 7,
+  NewAchievement = 8,
+}
 
 interface Notification {
   id: number;
-  type: number;
+  type: NotificationType;
   message: string;
   createdNaturaltime: string;
   created: string;
@@ -57,49 +69,35 @@ export class HeaderNotificationsComponent implements OnInit, OnDestroy {
 
   protected cdr = inject(ChangeDetectorRef);
 
-  @ViewChild('notificationAudio') notificationAudio: any;
+  @ViewChild('notificationAudio') notificationAudio?: ElementRef<HTMLAudioElement>;
 
-  private _intervalId: any;
-  private _unsubscribeAll = new Subject();
+  private readonly destroy$ = new Subject<void>();
+  private initTimeoutId: ReturnType<typeof setTimeout> | null = null;
   protected readonly Resources = Resources;
+  protected readonly NotificationType = NotificationType;
 
   constructor(
     public notificationsService: NotificationsService,
     public wsService: WebsocketService,
     public authService: AuthService,
+    private translateService: TranslateService,
   ) {
   }
 
   ngOnInit(): void {
     this.updateNotifications();
-    setTimeout(() => this.init(), 2000);
+    this.initTimeoutId = setTimeout(() => this.init(), 2000);
   }
 
-  init() {
-    this.authService.currentUser.pipe(takeUntil(this._unsubscribeAll)).subscribe(
+  private init(): void {
+    this.authService.currentUser.pipe(takeUntil(this.destroy$)).subscribe(
       (user: AuthUser) => {
         if (user) {
           this.wsService.send('notification-add', user.username);
-          this.wsService.on(`notification-${user.username}`).subscribe(
-            (notification: Notification) => {
-              if (this.notifications.find(n => n.id === notification.id)) {
-                return;
-              }
-
-              if (notification.type === 1) {
-                Swal.fire({
-                  title: 'Information',
-                  html: notification.message,
-                  icon: 'info',
-                });
-              }
-              const notifications = this.notifications.reverse();
-              notifications.push(notification);
-              this.notifications = notifications.reverse();
-              this.notificationAudio.nativeElement.play();
-            }
+          this.wsService.on(`notification-${user.username}`).pipe(takeUntil(this.destroy$)).subscribe(
+            (notification: Notification) => this.handleIncomingNotification(notification),
           );
-        } else {
+        } else if (this.currentUser?.username) {
           this.wsService.send('notification-delete', this.currentUser.username);
         }
         this.currentUser = user;
@@ -107,7 +105,24 @@ export class HeaderNotificationsComponent implements OnInit, OnDestroy {
     );
   }
 
-  updateNotifications() {
+  private handleIncomingNotification(notification: Notification): void {
+    if (this.notifications.find(n => n.id === notification.id)) {
+      return;
+    }
+
+    if (notification.type === NotificationType.System) {
+      Swal.fire({
+        title: this.translateService.instant('NotificationInformationTitle'),
+        html: notification.message,
+        icon: 'info',
+      });
+    }
+
+    this.notifications = [notification, ...this.notifications];
+    this.notificationAudio?.nativeElement?.play();
+  }
+
+  updateNotifications(): void {
     this.isLoading = true;
     this.notificationsService.getNotifications(this.pageNumber, this.isAll).subscribe(
       (result: PageResult<Notification>) => {
@@ -121,42 +136,39 @@ export class HeaderNotificationsComponent implements OnInit, OnDestroy {
     );
   }
 
-  notificationClick(notification: Notification) {
+  notificationClick(notification: Notification): void {
     if (!this.isAll) {
       this.notificationsService.readNotification(notification.id).subscribe(
         (result: any) => {
           if (result.success) {
-            const index = this.notifications.findIndex((value: Notification) => value.id === notification.id);
-            if (index !== -1) {
-              this.notifications.splice(index, 1);
-            }
+            this.notifications = this.notifications.filter((value: Notification) => value.id !== notification.id);
           }
         }
       );
     }
   }
 
-  readAll() {
+  readAll(): void {
     this.notificationsService.readAllNotification().subscribe(
       (result: any) => {
         if (result.success) {
-          this.notifications.splice(0, this.notifications.length);
+          this.notifications = [];
         }
       }
     );
   }
 
-  click() {
+  click(): void {
     this.isAll = !this.isAll;
     this.notifications = [];
     this.updateNotifications();
   }
 
   ngOnDestroy(): void {
-    if (this._intervalId) {
-      clearInterval(this._intervalId);
+    if (this.initTimeoutId) {
+      clearTimeout(this.initTimeoutId);
     }
-    this._unsubscribeAll.next(null);
-    this._unsubscribeAll.complete();
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -145,6 +145,7 @@ export const localeEn = {
   NoNotifications: 'No notifications',
   New: 'New',
   Notifications: 'Notifications',
+  NotificationInformationTitle: 'Information',
   Copy: 'Copy',
   ArenaPauseText: 'Get started',
   ArenaStartText: 'You are participating. Wait for the next challenge!',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -143,6 +143,7 @@ export const localeRu = {
   New: 'Новый',
   Copied: 'Скопировано',
   Notifications: 'Уведомления',
+  NotificationInformationTitle: 'Информация',
   ArenaPauseText: 'Начните участие',
   ArenaStartText: 'Вы участвуете. Ждите следующего соперника!',
   Pause: 'Остановить',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -146,6 +146,7 @@ export const localeUz = {
   NoNotifications: 'Xabarnoma yoʻq',
   New: 'Yangi',
   Notifications: 'Xabarnomalar',
+  NotificationInformationTitle: 'Maʼlumot',
   ArenaPauseText: 'Musobaqani boshlash',
   ArenaStartText: 'Musobaqada ishtirok etyapsiz. Keyingi bellashuvni kuting!',
   Pause: 'Toʻxtatish',


### PR DESCRIPTION
## Summary
- replace magic numbers in the header notifications component with a NotificationType enum and tidy websocket teardown
- show translated system notification dialogs while immutably updating the local list of notifications
- localize notification dropdown labels and add the NotificationInformationTitle key across en/ru/uz resources

## Testing
- npm run lint *(fails: ng not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea623e1514832faa921c6fcc4cc1cc