### PR TITLE
Replace shop product gallery with custom carousel

### DIFF
--- a/src/app/modules/shop/components/product-item/product-item.component.html
+++ b/src/app/modules/shop/components/product-item/product-item.component.html
@@ -26,23 +26,28 @@
           >
             <span aria-hidden="true">&#10095;</span>
           </button>
+          @if (visibleThumbnails.length) {
+            <div
+              class="product-carousel__thumbnails"
+              [class.product-carousel__thumbnails--stacked]="(product?.images?.length ?? 0) > 3"
+            >
+              @for (thumbnail of visibleThumbnails; track thumbnail.index) {
+                <button
+                  type="button"
+                  class="product-carousel__thumbnail"
+                  [class.product-carousel__thumbnail--active]="thumbnail.index === currentImageIndex"
+                  (click)="selectImage(thumbnail.index)"
+                  [attr.aria-label]="thumbnail.image.name || product.title"
+                >
+                  <img
+                    [src]="thumbnail.image.url"
+                    [alt]="thumbnail.image.name || product.title"
+                  />
+                </button>
+              }
+            </div>
+          }
         </div>
-
-        @if (hasMultipleImages()) {
-          <div class="product-carousel__thumbnails">
-            @for (image of product.images; track image.url; let index = $index) {
-              <button
-                type="button"
-                class="product-carousel__thumbnail"
-                [class.product-carousel__thumbnail--active]="index === currentImageIndex"
-                (click)="selectImage(index)"
-                [attr.aria-label]="image.name || product.title"
-              >
-                <img [src]="image.url" [alt]="image.name || product.title"/>
-              </button>
-            }
-          </div>
-        }
       </div>
     } @else {
       <div class="product-carousel__placeholder">

--- a/src/app/modules/shop/components/product-item/product-item.component.html
+++ b/src/app/modules/shop/components/product-item/product-item.component.html
@@ -1,25 +1,55 @@
 <kep-card>
-  <a class="card-img">
-    <p-galleria
-      [(value)]="product.images"
-      [circular]="true"
-      [responsiveOptions]="responsiveOptions"
-      [showItemNavigatorsOnHover]="true"
-      [showItemNavigators]="true"
-      [showThumbnailNavigators]="false"
-      [numVisible]="5"
-    >
-      <ng-template pTemplate="item" let-item>
-        <img [src]="item.url" style="width: 100%;"/>
-      </ng-template>
-      <ng-template pTemplate="thumbnail" let-item>
-        <div class="grid grid-nogutter justify-content-center">
-          <img [height]="64" [src]="item.url"/>
+  <div class="card-img">
+    @if (hasImages()) {
+      <div class="product-carousel">
+        <div class="product-carousel__viewport">
+          <button
+            type="button"
+            class="product-carousel__control product-carousel__control--prev"
+            (click)="showPreviousImage()"
+            [disabled]="!hasMultipleImages()"
+            aria-label="Previous image"
+          >
+            <span aria-hidden="true">&#10094;</span>
+          </button>
+          <img
+            class="product-carousel__image"
+            [src]="currentImageUrl"
+            [alt]="product.title"
+          />
+          <button
+            type="button"
+            class="product-carousel__control product-carousel__control--next"
+            (click)="showNextImage()"
+            [disabled]="!hasMultipleImages()"
+            aria-label="Next image"
+          >
+            <span aria-hidden="true">&#10095;</span>
+          </button>
         </div>
-      </ng-template>
-    </p-galleria>
-    <!--    <img [src]="product.images[1]?.url" alt="{{ product.title }}" />-->
-  </a>
+
+        @if (hasMultipleImages()) {
+          <div class="product-carousel__thumbnails">
+            @for (image of product.images; track image.url; let index = $index) {
+              <button
+                type="button"
+                class="product-carousel__thumbnail"
+                [class.product-carousel__thumbnail--active]="index === currentImageIndex"
+                (click)="selectImage(index)"
+                [attr.aria-label]="image.name || product.title"
+              >
+                <img [src]="image.url" [alt]="image.name || product.title"/>
+              </button>
+            }
+          </div>
+        }
+      </div>
+    } @else {
+      <div class="product-carousel__placeholder">
+        <span>No image available</span>
+      </div>
+    }
+  </div>
 
   <div class="card-header">
     <div class="card-title text-dark">

--- a/src/app/modules/shop/components/product-item/product-item.component.scss
+++ b/src/app/modules/shop/components/product-item/product-item.component.scss
@@ -10,6 +10,111 @@ product-item {
     border-bottom-right-radius: 0;
   }
 
+  .product-carousel {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    &__viewport {
+      position: relative;
+      overflow: hidden;
+      border-radius: 12px;
+      background: $body-bg;
+    }
+
+    &__image {
+      display: block;
+      width: 100%;
+      height: 260px;
+      object-fit: cover;
+    }
+
+    &__control {
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.5rem;
+      height: 2.5rem;
+      border: none;
+      border-radius: 50%;
+      background: rgba(0, 0, 0, 0.45);
+      color: $white;
+      cursor: pointer;
+      transition: background-color 0.2s ease;
+
+      &:disabled {
+        opacity: 0.4;
+        cursor: default;
+      }
+
+      &:not(:disabled):hover,
+      &:not(:disabled):focus {
+        background: rgba(0, 0, 0, 0.6);
+        outline: none;
+      }
+
+      &--prev {
+        left: 1rem;
+      }
+
+      &--next {
+        right: 1rem;
+      }
+    }
+
+    &__thumbnails {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+    }
+
+    &__thumbnail {
+      padding: 0;
+      border: 2px solid transparent;
+      border-radius: 10px;
+      background: transparent;
+      cursor: pointer;
+      overflow: hidden;
+      width: 64px;
+      height: 64px;
+      transition: border-color 0.2s ease, transform 0.2s ease;
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      &:hover,
+      &:focus {
+        border-color: $primary;
+        outline: none;
+        transform: scale(1.05);
+      }
+
+      &--active {
+        border-color: $primary;
+      }
+    }
+
+    &__placeholder {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 260px;
+      border-radius: 12px;
+      background: $body-bg;
+      color: $text-muted;
+      font-weight: 500;
+    }
+  }
+
   .badge-color {
     display: inline-block !important;
     padding: 1rem;

--- a/src/app/modules/shop/components/product-item/product-item.component.scss
+++ b/src/app/modules/shop/components/product-item/product-item.component.scss
@@ -23,7 +23,7 @@ product-item {
     &__image {
       display: block;
       width: 100%;
-      height: 260px;
+      height: 400px;
       object-fit: cover;
     }
 

--- a/src/app/modules/shop/components/product-item/product-item.component.scss
+++ b/src/app/modules/shop/components/product-item/product-item.component.scss
@@ -11,9 +11,7 @@ product-item {
   }
 
   .product-carousel {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
+    position: relative;
 
     &__viewport {
       position: relative;
@@ -44,6 +42,7 @@ product-item {
       color: $white;
       cursor: pointer;
       transition: background-color 0.2s ease;
+      z-index: 2;
 
       &:disabled {
         opacity: 0.4;
@@ -65,14 +64,6 @@ product-item {
       }
     }
 
-    &__thumbnails {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      flex-wrap: wrap;
-      gap: 0.75rem;
-    }
-
     &__thumbnail {
       padding: 0;
       border: 2px solid transparent;
@@ -80,9 +71,10 @@ product-item {
       background: transparent;
       cursor: pointer;
       overflow: hidden;
-      width: 64px;
-      height: 64px;
-      transition: border-color 0.2s ease, transform 0.2s ease;
+      width: 60px;
+      height: 60px;
+      transition: border-color 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
+      opacity: 0.55;
 
       img {
         width: 100%;
@@ -96,10 +88,33 @@ product-item {
         border-color: $primary;
         outline: none;
         transform: scale(1.05);
+        opacity: 0.85;
       }
 
       &--active {
         border-color: $primary;
+        opacity: 1;
+      }
+    }
+
+    &__thumbnails {
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.75rem;
+      padding: 0.75rem 1rem;
+      background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.55) 100%);
+      opacity: 0.95;
+      backdrop-filter: blur(4px);
+      z-index: 1;
+
+      &--stacked {
+        max-width: 220px;
+        margin: 0 auto;
       }
     }
 

--- a/src/app/modules/shop/components/product-item/product-item.component.ts
+++ b/src/app/modules/shop/components/product-item/product-item.component.ts
@@ -1,9 +1,8 @@
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { Product } from '@app/modules/shop/shop.interfaces';
 import { CoreCommonModule } from '@core/common.module';
 import { KepcoinViewModule } from '@shared/components/kepcoin-view/kepcoin-view.module';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-import { GalleriaModule } from 'primeng/galleria';
 import { KepCardComponent } from "@shared/components/kep-card/kep-card.component";
 
 @Component({
@@ -13,28 +12,68 @@ import { KepCardComponent } from "@shared/components/kep-card/kep-card.component
     CoreCommonModule,
     KepcoinViewModule,
     NgbModule,
-    GalleriaModule,
     KepCardComponent,
   ],
   templateUrl: './product-item.component.html',
   styleUrl: './product-item.component.scss',
   encapsulation: ViewEncapsulation.None,
 })
-export class ProductItemComponent {
+export class ProductItemComponent implements OnChanges {
   @Input() product: Product;
 
-  public responsiveOptions: any[] = [
-    {
-      breakpoint: '1024px',
-      numVisible: 4
-    },
-    {
-      breakpoint: '768px',
-      numVisible: 3
-    },
-    {
-      breakpoint: '560px',
-      numVisible: 2
+  public currentImageIndex = 0;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['product']) {
+      this.currentImageIndex = 0;
     }
-  ];
+  }
+
+  public showPreviousImage(): void {
+    const images = this.product?.images ?? [];
+
+    if (images.length <= 1) {
+      return;
+    }
+
+    this.currentImageIndex = (this.currentImageIndex - 1 + images.length) % images.length;
+  }
+
+  public showNextImage(): void {
+    const images = this.product?.images ?? [];
+
+    if (images.length <= 1) {
+      return;
+    }
+
+    this.currentImageIndex = (this.currentImageIndex + 1) % images.length;
+  }
+
+  public selectImage(index: number): void {
+    const images = this.product?.images ?? [];
+
+    if (!images.length || index === this.currentImageIndex) {
+      return;
+    }
+
+    this.currentImageIndex = Math.max(0, Math.min(index, images.length - 1));
+  }
+
+  public hasImages(): boolean {
+    return !!this.product?.images?.length;
+  }
+
+  public hasMultipleImages(): boolean {
+    return (this.product?.images?.length ?? 0) > 1;
+  }
+
+  public get currentImageUrl(): string | undefined {
+    const images = this.product?.images ?? [];
+
+    if (!images.length) {
+      return undefined;
+    }
+
+    return images[this.currentImageIndex]?.url;
+  }
 }

--- a/src/app/modules/shop/components/product-item/product-item.component.ts
+++ b/src/app/modules/shop/components/product-item/product-item.component.ts
@@ -29,8 +29,12 @@ export class ProductItemComponent implements OnChanges {
     }
   }
 
+  private get images(): Product['images'] {
+    return this.product?.images ?? [];
+  }
+
   public showPreviousImage(): void {
-    const images = this.product?.images ?? [];
+    const images = this.images;
 
     if (images.length <= 1) {
       return;
@@ -40,7 +44,7 @@ export class ProductItemComponent implements OnChanges {
   }
 
   public showNextImage(): void {
-    const images = this.product?.images ?? [];
+    const images = this.images;
 
     if (images.length <= 1) {
       return;
@@ -50,7 +54,7 @@ export class ProductItemComponent implements OnChanges {
   }
 
   public selectImage(index: number): void {
-    const images = this.product?.images ?? [];
+    const images = this.images;
 
     if (!images.length || index === this.currentImageIndex) {
       return;
@@ -60,20 +64,41 @@ export class ProductItemComponent implements OnChanges {
   }
 
   public hasImages(): boolean {
-    return !!this.product?.images?.length;
+    return !!this.images.length;
   }
 
   public hasMultipleImages(): boolean {
-    return (this.product?.images?.length ?? 0) > 1;
+    return this.images.length > 1;
   }
 
   public get currentImageUrl(): string | undefined {
-    const images = this.product?.images ?? [];
+    const images = this.images;
 
     if (!images.length) {
       return undefined;
     }
 
     return images[this.currentImageIndex]?.url;
+  }
+
+  public get visibleThumbnails(): Array<{ index: number; image: Product['images'][number] }> {
+    const images = this.images;
+
+    if (images.length <= 1) {
+      return [];
+    }
+
+    if (images.length <= 3) {
+      return images.map((image, index) => ({ index, image }));
+    }
+
+    const total = images.length;
+    const orderedIndexes = [
+      (this.currentImageIndex - 1 + total) % total,
+      this.currentImageIndex,
+      (this.currentImageIndex + 1) % total,
+    ];
+
+    return orderedIndexes.map((index) => ({ index, image: images[index] }));
   }
 }


### PR DESCRIPTION
## Summary
- replace the PrimeNG galleria on shop products with a bespoke image carousel
- add navigation, thumbnail selection, and placeholder handling for missing images
- style the new carousel controls and thumbnails to match the card layout

## Testing
- npm run lint *(fails: ng not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ebfbc0dc28832fa02c02b0e88c8583