### PR TITLE
Handle paginated contest registrants with rating ordering

### DIFF
--- a/src/app/modules/contests/contests.service.ts
+++ b/src/app/modules/contests/contests.service.ts
@@ -15,6 +15,7 @@ import {
 import { getCategoryIcon } from '@contests/utils/category-icon';
 import { PageResult } from '@core/common/classes/page-result';
 import { Attempt } from '@problems/models/attempts.models';
+import { ContestRegistrant } from '@contests/models';
 
 @Injectable({
   providedIn: 'root'
@@ -171,8 +172,8 @@ export class ContestsService {
     return this.api.get('problems/list');
   }
 
-  getContestRegistrants(contestId: number | string) {
-    return this.api.get(`contests/${contestId}/registrants`);
+  getContestRegistrants(contestId: number | string, params: Partial<Pageable> = {}) {
+    return this.api.get<PageResult<ContestRegistrant>>(`contests/${contestId}/registrants`, params);
   }
 
   getUserContestsRating(username: string) {

--- a/src/app/modules/contests/models/contest-registrant.ts
+++ b/src/app/modules/contests/models/contest-registrant.ts
@@ -3,4 +3,5 @@ export interface ContestRegistrant {
   rating: number;
   ratingTitle: string;
   team: any;
+  rowIndex?: number;
 }

--- a/src/app/modules/contests/pages/contest/contest-registrants/contest-registrants.component.html
+++ b/src/app/modules/contests/pages/contest/contest-registrants/contest-registrants.component.html
@@ -6,19 +6,39 @@
 
     <section class="mt-2">
       <div class="row">
-        <div  class="col-lg-9 col-12 order-2 order-lg-1">
+        <div  class="col-lg-9 col-12 order-2 order-lg-1 d-flex flex-column gap-2">
           <kep-card>
             <div class="card-header p-2">
               <contest-tab [contest]="contest"></contest-tab>
             </div>
           </kep-card>
 
-          @if (isLoading) {
-            <kep-card [cardHeight]="'300px'">
-              <spinner [height]="'300px'"/>
-            </kep-card>
-          } @else {
-            <kep-card>
+          <kep-card>
+            <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2 pb-0">
+              <table-ordering
+                (change)="orderingChange($event)"
+                [ordering]="ratingOrderingKey"
+                [value]="ordering"
+                [justifyContent]="'start'">
+                <span class="btn btn-sm" [ngClass]="isRatingOrderingActive() ? 'btn-primary' : 'btn-outline-primary'">
+                  {{ 'Rating' | translate }}
+                </span>
+              </table-ordering>
+
+              @if (!isLoading && total) {
+                <span class="text-muted small">{{ total }} {{ 'Users' | translate }}</span>
+              }
+            </div>
+
+            @if (isLoading) {
+              <div class="card-body d-flex justify-content-center py-5">
+                <spinner></spinner>
+              </div>
+            } @else if (!registrants.length) {
+              <div class="card-body text-center py-5">
+                <div class="text-muted">{{ 'NoResultFound' | translate }}</div>
+              </div>
+            } @else {
               <div class="table-responsive beautiful-table">
                 <table class="table">
                   <thead>
@@ -36,7 +56,7 @@
                   <tbody>
                     @for (registrant of registrants; track registrant.username) {
                       <tr>
-                        <td class="text-dark">{{ $index + 1 }}</td>
+                        <td class="text-dark">{{ registrant.rowIndex }}</td>
                         <td>
                           <contestant-view [team]="registrant.team" [user]="registrant"></contestant-view>
                         </td>
@@ -51,7 +71,21 @@
                   </tbody>
                 </table>
               </div>
-            </kep-card>
+            }
+          </kep-card>
+
+          @if (total) {
+            <kep-pagination
+              (pageChange)="pageChange($event)"
+              (pageSizeChange)="pageSizeChange($event)"
+              [collectionSize]="total"
+              [maxSize]="maxSize"
+              [page]="pageNumber"
+              [pageOptions]="pageOptions"
+              [pageSize]="pageSize"
+              [disabled]="isLoading"
+              [rotate]="true">
+            </kep-pagination>
           }
 
         </div>

--- a/src/app/modules/contests/pages/contest/contest-registrants/contest-registrants.component.ts
+++ b/src/app/modules/contests/pages/contest/contest-registrants/contest-registrants.component.ts
@@ -1,5 +1,4 @@
-import { ChangeDetectorRef, Component, inject, OnInit } from '@angular/core';
-import { BasePageComponent } from '@core/common/classes/base-page.component';
+import { Component, OnInit } from '@angular/core';
 import { ContentHeader } from "@shared/ui/components/content-header/content-header.component";
 import { ContestsService } from '@contests/contests.service';
 import { CoreCommonModule } from '@core/common.module';
@@ -10,6 +9,12 @@ import { ContestCardModule } from '@contests/components/contest-card/contest-car
 import { ContestRegistrant } from '@contests/models/contest-registrant';
 import { Contest } from '@contests/models/contest';
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
+import { Observable } from 'rxjs';
+import { PageResult } from '@core/common/classes/page-result';
+import { BaseTablePageComponent } from '@core/common/classes/base-table-page.component';
+import { KepPaginationComponent } from '@shared/components/kep-pagination/kep-pagination.component';
+import { TableOrderingModule } from '@shared/components/table-ordering/table-ordering.module';
+import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
 
 @Component({
   selector: 'app-contest-registrants',
@@ -23,32 +28,42 @@ import { KepCardComponent } from "@shared/components/kep-card/kep-card.component
     ContestantViewModule,
     ContestCardModule,
     KepCardComponent,
+    KepPaginationComponent,
+    TableOrderingModule,
+    SpinnerComponent,
   ]
 })
-export class ContestRegistrantsComponent extends BasePageComponent implements OnInit {
+export class ContestRegistrantsComponent extends BaseTablePageComponent<ContestRegistrant> implements OnInit {
+  override defaultPageSize = 20;
+  override pageOptions = [20, 50, 100];
+  override defaultOrdering = '-contests_rating';
+
   public contest: Contest;
-  public registrants: ContestRegistrant[] = [];
-  public isLoading = true;
-  protected cdr = inject(ChangeDetectorRef);
+  public readonly ratingOrderingKey = 'contests_rating';
 
   constructor(public service: ContestsService) {
     super();
   }
 
   ngOnInit() {
-    this.route.data.subscribe(
-      ({contest}) => {
-        this.contest = contest;
-        this.service.getContestRegistrants(this.contest.id).subscribe(
-          registrants => {
-            this.registrants = registrants;
-            this.isLoading = false;
-            this.cdr.detectChanges();
-          }
-        );
-      }
-    );
-    this.loadContentHeader();
+    this.route.data.subscribe(({contest}) => {
+      this.contest = contest;
+      this.loadContentHeader();
+      this.updatePageParams();
+      this.reloadPage();
+    });
+  }
+
+  get registrants(): ContestRegistrant[] {
+    return this.pageResult?.data || [];
+  }
+
+  isRatingOrderingActive(): boolean {
+    return this.ordering === this.ratingOrderingKey || this.ordering === `-${this.ratingOrderingKey}`;
+  }
+
+  getPage(): Observable<PageResult<ContestRegistrant>> {
+    return this.service.getContestRegistrants(this.contest.id, this.pageable);
   }
 
   protected getContentHeader(): ContentHeader {


### PR DESCRIPTION
## Summary
- update the contest registrants page to use the paginated API and expose ordering controls for contests_rating
- request paginated registrants data with ordering support from the contests service
- add table row indexing support for contest registrants records

## Testing
- npm run lint *(fails: ng command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ebfb2e1b20832f8bd8b12397fe18fa