### PR TITLE
Add manual change detection updates for challenges module

### DIFF
--- a/src/app/modules/challenges/pages/challenge/challenge.component.ts
+++ b/src/app/modules/challenges/pages/challenge/challenge.component.ts
@@ -72,6 +72,7 @@ export class ChallengeComponent extends BaseComponent implements OnInit, OnDestr
               playerSecondUsername: challenge.playerSecond.username,
             });
             this.updateStatus(true);
+            this.cdr.detectChanges();
           }
         );
       }
@@ -98,11 +99,13 @@ export class ChallengeComponent extends BaseComponent implements OnInit, OnDestr
       this.challenge.status = ChallengeStatus.Already;
       this.updateQuestion();
     }
+    this.cdr.detectChanges();
   }
 
   updateQuestion() {
     this.challenge.nextQuestion.question.number = this.challenge.nextQuestion.number;
     this.question = this.challenge.nextQuestion.question;
+    this.cdr.detectChanges();
   }
 
   startSweet() {
@@ -134,6 +137,7 @@ export class ChallengeComponent extends BaseComponent implements OnInit, OnDestr
     this.service.challengeStart(this.challenge.id).subscribe(
       () => {
         this.challengeUpdate().subscribe();
+        this.cdr.detectChanges();
       }
     );
   }
@@ -143,6 +147,7 @@ export class ChallengeComponent extends BaseComponent implements OnInit, OnDestr
       tap((challenge: Challenge) => {
         this.challenge = Challenge.fromJSON(challenge);
         this.updateStatus();
+        this.cdr.detectChanges();
       })
     );
   }
@@ -176,8 +181,10 @@ export class ChallengeComponent extends BaseComponent implements OnInit, OnDestr
               } else {
                 this.counter.start();
               }
+              this.cdr.detectChanges();
             }
           );
+          this.cdr.detectChanges();
         });
       }
     );
@@ -205,8 +212,10 @@ export class ChallengeComponent extends BaseComponent implements OnInit, OnDestr
             } else {
               this.counter.start();
             }
+            this.cdr.detectChanges();
           }
         );
+        this.cdr.detectChanges();
       });
     }
   }

--- a/src/app/modules/challenges/pages/challenges/sections/section-in-queue/section-in-queue.component.ts
+++ b/src/app/modules/challenges/pages/challenges/sections/section-in-queue/section-in-queue.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 
 import { ChallengeCallCardComponent } from '@challenges/components/challenge-call-card/challenge-call-card.component';
 import { NgxSkeletonLoaderModule } from 'ngx-skeleton-loader';
@@ -23,7 +23,7 @@ export class SectionInQueueComponent extends BaseUserComponent implements OnInit
   public challengeCalls: Array<ChallengeCall> = [];
   public challengeCallsSkeletonVisible = true;
 
-  constructor(public service: ChallengesApiService) {
+  constructor(public service: ChallengesApiService, private cdr: ChangeDetectorRef) {
     super();
   }
 
@@ -48,6 +48,7 @@ export class SectionInQueueComponent extends BaseUserComponent implements OnInit
           }
         }
         this.challengeCallsSkeletonVisible = false;
+        this.cdr.detectChanges();
       }
     );
   }
@@ -58,6 +59,7 @@ export class SectionInQueueComponent extends BaseUserComponent implements OnInit
         this.challengeCalls.splice(i, 1);
       }
     }
+    this.cdr.detectChanges();
   }
 
 }

--- a/src/app/modules/challenges/pages/challenges/sections/section-quickstart/section-quickstart.component.ts
+++ b/src/app/modules/challenges/pages/challenges/sections/section-quickstart/section-quickstart.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import { ChangeDetectorRef, Component, EventEmitter, OnInit, Output } from '@angular/core';
 import {
   NewChallengeButtonComponent
 } from '@challenges/components/new-challenge-button/new-challenge-button.component';
@@ -67,7 +67,11 @@ export class SectionQuickstartComponent extends BaseUserComponent implements OnI
     selectedChapters: [],
   };
 
-  constructor(public service: ChallengesApiService, public router: Router) {
+  constructor(
+    public service: ChallengesApiService,
+    public router: Router,
+    private cdr: ChangeDetectorRef,
+  ) {
     super();
   }
 
@@ -75,6 +79,7 @@ export class SectionQuickstartComponent extends BaseUserComponent implements OnI
     this.service.getChapters().subscribe(
       (chapters: Array<Chapter>) => {
         this.chapters = chapters;
+        this.cdr.detectChanges();
       }
     );
   }
@@ -92,6 +97,7 @@ export class SectionQuickstartComponent extends BaseUserComponent implements OnI
     ).subscribe(
       () => {
         this.newChallengeClick.emit(null);
+        this.cdr.detectChanges();
       }
     );
   }
@@ -108,11 +114,13 @@ export class SectionQuickstartComponent extends BaseUserComponent implements OnI
           if (challengeCall.timeSeconds === quickStart.timeSeconds && challengeCall.questionsCount === quickStart.questionsCount) {
             if (challengeCall.username !== this.currentUser.username) {
               this.acceptChallengeCall(challengeCall.id);
+              this.cdr.detectChanges();
               return;
             }
           }
         }
         this.newChallenge(quickStart);
+        this.cdr.detectChanges();
       }
     );
   }
@@ -128,6 +136,7 @@ export class SectionQuickstartComponent extends BaseUserComponent implements OnI
         if (result.success) {
           const challengeId = result.challengeId;
           this.router.navigateByUrl(getResourceById(Resources.Challenge, challengeId));
+          this.cdr.detectChanges();
         }
       }
     );


### PR DESCRIPTION
## Summary
- add manual change detection invocations to challenges quickstart and queue sections
- trigger view refreshes after async updates in the challenge detail component

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ebfd0c2f00832f90107700a2656e03