### PR TITLE
feat: redesign problem detail layout

### DIFF
--- a/src/@core/layouts/problem-layout/problem-layout.component.html
+++ b/src/@core/layouts/problem-layout/problem-layout.component.html
@@ -1,0 +1,6 @@
+<div class="page vertical-layout problem-layout">
+  <app-header class="problem-layout__header"></app-header>
+  <div class="problem-layout__body">
+    <router-outlet></router-outlet>
+  </div>
+</div>

--- a/src/@core/layouts/problem-layout/problem-layout.component.scss
+++ b/src/@core/layouts/problem-layout/problem-layout.component.scss
@@ -1,0 +1,20 @@
+.problem-layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--bs-body-bg, #f5f5f5);
+
+  &__header {
+    flex: 0 0 auto;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  &__body {
+    flex: 1 1 auto;
+    overflow: hidden;
+    background-color: inherit;
+    display: flex;
+  }
+}

--- a/src/@core/layouts/problem-layout/problem-layout.component.ts
+++ b/src/@core/layouts/problem-layout/problem-layout.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { HeaderComponent } from '@core/layouts/components/header/header.component';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-problem-layout',
+  standalone: true,
+  templateUrl: './problem-layout.component.html',
+  styleUrl: './problem-layout.component.scss',
+  imports: [
+    HeaderComponent,
+    RouterOutlet,
+  ],
+})
+export class ProblemLayoutComponent {}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,9 +2,45 @@ import { Routes } from '@angular/router';
 import { ContentLayoutComponent } from '@core/layouts/content-layout/content-layout.component';
 import { AuthenticationLayoutComponent } from '@core/layouts/authentication-layout/authentication-layout.component';
 import { LandingLayoutComponent } from "@core/layouts/landing-layout/landing-layout.component";
+import { ProblemLayoutComponent } from '@core/layouts/problem-layout/problem-layout.component';
 import { IsAuthenticatedGuard } from '@auth';
