### PR TITLE
Replace PrimeNG galleria in shop product card with custom carousel

### DIFF
--- a/src/app/modules/shop/components/product-item/product-item.component.html
+++ b/src/app/modules/shop/components/product-item/product-item.component.html
@@ -1,25 +1,50 @@
 <kep-card>
-  <a class="card-img">
-    <p-galleria
-      [(value)]="product.images"
-      [circular]="true"
-      [responsiveOptions]="responsiveOptions"
-      [showItemNavigatorsOnHover]="true"
-      [showItemNavigators]="true"
-      [showThumbnailNavigators]="false"
-      [numVisible]="5"
-    >
-      <ng-template pTemplate="item" let-item>
-        <img [src]="item.url" style="width: 100%;"/>
-      </ng-template>
-      <ng-template pTemplate="thumbnail" let-item>
-        <div class="grid grid-nogutter justify-content-center">
-          <img [height]="64" [src]="item.url"/>
+  <div class="card-img">
+    @if (product.images?.length) {
+      <div class="product-carousel">
+        <button
+          type="button"
+          class="carousel-control prev"
+          (click)="showPreviousImage()"
+          [disabled]="product.images.length === 1"
+          aria-label="Previous image"
+        >
+          ‹
+        </button>
+
+        <img
+          class="carousel-image"
+          [src]="product.images[activeImageIndex]?.url"
+          [alt]="product.title"
+        />
+
+        <button
+          type="button"
+          class="carousel-control next"
+          (click)="showNextImage()"
+          [disabled]="product.images.length === 1"
+          aria-label="Next image"
+        >
+          ›
+        </button>
+      </div>
+
+      @if (product.images.length > 1) {
+        <div class="product-thumbnails">
+          @for (image of product.images; let index = $index; track image.url) {
+            <button
+              type="button"
+              class="thumbnail"
+              [class.thumbnail-active]="index === activeImageIndex"
+              (click)="selectImage(index)"
+            >
+              <img [src]="image.url" [alt]="product.title" />
+            </button>
+          }
         </div>
-      </ng-template>
-    </p-galleria>
-    <!--    <img [src]="product.images[1]?.url" alt="{{ product.title }}" />-->
-  </a>
+      }
+    }
+  </div>
 
   <div class="card-header">
     <div class="card-title text-dark">

--- a/src/app/modules/shop/components/product-item/product-item.component.scss
+++ b/src/app/modules/shop/components/product-item/product-item.component.scss
@@ -10,6 +10,88 @@ product-item {
     border-bottom-right-radius: 0;
   }
 
+  .product-carousel {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: $white;
+    overflow: hidden;
+  }
+
+  .carousel-image {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    aspect-ratio: 1 / 1;
+    background: $light;
+  }
+
+  .carousel-control {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    border: none;
+    background: rgba($dark, 0.4);
+    color: $white;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 0.3s ease;
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: default;
+    }
+
+    &:not(:disabled):hover {
+      background: rgba($dark, 0.6);
+    }
+  }
+
+  .carousel-control.prev {
+    left: 0.5rem;
+  }
+
+  .carousel-control.next {
+    right: 0.5rem;
+  }
+
+  .product-thumbnails {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    padding: 0.75rem 0.5rem 0;
+    flex-wrap: wrap;
+  }
+
+  .thumbnail {
+    border: 2px solid transparent;
+    border-radius: 8px;
+    padding: 0;
+    background: transparent;
+    cursor: pointer;
+    transition: border-color 0.2s ease;
+
+    img {
+      width: 4rem;
+      height: 4rem;
+      object-fit: cover;
+      border-radius: 6px;
+    }
+
+    &.thumbnail-active,
+    &:hover {
+      border-color: $primary;
+    }
+  }
+
   .badge-color {
     display: inline-block !important;
     padding: 1rem;

--- a/src/app/modules/shop/components/product-item/product-item.component.ts
+++ b/src/app/modules/shop/components/product-item/product-item.component.ts
@@ -1,9 +1,8 @@
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { Product } from '@app/modules/shop/shop.interfaces';
 import { CoreCommonModule } from '@core/common.module';
 import { KepcoinViewModule } from '@shared/components/kepcoin-view/kepcoin-view.module';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { GalleriaModule } from 'primeng/galleria';
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
 
 @Component({
@@ -13,28 +12,51 @@ import { KepCardComponent } from "@shared/components/kep-card/kep-card.component
     CoreCommonModule,
     KepcoinViewModule,
     NgbModule,
-    GalleriaModule,
     KepCardComponent,
   ],
   templateUrl: './product-item.component.html',
   styleUrl: './product-item.component.scss',
   encapsulation: ViewEncapsulation.None,
 })
-export class ProductItemComponent {
+export class ProductItemComponent implements OnChanges {
   @Input() product: Product;
 
-  public responsiveOptions: any[] = [
-    {
-      breakpoint: '1024px',
-      numVisible: 4
-    },
-    {
-      breakpoint: '768px',
-      numVisible: 3
-    },
-    {
-      breakpoint: '560px',
-      numVisible: 2
+  public activeImageIndex = 0;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['product']) {
+      this.activeImageIndex = 0;
     }
-  ];
+  }
+
+  public showPreviousImage(): void {
+    if (!this.hasMultipleImages) {
+      return;
+    }
+
+    this.activeImageIndex =
+      (this.activeImageIndex - 1 + this.imagesLength) % this.imagesLength;
+  }
+
+  public showNextImage(): void {
+    if (!this.hasMultipleImages) {
+      return;
+    }
+
+    this.activeImageIndex = (this.activeImageIndex + 1) % this.imagesLength;
+  }
+
+  public selectImage(index: number): void {
+    if (index >= 0 && index < this.imagesLength) {
+      this.activeImageIndex = index;
+    }
+  }
+
+  private get hasMultipleImages(): boolean {
+    return this.imagesLength > 1;
+  }
+
+  private get imagesLength(): number {
+    return this.product?.images?.length ?? 0;
+  }
 }


### PR DESCRIPTION
## Summary
- remove the PrimeNG galleria from the shop product item card
- introduce a lightweight custom carousel with thumbnail selection and navigation controls
- style the new carousel and thumbnails to fit the existing card design

## Testing
- npm run lint *(fails: ng executable not available in environment)*
- npx ng lint *(fails: dependencies are not installed due to peer dependency conflicts when running npm install)*

------
https://chatgpt.com/codex/tasks/task_e_68ebfbc0dc28832fa02c02b0e88c8583