### PR TITLE
Enable search filtering for arena and tournament listings

### DIFF
--- a/src/app/modules/arena/arena.service.ts
+++ b/src/app/modules/arena/arena.service.ts
@@ -12,7 +12,7 @@ export class ArenaService {
     public api: ApiService,
   ) { }
 
-  getArenaAll(params?: { status?: ArenaStatus } & Partial<Pageable>) {
+  getArenaAll(params?: { status?: ArenaStatus, title?: string } & Partial<Pageable>) {
     return this.api.get('arena', params);
   }
 

--- a/src/app/modules/arena/pages/arena/arena.component.html
+++ b/src/app/modules/arena/pages/arena/arena.component.html
@@ -8,7 +8,12 @@
       <span *ngIf="!isLoading" class="total-count">({{ pageResult?.total }})</span>
     </div>
     <div>
-      <input class="form-control mt-md-0 mt-1ca" placeholder="{{ 'Search' | translate }}">
+      <input
+        [formControl]="searchControl"
+        class="form-control mt-md-0 mt-1ca"
+        placeholder="{{ 'Search' | translate }}"
+        type="search"
+      >
     </div>
   </div>
 </kep-card>

--- a/src/app/modules/arena/pages/arena/arena.component.ts
+++ b/src/app/modules/arena/pages/arena/arena.component.ts
@@ -11,6 +11,8 @@ import { ContentHeaderModule } from '@shared/ui/components/content-header/conten
 import { KepPaginationComponent } from '@shared/components/kep-pagination/kep-pagination.component';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { debounceTime, takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-arena',
@@ -24,9 +26,12 @@ import { KepCardComponent } from "@shared/components/kep-card/kep-card.component
     KepPaginationComponent,
     NgxSkeletonLoaderModule,
     KepCardComponent,
+    ReactiveFormsModule,
   ]
 })
 export class ArenaComponent extends BaseTablePageComponent<Arena> implements OnInit {
+
+  public searchControl = new FormControl();
 
   constructor(public service: ArenaService) {
     super();
@@ -36,8 +41,23 @@ export class ArenaComponent extends BaseTablePageComponent<Arena> implements OnI
     return this.pageResult?.data;
   }
 
+  override ngOnInit(): void {
+    super.ngOnInit();
+
+    this.searchControl.valueChanges.pipe(
+      takeUntil(this._unsubscribeAll),
+      debounceTime(1000),
+    ).subscribe(() => {
+      this.pageNumber = this.defaultPageNumber;
+      this.reloadPage();
+    });
+  }
+
   getPage(): Observable<PageResult<Arena>> {
-    return this.service.getArenaAll(this.pageable);
+    return this.service.getArenaAll({
+      ...this.pageable,
+      title: this.searchControl.value,
+    });
   }
 
   protected getContentHeader(): ContentHeader {

--- a/src/app/modules/tournaments/data-access/tournaments-api.service.ts
+++ b/src/app/modules/tournaments/data-access/tournaments-api.service.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { ApiService } from '@core/data-access/api.service';
+import { Pageable } from '@core/common/classes/pageable';
 
 @Injectable({
   providedIn: 'root'
@@ -7,8 +8,8 @@ import { ApiService } from '@core/data-access/api.service';
 export class TournamentsApiService {
   protected api = inject(ApiService);
 
-  getTournaments() {
-    return this.api.get('tournaments');
+  getTournaments(params?: Partial<Pageable> & { title?: string }) {
+    return this.api.get('tournaments', params);
   }
 
   getTournament(tournamentId: number | string) {

--- a/src/app/modules/tournaments/ui/pages/tournaments-list/tournaments-list.page.html
+++ b/src/app/modules/tournaments/ui/pages/tournaments-list/tournaments-list.page.html
@@ -12,7 +12,12 @@
               <span class="total-count" *ngIf="!isLoading">({{ pageResult?.total }})</span>
             </div>
             <div>
-              <input placeholder="{{ 'Search' | translate }}" class="form-control mt-md-0 mt-1">
+              <input
+                [formControl]="searchControl"
+                placeholder="{{ 'Search' | translate }}"
+                class="form-control mt-md-0 mt-1"
+                type="search"
+              >
             </div>
           </div>
         </kep-card>

--- a/src/app/modules/tournaments/ui/pages/tournaments-list/tournaments-list.page.ts
+++ b/src/app/modules/tournaments/ui/pages/tournaments-list/tournaments-list.page.ts
@@ -13,6 +13,8 @@ import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
 import { TournamentsApiService } from "@app/modules/tournaments/data-access/tournaments-api.service";
 import { Tournament } from "@app/modules/tournaments/domain";
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { debounceTime, takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'page-tournaments',
@@ -27,17 +29,35 @@ import { Tournament } from "@app/modules/tournaments/domain";
     KepPaginationComponent,
     NgxSkeletonLoaderModule,
     KepCardComponent,
+    ReactiveFormsModule,
   ]
 })
 export class TournamentsListPage extends BaseTablePageComponent<Tournament> implements OnInit {
   protected tournamentsApiService = inject(TournamentsApiService);
+
+  public searchControl = new FormControl();
 
   get tournaments() {
     return this.pageResult?.data;
   }
 
   getPage(): Observable<PageResult<Tournament>> {
-    return this.tournamentsApiService.getTournaments();
+    return this.tournamentsApiService.getTournaments({
+      ...this.pageable,
+      title: this.searchControl.value,
+    });
+  }
+
+  override ngOnInit(): void {
+    super.ngOnInit();
+
+    this.searchControl.valueChanges.pipe(
+      takeUntil(this._unsubscribeAll),
+      debounceTime(1000),
+    ).subscribe(() => {
+      this.pageNumber = this.defaultPageNumber;
+      this.reloadPage();
+    });
   }
 
   protected getContentHeader(): ContentHeader {


### PR DESCRIPTION
## Summary
- add reactive search inputs to the arena and tournament list pages that reload data as the query changes
- forward the search term to the arena and tournament APIs so the backend can filter results

## Testing
- npm run lint *(fails: `ng` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebb07a51d0832f9b865886af18f05f