+import { ProblemResolver } from '@problems/problems.resolver';
+import { ProblemGuard } from '@problems/problems.guard';
 
 export const routes: Routes = [
+  {
+    path: 'practice/problems/problem/:id',
+    component: ProblemLayoutComponent,
+    children: [
+      {
+        path: '',
+        loadComponent: () => import('./modules/problems/pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: { title: 'Problems.Problem', defaultTab: 'problem' },
+        resolve: {
+          problem: ProblemResolver,
+        },
+        canActivate: [ProblemGuard],
+      },
+      {
+        path: 'attempts',
+        loadComponent: () => import('./modules/problems/pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: { title: 'Problems.Problem', defaultTab: 'attempts' },
+        resolve: {
+          problem: ProblemResolver,
+        },
+        canActivate: [ProblemGuard],
+      },
+      {
+        path: 'hacks',
+        loadComponent: () => import('./modules/problems/pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: { title: 'Problems.Problem', defaultTab: 'hacks' },
+        resolve: {
+          problem: ProblemResolver,
+        },
+        canActivate: [ProblemGuard],
+      },
+    ]
+  },
   {
     path: '',
     component: LandingLayoutComponent,

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -1,177 +1,158 @@
-<div class="content-wrapper container-xxl p-0">
-  <div class="content-body">
-    <app-content-header [contentHeader]="contentHeader">
-      <div class="btn-group" role="group">
-        <button
-          class="btn btn-primary-light btn-wave"
-          type="button"
-          (click)="goToPreviousProblem()"
-          ngbTooltip="{{ 'PreviousProblem' | translate }}"
-        >
-          <kep-icon name="left"/>
-        </button>
-        <button
-          class="btn btn-primary-light btn-wave"
-          type="button"
-          (click)="goToNextProblem()"
-          ngbTooltip="{{ 'NextProblem' | translate }}"
-        >
-          <kep-icon name="right"/>
-        </button>
+<div class="problem-page" *ngIf="problem">
+  <div class="problem-page__left">
+    <div class="problem-page__left-inner">
+      <div class="problem-page__heading">
+        <div class="problem-page__heading-info">
+          <div class="problem-page__breadcrumbs">
+            <a routerLink="/practice/problems">{{ 'Problems' | translate }}</a>
+            <span class="problem-page__breadcrumbs-separator">/</span>
+            <span>{{ problem.id }}</span>
+          </div>
+          <h1 class="problem-page__title">{{ problem.title }}</h1>
+        </div>
+        <div class="problem-page__controls">
+          <button
+            class="problem-page__control-btn btn btn-icon btn-light"
+            type="button"
+            ngbTooltip="{{ 'PreviousProblem' | translate }}"
+            (click)="goToPreviousProblem()"
+          >
+            <kep-icon name="left"></kep-icon>
+          </button>
+          <button
+            class="problem-page__control-btn btn btn-icon btn-light"
+            type="button"
+            ngbTooltip="{{ 'NextProblem' | translate }}"
+            (click)="goToNextProblem()"
+          >
+            <kep-icon name="right"></kep-icon>
+          </button>
+        </div>
       </div>
-    </app-content-header>
-    <section  class="mt-2">
-      <div class="row">
-        <div class="col-lg-9 col-md-12 col-sm-12">
-          <kep-card>
-            <div class="card-header">
-              <ul
-                #navWithIcons="ngbNav"
-                (activeIdChange)="activeIdChange($event)" [(activeId)]="activeId" [destroyOnHide]="false"
-                class="nav-tabs" ngbNav>
-                <li [ngbNavItem]="1">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
-                    {{ 'Problem' | translate }}
-                  </a>
-                  <ng-template ngbNavContent>
-                    <problem-description [problem]="problem"></problem-description>
-                  </ng-template>
-                </li>
 
-                <li [ngbNavItem]="2">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
-                    {{ 'Attempts' | translate }}
-                  </a>
-                  <ng-template ngbNavContent>
-                    <problem-attempts
-                      (hackSubmitted)="activeId = 3;"
-                      [problem]="problem"
-                      [submitEvent]="submitEvent?.asObservable()"
-                    >
-                    </problem-attempts>
-                  </ng-template>
-                </li>
-
-                @if (problem.hasCheckInput) {
-                  <li [ngbNavItem]="3" destroyOnHide="true">
-                    <a class="nav-link" ngbNavLink>
-                      <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
-                      {{ 'Hacks' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-hacks [problem]="problem"></problem-hacks>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (studyPlanId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
-                      <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (contestId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.ContestProblems | resourceById:contestId">
-                      <kep-icon name="contest" color="primary" type="duotone"/>
-                      {{ 'Contest' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-              </ul>
-
-              @if (isAuthenticated) {
-                <button (click)="codeEditorSidebarToggle()" class="btn btn-sm btn-primary">{{ 'Submit' | translate }}
-                </button>
-              }
-            </div>
-
-            <div class="card-footer">
-              <div [ngbNavOutlet]="navWithIcons"></div>
-            </div>
-          </kep-card>
-
-          @if (currentUser?.permissions.canCreateProblems) {
-            <div class="card">
-              <div class="card-header">
-                <div class="card-title">
-                  Check input
-                </div>
-              </div>
-              <div class="card-body">
-                <monaco-editor
-                  [lang]="'py'"
-                  class="mt-1"
-                  [ngModelOptions]="{standalone: true}"
-                  [(ngModel)]="checkInput"
-                ></monaco-editor>
-                <div class="btn mt-2 btn-primary btn-sm" (click)="saveCheckInput()">Save</div>
-              </div>
-            </div>
-          }
+      <div class="problem-page__scroll">
+        <div class="problem-page__tabs">
+          <ul
+            #navWithIcons="ngbNav"
+            ngbNav
+            class="nav nav-tabs problem-page__tablist"
+            [destroyOnHide]="false"
+            [(activeId)]="activeId"
+            (activeIdChange)="activeIdChange($event)"
+          >
+            <li [ngbNavItem]="1">
+              <a ngbNavLink class="problem-page__tab-link">
+                <kep-icon size="small-4" color="primary" name="problem" type="duotone"></kep-icon>
+                {{ 'Problem' | translate }}
+              </a>
+              <ng-template ngbNavContent>
+                <problem-description [problem]="problem"></problem-description>
+              </ng-template>
+            </li>
+            <li [ngbNavItem]="2">
+              <a ngbNavLink class="problem-page__tab-link">
+                <kep-icon size="small-4" color="warning" name="attempt" type="duotone"></kep-icon>
+                {{ 'Attempts' | translate }}
+              </a>
+              <ng-template ngbNavContent>
+                <problem-attempts
+                  [problem]="problem"
+                  [submitEvent]="submitEvent?.asObservable()"
+                  (hackSubmitted)="activeId = 3; navigateToTab('hacks')"
+                ></problem-attempts>
+              </ng-template>
+            </li>
+            @if (problem.hasCheckInput) {
+              <li [ngbNavItem]="3" destroyOnHide="true">
+                <a ngbNavLink class="problem-page__tab-link">
+                  <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"></kep-icon>
+                  {{ 'Hacks' | translate }}
+                </a>
+                <ng-template ngbNavContent>
+                  <problem-hacks [problem]="problem"></problem-hacks>
+                </ng-template>
+              </li>
+            }
+            @if (studyPlanId) {
+              <li [ngbNavItem]="4">
+                <a
+                  ngbNavLink
+                  class="problem-page__tab-link"
+                  [routerLink]="Resources.StudyPlan | resourceById:studyPlanId"
+                >
+                  <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
+                </a>
+              </li>
+            }
+            @if (contestId) {
+              <li [ngbNavItem]="5">
+                <a
+                  ngbNavLink
+                  class="problem-page__tab-link"
+                  [routerLink]="Resources.ContestProblems | resourceById:contestId"
+                >
+                  <kep-icon name="contest" color="primary" type="duotone"></kep-icon>
+                  {{ 'Contest' | translate }}
+                </a>
+              </li>
+            }
+          </ul>
         </div>
 
-        <div class="col-lg-3 col-md-12 col-sm-12">
+        <div class="problem-page__content" [ngbNavOutlet]="navWithIcons"></div>
+
+        <div class="problem-page__sidebar">
           <problem-sidebar [problem]="problem"></problem-sidebar>
-
-          @if (isAuthenticated) {
-            <problem-submit-card
-              [availableLanguages]="problem.availableLanguages"
-              [submitUrl]="'problems/' + problem.id + '/submit/'"
-              (submitted)="onSubmit()"
-            />
-          }
         </div>
 
+        @if (currentUser?.permissions.canCreateProblems) {
+          <div class="problem-page__check-input card">
+            <div class="card-header">
+              <div class="card-title">Check input</div>
+            </div>
+            <div class="card-body">
+              <monaco-editor
+                [lang]="'py'"
+                class="mt-1"
+                [ngModelOptions]="{ standalone: true }"
+                [(ngModel)]="checkInput"
+              ></monaco-editor>
+              <button class="btn btn-primary btn-sm mt-2" (click)="saveCheckInput()">Save</button>
+            </div>
+          </div>
+        }
       </div>
+    </div>
+  </div>
 
-      @if (problem && isAuthenticated) {
+  <div class="problem-page__right">
+    @if (problem && isAuthenticated) {
+      <div class="problem-page__editor">
         <code-editor-modal
           [customClass]="'tour-step-2'"
+          [displayMode]="'docked'"
           [uniqueName]="'problem-' + problem.id"
           [sampleTests]="problem.sampleTests"
           [submitUrl]="'problems/' + problem.id + '/submit/'"
           [problem]="problem"
           [answerForInputEnabled]="problem.hasSolution && problem.hasCheckInput"
           [availableLanguages]="problem.availableLanguages"
-          (submittedEvent)="onSubmit()"></code-editor-modal>
-      }
-    </section>
+          (submittedEvent)="onSubmit()"
+        ></code-editor-modal>
+      </div>
+    }
+
+    @if (isAuthenticated) {
+      <div class="problem-page__file-submit">
+        <problem-submit-card
+          [availableLanguages]="problem.availableLanguages"
+          [submitUrl]="'problems/' + problem.id + '/submit/'"
+          (submitted)="onSubmit()"
+        ></problem-submit-card>
+      </div>
+    }
   </div>
 </div>
 
 <tour-css></tour-css>
 <ng-select-css></ng-select-css>
-
-<!--<div class="col-lg-6 col-md-12 col-sm-12">-->
-<!--  <kep-card>-->
-<!--    <div class="card-header p-2">-->
-<!--      <div class="card-title">-->
-<!--        <kep-icon name="square-brackets" color="primary" type="duotone"/>-->
-<!--        {{ 'Code' | translate }}-->
-<!--      </div>-->
-<!--    </div>-->
-
-<!--    <ng-select-->
-<!--      [appendTo]="'body'"-->
-<!--      [clearable]="false">-->
-<!--      @for (availableLanguage of problem.availableLanguages; track availableLanguage) {-->
-<!--        <ng-option-->
-<!--          [value]="availableLanguage.lang">-->
-<!--          {{ availableLanguage.langFull || availableLanguage.lang }}-->
-<!--        </ng-option>-->
-<!--      }-->
-<!--    </ng-select>-->
-<!--    <monaco-editor lang="py"/>-->
-<!--  </kep-card>-->
-<!--</div>-->

--- a/src/app/modules/problems/pages/problem/problem.component.scss
+++ b/src/app/modules/problems/pages/problem/problem.component.scss
@@ -1,19 +1,201 @@
-.card .card-header {
-  padding: 1rem !important;
-  padding-bottom: 0 !important;
-  align-items: center;
-}
-
-.problem-container {
+:host {
+  display: block;
   height: 100%;
 }
 
-/* Стили для блока с кодом */
-pre {
-  background-color: #f8f9fa;
-  padding: 1rem;
-  border-radius: 0.3rem;
+.problem-page {
+  display: flex;
+  gap: 1.5rem;
+  height: 100%;
+  padding: 1.5rem;
+  box-sizing: border-box;
+  background-color: var(--bs-body-bg, #f5f5f5);
+
+  @media (max-width: 992px) {
+    flex-direction: column;
+    height: auto;
+    min-height: 100%;
+    padding: 1rem;
+  }
+}
+
+.problem-page__left,
+.problem-page__right {
+  background-color: var(--bs-card-bg, #ffffff);
+  border-radius: 1rem;
+  box-shadow: 0 0.25rem 1rem rgba(15, 23, 42, 0.08);
+}
+
+.problem-page__left {
+  flex: 0 0 55%;
+  min-width: 0;
+  display: flex;
+
+  @media (max-width: 1200px) {
+    flex-basis: 60%;
+  }
+
+  @media (max-width: 992px) {
+    flex-basis: auto;
+  }
+}
+
+.problem-page__left-inner {
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  width: 100%;
+  min-height: 0;
+
+  @media (max-width: 992px) {
+    padding: 1rem;
+  }
+}
+
+.problem-page__heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+
+  @media (max-width: 576px) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+}
+
+.problem-page__heading-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.problem-page__breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--bs-secondary-color, #6c757d);
+}
+
+.problem-page__breadcrumbs a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.problem-page__title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--bs-body-color, #0f172a);
+}
+
+.problem-page__controls {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.problem-page__control-btn {
+  width: 38px;
+  height: 38px;
+  border-radius: 0.75rem;
+  box-shadow: 0 0.25rem 0.75rem rgba(15, 23, 42, 0.08);
+}
+
+.problem-page__scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding-right: 0.75rem;
+
+  @media (max-width: 992px) {
+    padding-right: 0;
+  }
+}
+
+.problem-page__tablist {
+  display: inline-flex;
+  flex-wrap: nowrap;
+  gap: 0.75rem;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  padding-bottom: 0.75rem;
+  margin: 0;
   overflow-x: auto;
 }
 
-/* Дополнительные стили можно добавить по необходимости */
+.problem-page__tablist .nav-link {
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background-color: transparent;
+  color: var(--bs-secondary-color, #6c757d);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.problem-page__tablist .nav-link.active,
+.problem-page__tablist .nav-link:hover {
+  background-color: rgba(31, 41, 55, 0.1);
+  color: var(--bs-body-color, #0f172a);
+}
+
+.problem-page__content {
+  flex: 0 0 auto;
+}
+
+.problem-page__sidebar {
+  flex: 0 0 auto;
+}
+
+.problem-page__check-input {
+  flex: 0 0 auto;
+}
+
+.problem-page__right {
+  flex: 1 1 45%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem;
+  gap: 1.5rem;
+  min-height: 0;
+
+  @media (max-width: 992px) {
+    padding: 1rem;
+  }
+}
+
+.problem-page__editor {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+}
+
+.problem-page__editor code-editor-modal {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+}
+
+.problem-page__file-submit {
+  flex: 0 0 auto;
+}
+
+.dark-layout .problem-page__left,
+.dark-layout .problem-page__right {
+  background-color: color-mix(in srgb, #0f172a 90%, var(--bs-body-bg, #0f172a) 10%);
+  box-shadow: none;
+}
+
+.dark-layout .problem-page__tablist .nav-link.active,
+.dark-layout .problem-page__tablist .nav-link:hover {
+  background-color: rgba(148, 163, 184, 0.2);
+  color: #e2e8f0;
+}

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -17,9 +17,6 @@ import { TourModule } from '@shared/third-part-modules/tour/tour.module';
 import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
 import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
 import { BasePageComponent } from '@core/common/classes/base-page.component';
-import { SidebarService } from '@shared/ui/sidebar/sidebar.service';
-import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
-import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 
 import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
 import { take } from 'rxjs/operators';
@@ -32,7 +29,6 @@ import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
   standalone: true,
   imports: [
     CoreCommonModule,
-    ContentHeaderModule,
     NgbNavModule,
     ProblemDescriptionComponent,
     ProblemAttemptsComponent,
@@ -43,7 +39,6 @@ import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
     TourModule,
     NgSelectModule,
     MonacoEditorComponent,
-    KepCardComponent,
 
     ProblemSubmitCardComponent,
     NgbTooltipModule,
@@ -59,28 +54,32 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
 
   public submitEvent = new Subject();
   public checkInput = '';
+
+  private readonly _tabSegments: Record<number, string> = {
+    1: '',
+    2: 'attempts',
+    3: 'hacks',
+  };
+
   constructor(
     public service: ProblemsApiService,
     public api: ApiService,
-    protected coreSidebarService: SidebarService,
   ) {
     super();
   }
 
   ngOnInit(): void {
-    if (this._queryParams.tab === 'hacks') {
-      this.activeId = 3;
-    } else if (this._queryParams.tab === 'attempts') {
-      this.activeId = 2;
-    }
+    const initialTab = this.getTabId(this._queryParams?.tab as string ?? this.route.snapshot.data['defaultTab']);
+    this.activeId = initialTab;
 
-    this.route.data.subscribe(({ problem }) => {
+    this.route.data.subscribe(({ problem, defaultTab }) => {
       this.problem = problem;
       this.titleService.updateTitle(this.route, {
         problemTitle: this.problem.title,
         problemId: this.problem.id
       });
       this.checkInput = this.problem.checkInputSource;
+      this.activeId = this.getTabId(this._queryParams?.tab as string ?? defaultTab);
       this.loadContentHeader();
     });
   }
@@ -117,12 +116,10 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
   }
 
   activeIdChange(index: number) {
-    if (index === 1) {
-      this.updateQueryParams({ tab: null });
-    } else if (index === 2) {
-      this.updateQueryParams({ tab: 'attempts' });
-    } else if (index === 3) {
-      this.updateQueryParams({ tab: 'hacks' });
+    this.activeId = index;
+    const segment = this._tabSegments[index];
+    if (segment !== undefined) {
+      this.navigateToTab(segment);
     }
   }
 
@@ -136,13 +133,9 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     );
   }
 
-  codeEditorSidebarToggle() {
-    this.coreSidebarService.getSidebarRegistry('codeEditorSidebar').toggleOpen();
-  }
-
   onSubmit() {
-    console.log(4142);
     this.activeId = 2;
+    this.navigateToTab(this._tabSegments[2]);
     this.submitEvent.next(null);
   }
 
@@ -170,8 +163,44 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     if (!problemId || this.problem?.id === problemId) {
       return;
     }
-    this.router.navigate(['/practice/problems/problem', problemId], {
-      queryParams: this.route.snapshot.queryParams,
+    const segment = this._tabSegments[this.activeId];
+    const commands = ['/practice/problems/problem', problemId];
+    if (segment) {
+      commands.push(segment);
+    }
+    const queryParams = { ...this.route.snapshot.queryParams };
+    delete queryParams['tab'];
+    this.router.navigate(commands, {
+      queryParams,
     });
+  }
+
+  navigateToTab(segment?: string) {
+    if (!this.problem) {
+      return;
+    }
+    const commands = ['/practice/problems/problem', this.problem.id];
+    if (segment) {
+      commands.push(segment);
+    }
+    const queryParams = { ...this.route.snapshot.queryParams };
+    delete queryParams['tab'];
+    this.router.navigate(commands, {
+      queryParams,
+    });
+  }
+
+  private getTabId(tabKey?: string | null): number {
+    if (!tabKey) {
+      return 1;
+    }
+    const normalized = tabKey.toLowerCase();
+    if (normalized === 'attempts') {
+      return 2;
+    }
+    if (normalized === 'hacks') {
+      return 3;
+    }
+    return 1;
   }
 }

--- a/src/app/modules/problems/problems.routing.ts
+++ b/src/app/modules/problems/problems.routing.ts
@@ -20,39 +20,6 @@ export default [
   //     studyPlan: StudyPlanResolver,
   //   }
   // },
-  {
-    path: 'problem/:id',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/attempts',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/hacks',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
-  },
   // {
   //   path: 'problem/:id/og-image',
   //   loadComponent: () => import('./pages/problem/problem-og-image/problem-og-image.component').then(c => c.ProblemOgImageComponent),

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.html
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.html
@@ -1,214 +1,220 @@
-<sidebar [hideOnEsc]="true" [name]="sidebarName" class="code-editor-sidebar">
-  <a
-    (click)="toggleSidebar()"
-    class="btn-toggle d-flex align-items-center justify-content-center">
-    <i [data-feather]="'terminal'"></i>
-  </a>
+<ng-template #editorCard>
+  <kep-card (keydown)="onKeyDown($event)" customClass="full-height position-relative">
+    <div class="card-header">
+      <div class="card-title">
+        {{ 'CodeEditor.Editor' | translate }}
+      </div>
 
-  <ng-scrollbar>
-    <kep-card (keydown)="onKeyDown($event)" customClass="full-height position-relative">
-      <div class="card-header">
-        <div class="card-title">
-          {{ 'CodeEditor.Editor' | translate }}
-        </div>
-
+      @if (displayMode !== 'docked') {
         <div class="d-flex justify-content-between">
           <button (click)="toggleSidebar()" aria-label="Close" class="btn-close" type="button"></button>
         </div>
-      </div>
-      <hr class="mt-0 mb-50">
-      <div [formGroup]="editorForm" class="card-body">
-        <div class="row">
-          <div class="col-lg-8 col-md-7 col-12">
-            <div
-              [ngbTooltip]="editorForm.controls.code.errors | errorMessage"
-              [style.height.%]="100"
-              container="body"
-              tooltipClass="tooltip-danger"
+      }
+    </div>
+    <hr class="mt-0 mb-50">
+    <div [formGroup]="editorForm" class="card-body">
+      <div class="row">
+        <div class="col-lg-8 col-md-7 col-12">
+          <div
+            [ngbTooltip]="editorForm.controls.code.errors | errorMessage"
+            [style.height.%]="100"
+            container="body"
+            tooltipClass="tooltip-danger"
+          >
+            <monaco-editor
+              [formControl]="editorForm.controls.code"
+              [height]="displayMode === 'docked' ? '100%' : 480"
+              [lang]="editorForm.controls.lang.value"
+            ></monaco-editor>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-5 d-none d-md-block">
+          <div class="mb-1">
+            <label class="fw-medium">{{ 'Language' | translate }}: </label>
+            <ng-select
+              (change)="langChange($event)"
+              [clearable]="false"
+              [formControl]="editorForm.controls.lang"
             >
-              <monaco-editor
-                [formControl]="editorForm.controls.code"
-                [height]="480"
-                [lang]="editorForm.controls.lang.value">
-              </monaco-editor>
-            </div>
+              @for (availableLanguage of availableLanguages; track availableLanguage) {
+                <ng-option [value]="availableLanguage.lang">
+                  {{ availableLanguage.langFull || availableLanguage.lang }}
+                </ng-option>
+              }
+            </ng-select>
           </div>
 
-          <div class="col-lg-4 col-md-5 d-none d-md-block">
+          @if (sampleTests.length > 0) {
             <div class="mb-1">
-              <label class="fw-medium">{{ 'Language' | translate }}: </label>
+              <label class="fw-medium">{{ 'CodeEditor.SampleTest' | translate }}: </label>
               <ng-select
-                (change)="langChange($event)"
+                (change)="onSampleTestChange()"
                 [clearable]="false"
-                [formControl]="editorForm.controls.lang">
-                @for (availableLanguage of availableLanguages; track availableLanguage) {
-                  <ng-option
-                    [value]="availableLanguage.lang">
-                    {{ availableLanguage.langFull || availableLanguage.lang }}
+                formControlName="testCaseNumber"
+              >
+                @for (sampleTest of sampleTests; track sampleTest; let i = $index) {
+                  <ng-option value="{{ i + 1 }}">
+                    {{ i + 1 }}
                   </ng-option>
                 }
               </ng-select>
             </div>
+          }
 
-            @if (sampleTests.length > 0) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.SampleTest' | translate }}: </label>
-                <ng-select
-                  (change)="onSampleTestChange()"
-                  [clearable]="false"
-                  formControlName="testCaseNumber"
-                >
-                  @for (sampleTest of sampleTests; track sampleTest; let i = $index) {
-                    <ng-option
-                      value="{{ i + 1 }}">
-                      {{ i + 1 }}
-                    </ng-option>
-                  }
-                </ng-select>
-              </div>
-            }
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Input' | translate }}:</label>
+              <textarea
+                [ngbTooltip]="editorForm.controls.input.errors | errorMessage"
+                class="form-control"
+                formControlName="input"
+                rows="3"
+                tooltipClass="tooltip-danger"
+              ></textarea>
+            </div>
+          }
 
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Input' | translate }}:</label>
-                <textarea
-                  [ngbTooltip]="editorForm.controls.input.errors | errorMessage"
-                  class="form-control"
-                  formControlName="input"
-                  placeholder=""
-                  rows="3"
-                  tooltipClass="tooltip-danger"
-                ></textarea>
-              </div>
-            }
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Output' | translate }}:</label>
+              <textarea class="form-control" formControlName="output" rows="2"></textarea>
+            </div>
+          }
 
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Output' | translate }}:</label>
-                <textarea
-                  class="form-control"
-                  formControlName="output"
-                  rows="2"
-                ></textarea>
-              </div>
-            }
-
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Answer' | translate }}:</label>
-                <textarea
-                  class="form-control"
-                  formControlName="answer"
-                  rows="2"
-                ></textarea>
-              </div>
-            }
-          </div>
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Answer' | translate }}:</label>
+              <textarea class="form-control" formControlName="answer" rows="2"></textarea>
+            </div>
+          }
         </div>
       </div>
+    </div>
 
-      <div class="card-footer d-none d-md-flex justify-content-between">
-        @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
-          <kepcoin-spend-swal
-            (success)="checkSamplesPurchaseSuccess()"
-            [customContent]="true"
-            [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
-            [value]="100"
-          >
-            <div new-feature class="position-relative">
-              <button class="btn btn-glow btn-dark bg-dark">
-                {{ 'CodeEditor.CheckSamples' | translate }}
-                <i data-feather="shopping-cart"></i>
-              </button>
-            </div>
-          </kepcoin-spend-swal>
-        } @else {
+    <div class="card-footer d-none d-md-flex justify-content-between">
+      @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
+        <kepcoin-spend-swal
+          (success)="checkSamplesPurchaseSuccess()"
+          [customContent]="true"
+          [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
+          [value]="100"
+        >
+          <div new-feature class="position-relative">
+            <button class="btn btn-glow btn-dark bg-dark">
+              {{ 'CodeEditor.CheckSamples' | translate }}
+              <i data-feather="shopping-cart"></i>
+            </button>
+          </div>
+        </kepcoin-spend-swal>
+      } @else {
+        <button
+          (click)="checkSamples()"
+          ngbTooltip="Alt+Z"
+          class="btn btn-glow btn-dark bg-dark me-1"
+          type="button"
+        >
+          @if (isCheckSamples) {
+            <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
+          }
+          @if (!isCheckSamples) {
+            <span><i data-feather="terminal"></i></span>
+          }
+          {{ 'CodeEditor.CheckSamples' | translate }}
+        </button>
+      }
+      <div class="d-flex">
+        @if (!isSelectedLangText()) {
           <button
-            (click)="checkSamples()"
-            ngbTooltip="Alt+Z"
+            ngbTooltip="Alt+X"
+            (click)="run()"
             class="btn btn-glow btn-dark bg-dark me-1"
-            type="button">
-            @if (isCheckSamples) {
+            type="button"
+          >
+            @if (isRunning) {
               <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
             }
-            @if (!isCheckSamples) {
+            @if (!isRunning) {
               <span><i data-feather="terminal"></i></span>
             }
-            {{ 'CodeEditor.CheckSamples' | translate }}
+            {{ 'CodeEditor.Run' | translate }}
           </button>
         }
-        <div class="d-flex">
-          @if (!isSelectedLangText()) {
-            <button
-              ngbTooltip="Alt+X"
-              (click)="run()"
-              class="btn btn-glow btn-dark bg-dark me-1"
-              type="button">
-              @if (isRunning) {
-                <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
+
+        @if (answerForInputEnabled) {
+          <kepcoin-spend-swal
+            (success)="answerForInput($event)"
+            [customContent]="true"
+            [purchaseUrl]="'problems/' + problem?.id + '/answer-for-input/'"
+            [requestBody]="{ input_data: editorForm.get('input').value }"
+            [value]="1"
+          >
+            <button class="btn btn-glow btn-dark bg-dark me-1" type="button">
+              @if (isAnswerForInput) {
+                <span class="spinner-border spinner-border-sm" role="status"></span>
               }
-              @if (!isRunning) {
-                <span><i data-feather="terminal"></i></span>
+              @if (!isAnswerForInput) {
+                <span>
+                  <i data-feather="check-square"></i>
+                </span>
               }
-              {{ 'CodeEditor.Run' | translate }}
+              {{ 'CodeEditor.AnswerForInput' | translate }}
             </button>
-          }
+          </kepcoin-spend-swal>
+        }
 
-          @if (answerForInputEnabled) {
-            <kepcoin-spend-swal
-              (success)="answerForInput($event)"
-              [customContent]="true"
-              [purchaseUrl]="'problems/' + problem?.id + '/answer-for-input/'"
-              [requestBody]="{input_data: editorForm.get('input').value}"
-              [value]="1"
-            >
-              <button class="btn btn-glow btn-dark bg-dark me-1" type="button">
-                @if (isAnswerForInput) {
-                  <span
-                    class="spinner-border spinner-border-sm"
-                    role="status">
-                  </span>
-                }
-                @if (!isAnswerForInput) {
-                  <span>
-                    <i data-feather="check-square"></i>
-                  </span>
-                }
-                {{ 'CodeEditor.AnswerForInput' | translate }}
-              </button>
-            </kepcoin-spend-swal>
-          }
-
-          @if (submitUrl) {
-            <button
-              ngbTooltip="Alt+Enter"
-              (click)="submit()"
-              [disabled]="!editorForm.valid"
-              class="btn btn-glow btn-dark bg-dark"
-              type="submit">
-              <i data-feather="send"></i>
-              {{ 'CodeEditor.Submit' | translate }}
-            </button>
-          }
-        </div>
-      </div>
-
-      <div class="card-footer d-md-none d-block text-end">
         @if (submitUrl) {
           <button
             ngbTooltip="Alt+Enter"
             (click)="submit()"
             [disabled]="!editorForm.valid"
             class="btn btn-glow btn-dark bg-dark"
-            type="submit">
+            type="submit"
+          >
             <i data-feather="send"></i>
             {{ 'CodeEditor.Submit' | translate }}
           </button>
         }
       </div>
-    </kep-card>
-  </ng-scrollbar>
-</sidebar>
+    </div>
+
+    <div class="card-footer d-md-none d-block text-end">
+      @if (submitUrl) {
+        <button
+          ngbTooltip="Alt+Enter"
+          (click)="submit()"
+          [disabled]="!editorForm.valid"
+          class="btn btn-glow btn-dark bg-dark"
+          type="submit"
+        >
+          <i data-feather="send"></i>
+          {{ 'CodeEditor.Submit' | translate }}
+        </button>
+      }
+    </div>
+  </kep-card>
+</ng-template>
+
+@if (displayMode === 'docked') {
+  <div class="code-editor-docked" [ngClass]="customClass">
+    <ng-scrollbar>
+      <ng-container *ngTemplateOutlet="editorCard"></ng-container>
+    </ng-scrollbar>
+  </div>
+} @else {
+  <sidebar [hideOnEsc]="true" [name]="sidebarName" class="code-editor-sidebar" [ngClass]="customClass">
+    <a
+      (click)="toggleSidebar()"
+      class="btn-toggle d-flex align-items-center justify-content-center"
+    >
+      <i [data-feather]="'terminal'"></i>
+    </a>
+
+    <ng-scrollbar>
+      <ng-container *ngTemplateOutlet="editorCard"></ng-container>
+    </ng-scrollbar>
+  </sidebar>
+}
 
 <sidebar [hideOnEsc]="true" [name]="checkSamplesResultSidebarName" class="check-samples-result">
   <ng-scrollbar autoWidthDisabled="false">
@@ -225,50 +231,6 @@
         </div>
         <hr class="mt-0 mb-0">
         <div class="card-body">
-          <!--          <ngb-accordion [closeOthers]="false" [destroyOnHide]="false">-->
-          <!--            @for (result of checkSamplesResult; track result.input){-->
-          <!--              <ngb-panel [cardClass]="'collapse-margin'" [id]="'result' + $index">-->
-          <!--                <ng-template ngbPanelTitle>-->
-          <!--                  <div class="fw-semibold d-flex justify-content-between">-->
-          <!--                    <span>TC #{{ $index + 1 }}</span>-->
-          <!--                    <span [class]="{-->
-          <!--                      'text-success': result.verdict == Verdicts.Accepted,-->
-          <!--                      'text-danger': result.verdict != Verdicts.Accepted,-->
-          <!--                    }">{{ result.verdict | verdictShortTitle }}</span>-->
-          <!--                  </div>-->
-          <!--                </ng-template>-->
-          <!--                <ng-template ngbPanelContent>-->
-          <!--                  @if (result.input) {-->
-          <!--                    <div class="meta">-->
-          <!--                      <div class="fw-medium">Input:</div>-->
-          <!--                      <div>{{ result.input }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-
-          <!--                  @if (result.answer) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Answer:</div>-->
-          <!--                      <div>{{ result.answer }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-
-          <!--                  @if (result.output) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Output:</div>-->
-          <!--                      <div>{{ result.output }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-
-          <!--                  @if (result.error) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Error:</div>-->
-          <!--                      <div><pre>{{ result.error }}</pre></div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-          <!--                </ng-template>-->
-          <!--              </ngb-panel>-->
-          <!--            }-->
-          <!--          </ngb-accordion>-->
         </div>
       }
     </div>

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.scss
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.scss
@@ -94,6 +94,32 @@
   }
 }
 
+.code-editor-docked {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  ng-scrollbar {
+    flex: 1 1 auto;
+    max-height: 100%;
+  }
+
+  kep-card {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+
+    .card-body {
+      flex: 1 1 auto;
+      overflow: auto;
+    }
+
+    .card-footer {
+      flex: 0 0 auto;
+    }
+  }
+}
+
 .check-samples-result {
   width: 250px;
   right: -250px;

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.ts
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Language, TranslateService } from '@ngx-translate/core';
 import { LanguageService } from 'app/modules/problems/services/language.service';
@@ -32,7 +32,7 @@ interface CheckSamplesResultOne {
   encapsulation: ViewEncapsulation.None,
   standalone: false,
 })
-export class CodeEditorModalComponent implements OnInit {
+export class CodeEditorModalComponent implements OnInit, OnChanges {
 
   @Input() submitUrl: string;
   @Input() submitParams: any = {};
@@ -42,6 +42,7 @@ export class CodeEditorModalComponent implements OnInit {
   @Input() answerForInputEnabled = false;
   @Input() availableLanguages: Array<AvailableLanguage> = [];
   @Input() problem: Problem;
+  @Input() displayMode: 'sidebar' | 'docked' = 'sidebar';
   @Output() submittedEvent = new EventEmitter<null>();
 
   public canSubmit = true;
@@ -83,11 +84,16 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   get sidebarIsOpened() {
-    return this.coreSidebarService.getSidebarRegistry(this.sidebarName).isOpened;
+    if (this.displayMode === 'docked') {
+      return true;
+    }
+    const sidebar = this.coreSidebarService.getSidebarRegistry(this.sidebarName);
+    return sidebar ? sidebar.isOpened : false;
   }
 
   get resultSidebarIsOpened() {
-    return this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName).isOpened;
+    const sidebar = this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName);
+    return sidebar ? sidebar.isOpened : false;
   }
 
   ngOnInit(): void {
@@ -148,9 +154,17 @@ export class CodeEditorModalComponent implements OnInit {
     );
   }
 
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.displayMode === 'docked' && this.availableLanguages?.length && this.problem) {
+      const codeValue = this.editorForm.get('code').value;
+      if (!codeValue) {
+        this.init();
+      }
+    }
+  }
+
   init() {
     const editorLang = this.editorForm.get('lang').value as AttemptLangs;
-    console.log(editorLang)
     const code = this.templateCodeService.get(this.uniqueName, editorLang)
       || findAvailableLang(this.availableLanguages, editorLang)?.codeTemplate
       || this.availableLanguages[0].codeTemplate;
@@ -215,7 +229,9 @@ export class CodeEditorModalComponent implements OnInit {
       return;
     }
 
-    this.toggleSidebar();
+    if (this.displayMode !== 'docked') {
+      this.toggleSidebar();
+    }
     this.canSubmit = false;
     const data = {
       sourceCode: this.editorForm.get('code').value,
@@ -238,6 +254,12 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   toggleSidebar(): void {
+    if (this.displayMode === 'docked') {
+      if (!this.editorForm.get('code').value) {
+        this.init();
+      }
+      return;
+    }
     if (!this.sidebarIsOpened) {
       this.openSidebar();
     } else {
@@ -246,6 +268,9 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   openSidebar() {
+    if (this.displayMode === 'docked') {
+      return;
+    }
     if (this.sidebarIsOpened) {
       return;
     }
@@ -254,6 +279,9 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   closeSidebar() {
+    if (this.displayMode === 'docked') {
+      return;
+    }
     if (!this.sidebarIsOpened) {
       return;
     }

--- a/src/app/shared/third-part-modules/monaco-editor/monaco-editor.component.ts
+++ b/src/app/shared/third-part-modules/monaco-editor/monaco-editor.component.ts
@@ -20,7 +20,7 @@ import { AppStateService } from "@core/services/app-state.service";
 @Component({
   selector: 'monaco-editor',
   template: `
-    <ngx-monaco-editor [style.height.px]="height" [options]="options" [(ngModel)]="value"></ngx-monaco-editor>`,
+    <ngx-monaco-editor [style.height]="heightStyle" [options]="options" [(ngModel)]="value"></ngx-monaco-editor>`,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -38,7 +38,7 @@ export class MonacoEditorComponent implements ControlValueAccessor, OnInit, OnCh
   @ViewChild(EditorComponent) editorComponent: EditorComponent;
 
   @Input() lang: AttemptLangs;
-  @Input() height = 300;
+  @Input() height: number | string = 300;
   @Input() tabSize = 4;
 
   public options = {
@@ -50,6 +50,13 @@ export class MonacoEditorComponent implements ControlValueAccessor, OnInit, OnCh
   };
   public value: string;
   public disabled: boolean;
+
+  get heightStyle(): string {
+    if (typeof this.height === 'number') {
+      return `${this.height}px`;
+    }
+    return this.height || '300px';
+  }
 
   onChange: () => {};
   onTouched: () => {};


### PR DESCRIPTION
## Summary
- add a dedicated problem layout that wraps the detail routes without the global sidebar
- rebuild the problem detail component with a two-column workspace and in-page submission tools
- update the shared code editor to support a docked 100vh mode and flexible Monaco heights

## Testing
- `npm run lint` *(fails: Angular CLI not installed in the environment)*
- `npm install` *(fails: dependency conflict on @fullcalendar/angular)*

------
https://chatgpt.com/codex/tasks/task_e_68ec03e34f84832f9a8e1a24cec29c1f