### PR TITLE
feat: implement dedicated problem detail layout

### DIFF
--- a/src/@core/layouts/problem-layout/problem-layout.component.html
+++ b/src/@core/layouts/problem-layout/problem-layout.component.html
@@ -1,0 +1,6 @@
+<div class="problem-layout">
+  <app-header class="problem-layout__header"></app-header>
+  <div class="problem-layout__body">
+    <ng-content></ng-content>
+  </div>
+</div>

--- a/src/@core/layouts/problem-layout/problem-layout.component.scss
+++ b/src/@core/layouts/problem-layout/problem-layout.component.scss
@@ -1,0 +1,19 @@
+.problem-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: var(--bs-body-bg, #f5f7fb);
+}
+
+.problem-layout__header {
+  position: sticky;
+  top: 0;
+  z-index: 1050;
+}
+
+.problem-layout__body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bs-gray-100, #f3f4f6);
+}

--- a/src/@core/layouts/problem-layout/problem-layout.component.ts
+++ b/src/@core/layouts/problem-layout/problem-layout.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { HeaderComponent } from '@core/layouts/components/header/header.component';
+
+@Component({
+  selector: 'problem-layout',
+  standalone: true,
+  imports: [HeaderComponent],
+  templateUrl: './problem-layout.component.html',
+  styleUrls: ['./problem-layout.component.scss']
+})
+export class ProblemLayoutComponent {}

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -1,65 +1,77 @@
-<div class="content-wrapper container-xxl p-0">
-  <div class="content-body">
-    <app-content-header [contentHeader]="contentHeader">
-      <div class="btn-group" role="group">
-        <button
-          class="btn btn-primary-light btn-wave"
-          type="button"
-          (click)="goToPreviousProblem()"
-          ngbTooltip="{{ 'PreviousProblem' | translate }}"
-        >
-          <kep-icon name="left"/>
-        </button>
-        <button
-          class="btn btn-primary-light btn-wave"
-          type="button"
-          (click)="goToNextProblem()"
-          ngbTooltip="{{ 'NextProblem' | translate }}"
-        >
-          <kep-icon name="right"/>
-        </button>
-      </div>
-    </app-content-header>
-    <section  class="mt-2">
-      <div class="row">
-        <div class="col-lg-9 col-md-12 col-sm-12">
-          <kep-card>
-            <div class="card-header">
+<problem-layout>
+  @if (problem) {
+    <div class="problem-detail">
+      <div class="problem-detail__panel problem-detail__panel--left">
+        <div class="problem-detail__panel-content">
+          <div class="problem-detail__toolbar">
+            <button
+              class="btn btn-icon btn-light problem-detail__nav-button"
+              type="button"
+              (click)="goToPreviousProblem()"
+              ngbTooltip="{{ 'PreviousProblem' | translate }}"
+            >
+              <kep-icon name="left"></kep-icon>
+            </button>
+
+            <div class="problem-detail__title">
+              <span class="problem-detail__id">#{{ problem.id }}</span>
+              <h1 class="problem-detail__name">{{ problem.title }}</h1>
+            </div>
+
+            <button
+              class="btn btn-icon btn-light problem-detail__nav-button"
+              type="button"
+              (click)="goToNextProblem()"
+              ngbTooltip="{{ 'NextProblem' | translate }}"
+            >
+              <kep-icon name="right"></kep-icon>
+            </button>
+          </div>
+
+          <div class="problem-detail__meta">
+            <problem-sidebar [problem]="problem"></problem-sidebar>
+          </div>
+
+          <kep-card class="problem-detail__card">
+            <div class="problem-detail__tabs">
               <ul
                 #navWithIcons="ngbNav"
-                (activeIdChange)="activeIdChange($event)" [(activeId)]="activeId" [destroyOnHide]="false"
-                class="nav-tabs" ngbNav>
+                class="nav problem-detail__tabs-nav"
+                ngbNav
+                [(activeId)]="activeId"
+                (activeIdChange)="activeIdChange($event)"
+                [destroyOnHide]="false"
+              >
                 <li [ngbNavItem]="1">
-                  <a class="nav-link" ngbNavLink>
+                  <button class="nav-link" ngbNavLink type="button">
                     <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
                     {{ 'Problem' | translate }}
-                  </a>
+                  </button>
                   <ng-template ngbNavContent>
                     <problem-description [problem]="problem"></problem-description>
                   </ng-template>
                 </li>
 
                 <li [ngbNavItem]="2">
-                  <a class="nav-link" ngbNavLink>
+                  <button class="nav-link" ngbNavLink type="button">
                     <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
                     {{ 'Attempts' | translate }}
-                  </a>
+                  </button>
                   <ng-template ngbNavContent>
                     <problem-attempts
                       (hackSubmitted)="activeId = 3;"
                       [problem]="problem"
                       [submitEvent]="submitEvent?.asObservable()"
-                    >
-                    </problem-attempts>
+                    ></problem-attempts>
                   </ng-template>
                 </li>
 
                 @if (problem.hasCheckInput) {
                   <li [ngbNavItem]="3" destroyOnHide="true">
-                    <a class="nav-link" ngbNavLink>
+                    <button class="nav-link" ngbNavLink type="button">
                       <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
                       {{ 'Hacks' | translate }}
-                    </a>
+                    </button>
                     <ng-template ngbNavContent>
                       <problem-hacks [problem]="problem"></problem-hacks>
                     </ng-template>
@@ -68,8 +80,9 @@
 
                 @if (studyPlanId) {
                   <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
-                      <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
+                    <a class="nav-link" ngbNavLink [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
+                      <span [data-feather]="'activity'"></span>
+                      {{ 'StudyPlan' | translate }}
                     </a>
                     <ng-template ngbNavContent>
                       <problem-description [problem]="problem"></problem-description>
@@ -78,8 +91,8 @@
                 }
 
                 @if (contestId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.ContestProblems | resourceById:contestId">
+                  <li [ngbNavItem]="5">
+                    <a class="nav-link" ngbNavLink [routerLink]="Resources.ContestProblems | resourceById:contestId">
                       <kep-icon name="contest" color="primary" type="duotone"/>
                       {{ 'Contest' | translate }}
                     </a>
@@ -89,89 +102,70 @@
                   </li>
                 }
               </ul>
-
-              @if (isAuthenticated) {
-                <button (click)="codeEditorSidebarToggle()" class="btn btn-sm btn-primary">{{ 'Submit' | translate }}
-                </button>
-              }
             </div>
 
-            <div class="card-footer">
-              <div [ngbNavOutlet]="navWithIcons"></div>
-            </div>
+            <div class="problem-detail__tab-content" [ngbNavOutlet]="navWithIcons"></div>
           </kep-card>
 
           @if (currentUser?.permissions.canCreateProblems) {
-            <div class="card">
-              <div class="card-header">
-                <div class="card-title">
-                  Check input
-                </div>
+            <kep-card class="problem-detail__card">
+              <div class="problem-detail__card-header d-flex align-items-center justify-content-between">
+                <div class="problem-detail__card-title">Check input</div>
+                <button class="btn btn-sm btn-primary" type="button" (click)="saveCheckInput()">
+                  {{ 'Save' | translate }}
+                </button>
               </div>
-              <div class="card-body">
+              <div class="problem-detail__card-body">
                 <monaco-editor
                   [lang]="'py'"
-                  class="mt-1"
+                  class="problem-detail__check-input"
                   [ngModelOptions]="{standalone: true}"
                   [(ngModel)]="checkInput"
                 ></monaco-editor>
-                <div class="btn mt-2 btn-primary btn-sm" (click)="saveCheckInput()">Save</div>
               </div>
-            </div>
+            </kep-card>
           }
         </div>
+      </div>
 
-        <div class="col-lg-3 col-md-12 col-sm-12">
-          <problem-sidebar [problem]="problem"></problem-sidebar>
-
+      <div class="problem-detail__panel problem-detail__panel--right">
+        <div class="problem-detail__panel-content">
           @if (isAuthenticated) {
+            <div class="problem-detail__workspace">
+              <code-editor-modal
+                inline="true"
+                [customClass]="'problem-detail__editor-card'"
+                [uniqueName]="'problem-' + problem.id"
+                [sampleTests]="problem.sampleTests"
+                [submitUrl]="'problems/' + problem.id + '/submit/'"
+                [problem]="problem"
+                [answerForInputEnabled]="problem.hasSolution && problem.hasCheckInput"
+                [availableLanguages]="problem.availableLanguages"
+                (submittedEvent)="onSubmit()"
+              ></code-editor-modal>
+            </div>
+
             <problem-submit-card
+              class="problem-detail__submit-card"
               [availableLanguages]="problem.availableLanguages"
               [submitUrl]="'problems/' + problem.id + '/submit/'"
               (submitted)="onSubmit()"
-            />
+            ></problem-submit-card>
+          } @else {
+            <div class="problem-detail__signin">
+              <kep-icon class="problem-detail__signin-icon" name="lock" size="medium"></kep-icon>
+              <h3>{{ 'Login' | translate }}</h3>
+              <p class="text-muted">{{ 'LoginText' | translate }}</p>
+              <a class="btn btn-primary" [routerLink]="[Resources.Login]">
+                {{ 'Login' | translate }}
+              </a>
+            </div>
           }
         </div>
-
       </div>
-
-      @if (problem && isAuthenticated) {
-        <code-editor-modal
-          [customClass]="'tour-step-2'"
-          [uniqueName]="'problem-' + problem.id"
-          [sampleTests]="problem.sampleTests"
-          [submitUrl]="'problems/' + problem.id + '/submit/'"
-          [problem]="problem"
-          [answerForInputEnabled]="problem.hasSolution && problem.hasCheckInput"
-          [availableLanguages]="problem.availableLanguages"
-          (submittedEvent)="onSubmit()"></code-editor-modal>
-      }
-    </section>
-  </div>
-</div>
+    </div>
+  }
+</problem-layout>
 
 <tour-css></tour-css>
 <ng-select-css></ng-select-css>
-
-<!--<div class="col-lg-6 col-md-12 col-sm-12">-->
-<!--  <kep-card>-->
-<!--    <div class="card-header p-2">-->
-<!--      <div class="card-title">-->
-<!--        <kep-icon name="square-brackets" color="primary" type="duotone"/>-->
-<!--        {{ 'Code' | translate }}-->
-<!--      </div>-->
-<!--    </div>-->
-
-<!--    <ng-select-->
-<!--      [appendTo]="'body'"-->
-<!--      [clearable]="false">-->
-<!--      @for (availableLanguage of problem.availableLanguages; track availableLanguage) {-->
-<!--        <ng-option-->
-<!--          [value]="availableLanguage.lang">-->
-<!--          {{ availableLanguage.langFull || availableLanguage.lang }}-->
-<!--        </ng-option>-->
-<!--      }-->
-<!--    </ng-select>-->
-<!--    <monaco-editor lang="py"/>-->
-<!--  </kep-card>-->
-<!--</div>-->

--- a/src/app/modules/problems/pages/problem/problem.component.scss
+++ b/src/app/modules/problems/pages/problem/problem.component.scss
@@ -1,19 +1,217 @@
-.card .card-header {
-  padding: 1rem !important;
-  padding-bottom: 0 !important;
-  align-items: center;
-}
-
-.problem-container {
+:host {
+  display: block;
   height: 100%;
 }
 
-/* Стили для блока с кодом */
-pre {
-  background-color: #f8f9fa;
-  padding: 1rem;
-  border-radius: 0.3rem;
-  overflow-x: auto;
+.problem-detail {
+  display: flex;
+  gap: 1.5rem;
+  height: 100%;
+  min-height: 0;
+  padding: 1.5rem 2rem;
 }
 
-/* Дополнительные стили можно добавить по необходимости */
+.problem-detail__panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.problem-detail__panel--left {
+  flex: 1 1 55%;
+}
+
+.problem-detail__panel--right {
+  flex: 1 1 45%;
+}
+
+.problem-detail__panel-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.75rem;
+}
+
+.problem-detail__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  background: var(--bs-body-bg, #ffffff);
+  box-shadow: 0 12px 35px rgba(15, 23, 42, 0.08);
+}
+
+.problem-detail__nav-button {
+  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.problem-detail__title {
+  flex: 1;
+  text-align: center;
+}
+
+.problem-detail__id {
+  font-weight: 600;
+  color: var(--bs-primary, #5a67d8);
+  display: block;
+  font-size: 0.875rem;
+  margin-bottom: 0.25rem;
+}
+
+.problem-detail__name {
+  font-size: 1.75rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--bs-gray-900, #1f2937);
+}
+
+.problem-detail__meta problem-sidebar {
+  display: block;
+}
+
+.problem-detail__meta .layout-spacing {
+  margin: 0;
+}
+
+.problem-detail__meta kep-card {
+  width: 100%;
+}
+
+.problem-detail__card {
+  width: 100%;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
+  border-radius: 1rem;
+}
+
+.problem-detail__tabs {
+  padding: 1rem 1.5rem 0.5rem;
+}
+
+.problem-detail__tabs-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.problem-detail__tabs-nav .nav-link {
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  background: transparent;
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--bs-gray-700, #4b5563);
+  transition: all 0.2s ease;
+}
+
+.problem-detail__tabs-nav .nav-link.active,
+.problem-detail__tabs-nav .nav-link:hover {
+  border-color: rgba(var(--bs-primary-rgb, 90, 103, 216), 0.2);
+  background: rgba(var(--bs-primary-rgb, 90, 103, 216), 0.12);
+  color: var(--bs-primary, #5a67d8);
+}
+
+.problem-detail__tab-content {
+  padding: 1rem 1.5rem 1.5rem;
+  min-height: 0;
+}
+
+.problem-detail__card-header {
+  padding: 1.25rem 1.5rem 0;
+}
+
+.problem-detail__card-body {
+  padding: 0 1.5rem 1.5rem;
+}
+
+.problem-detail__check-input {
+  height: 240px;
+}
+
+.problem-detail__workspace {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.problem-detail__workspace code-editor-modal,
+.problem-detail__workspace .code-editor-inline {
+  flex: 1;
+  min-height: 0;
+}
+
+.problem-detail__submit-card {
+  box-shadow: 0 12px 35px rgba(15, 23, 42, 0.08);
+  border-radius: 1rem;
+}
+
+.problem-detail__signin {
+  margin: auto;
+  text-align: center;
+  padding: 2rem;
+  border-radius: 1rem;
+  background: var(--bs-body-bg, #ffffff);
+  box-shadow: 0 12px 35px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.problem-detail__signin-icon {
+  width: 48px;
+  height: 48px;
+  color: var(--bs-primary, #5a67d8);
+}
+
+@media (max-width: 1399.98px) {
+  .problem-detail__panel--left,
+  .problem-detail__panel--right {
+    flex-basis: 50%;
+  }
+}
+
+@media (max-width: 1199.98px) {
+  .problem-detail {
+    padding: 1rem;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .problem-detail {
+    flex-direction: column;
+    height: auto;
+  }
+
+  .problem-detail__panel {
+    flex-basis: auto;
+  }
+
+  .problem-detail__panel-content {
+    overflow: visible;
+    padding-right: 0;
+  }
+
+  .problem-detail__toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  .problem-detail__workspace {
+    min-height: 400px;
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -10,20 +10,17 @@ import { NgbNavModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { ProblemDescriptionComponent } from '@problems/pages/problem/problem-description/problem-description.component';
 import { ProblemAttemptsComponent } from '@problems/pages/problem/problem-attempts/problem-attempts.component';
 import { ProblemHacksComponent } from '@problems/pages/problem/problem-hacks/problem-hacks.component';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { CodeEditorModule } from '@shared/components/code-editor/code-editor.module';
 import { ProblemSidebarComponent } from '@problems/pages/problem/problem-sidebar/problem-sidebar.component';
 import { TourModule } from '@shared/third-part-modules/tour/tour.module';
 import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
 import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
 import { BasePageComponent } from '@core/common/classes/base-page.component';
-import { SidebarService } from '@shared/ui/sidebar/sidebar.service';
-import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
-
 import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
 import { take } from 'rxjs/operators';
 import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
+import { ProblemLayoutComponent } from '@core/layouts/problem-layout/problem-layout.component';
 
 @Component({
   selector: 'app-problem',
@@ -32,12 +29,11 @@ import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
   standalone: true,
   imports: [
     CoreCommonModule,
-    ContentHeaderModule,
     NgbNavModule,
+    ProblemLayoutComponent,
     ProblemDescriptionComponent,
     ProblemAttemptsComponent,
     ProblemHacksComponent,
-    MonacoEditorModule,
     CodeEditorModule,
     ProblemSidebarComponent,
     TourModule,
@@ -62,7 +58,6 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
   constructor(
     public service: ProblemsApiService,
     public api: ApiService,
-    protected coreSidebarService: SidebarService,
   ) {
     super();
   }
@@ -136,12 +131,7 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     );
   }
 
-  codeEditorSidebarToggle() {
-    this.coreSidebarService.getSidebarRegistry('codeEditorSidebar').toggleOpen();
-  }
-
   onSubmit() {
-    console.log(4142);
     this.activeId = 2;
     this.submitEvent.next(null);
   }

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.html
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.html
@@ -1,199 +1,182 @@
-<sidebar [hideOnEsc]="true" [name]="sidebarName" class="code-editor-sidebar">
-  <a
-    (click)="toggleSidebar()"
-    class="btn-toggle d-flex align-items-center justify-content-center">
-    <i [data-feather]="'terminal'"></i>
-  </a>
+<ng-template #editorCard>
+  <kep-card
+    (keydown)="onKeyDown($event)"
+    [customClass]="['full-height position-relative', customClass].filter(Boolean).join(' ')"
+  >
+    <div class="card-header">
+      <div class="card-title">
+        {{ 'CodeEditor.Editor' | translate }}
+      </div>
 
-  <ng-scrollbar>
-    <kep-card (keydown)="onKeyDown($event)" customClass="full-height position-relative">
-      <div class="card-header">
-        <div class="card-title">
-          {{ 'CodeEditor.Editor' | translate }}
-        </div>
-
+      @if (!inline) {
         <div class="d-flex justify-content-between">
           <button (click)="toggleSidebar()" aria-label="Close" class="btn-close" type="button"></button>
         </div>
-      </div>
-      <hr class="mt-0 mb-50">
-      <div [formGroup]="editorForm" class="card-body">
-        <div class="row">
-          <div class="col-lg-8 col-md-7 col-12">
-            <div
-              [ngbTooltip]="editorForm.controls.code.errors | errorMessage"
-              [style.height.%]="100"
-              container="body"
-              tooltipClass="tooltip-danger"
-            >
-              <monaco-editor
-                [formControl]="editorForm.controls.code"
-                [height]="480"
-                [lang]="editorForm.controls.lang.value">
-              </monaco-editor>
-            </div>
+      }
+    </div>
+    <hr class="mt-0 mb-50">
+    <div [formGroup]="editorForm" class="card-body">
+      <div class="row">
+        <div class="col-lg-8 col-md-7 col-12">
+          <div
+            [ngbTooltip]="editorForm.controls.code.errors | errorMessage"
+            [style.height.%]="100"
+            container="body"
+            tooltipClass="tooltip-danger"
+          >
+            <monaco-editor
+              [formControl]="editorForm.controls.code"
+              [height]="inline ? editorHeight : 480"
+              [lang]="editorForm.controls.lang.value">
+            </monaco-editor>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-5 d-none d-md-block">
+          <div class="mb-1">
+            <label class="fw-medium">{{ 'Language' | translate }}: </label>
+            <ng-select
+              (change)="langChange($event)"
+              [clearable]="false"
+              [formControl]="editorForm.controls.lang">
+              @for (availableLanguage of availableLanguages; track availableLanguage) {
+                <ng-option
+                  [value]="availableLanguage.lang">
+                  {{ availableLanguage.langFull || availableLanguage.lang }}
+                </ng-option>
+              }
+            </ng-select>
           </div>
 
-          <div class="col-lg-4 col-md-5 d-none d-md-block">
+          @if (sampleTests.length > 0) {
             <div class="mb-1">
-              <label class="fw-medium">{{ 'Language' | translate }}: </label>
+              <label class="fw-medium">{{ 'CodeEditor.SampleTest' | translate }}: </label>
               <ng-select
-                (change)="langChange($event)"
+                (change)="onSampleTestChange()"
                 [clearable]="false"
-                [formControl]="editorForm.controls.lang">
-                @for (availableLanguage of availableLanguages; track availableLanguage) {
+                formControlName="testCaseNumber"
+              >
+                @for (sampleTest of sampleTests; track sampleTest; let i = $index) {
                   <ng-option
-                    [value]="availableLanguage.lang">
-                    {{ availableLanguage.langFull || availableLanguage.lang }}
+                    value="{{ i + 1 }}">
+                    {{ i + 1 }}
                   </ng-option>
                 }
               </ng-select>
             </div>
+          }
 
-            @if (sampleTests.length > 0) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.SampleTest' | translate }}: </label>
-                <ng-select
-                  (change)="onSampleTestChange()"
-                  [clearable]="false"
-                  formControlName="testCaseNumber"
-                >
-                  @for (sampleTest of sampleTests; track sampleTest; let i = $index) {
-                    <ng-option
-                      value="{{ i + 1 }}">
-                      {{ i + 1 }}
-                    </ng-option>
-                  }
-                </ng-select>
-              </div>
-            }
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Input' | translate }}:</label>
+              <textarea
+                [ngbTooltip]="editorForm.controls.input.errors | errorMessage"
+                class="form-control"
+                formControlName="input"
+                placeholder=""
+                rows="3"
+                tooltipClass="tooltip-danger"
+              ></textarea>
+            </div>
+          }
 
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Input' | translate }}:</label>
-                <textarea
-                  [ngbTooltip]="editorForm.controls.input.errors | errorMessage"
-                  class="form-control"
-                  formControlName="input"
-                  placeholder=""
-                  rows="3"
-                  tooltipClass="tooltip-danger"
-                ></textarea>
-              </div>
-            }
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Output' | translate }}:</label>
+              <textarea
+                class="form-control"
+                formControlName="output"
+                rows="2"
+              ></textarea>
+            </div>
+          }
 
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Output' | translate }}:</label>
-                <textarea
-                  class="form-control"
-                  formControlName="output"
-                  rows="2"
-                ></textarea>
-              </div>
-            }
-
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Answer' | translate }}:</label>
-                <textarea
-                  class="form-control"
-                  formControlName="answer"
-                  rows="2"
-                ></textarea>
-              </div>
-            }
-          </div>
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Answer' | translate }}:</label>
+              <textarea
+                class="form-control"
+                formControlName="answer"
+                rows="2"
+              ></textarea>
+            </div>
+          }
         </div>
       </div>
+    </div>
 
-      <div class="card-footer d-none d-md-flex justify-content-between">
-        @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
-          <kepcoin-spend-swal
-            (success)="checkSamplesPurchaseSuccess()"
-            [customContent]="true"
-            [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
-            [value]="100"
-          >
-            <div new-feature class="position-relative">
-              <button class="btn btn-glow btn-dark bg-dark">
-                {{ 'CodeEditor.CheckSamples' | translate }}
-                <i data-feather="shopping-cart"></i>
-              </button>
-            </div>
-          </kepcoin-spend-swal>
-        } @else {
+    <div class="card-footer d-none d-md-flex justify-content-between">
+      @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
+        <kepcoin-spend-swal
+          (success)="checkSamplesPurchaseSuccess()"
+          [customContent]="true"
+          [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
+          [value]="100"
+        >
+          <div new-feature class="position-relative">
+            <button class="btn btn-glow btn-dark bg-dark">
+              {{ 'CodeEditor.CheckSamples' | translate }}
+              <i data-feather="shopping-cart"></i>
+            </button>
+          </div>
+        </kepcoin-spend-swal>
+      } @else {
+        <button
+          (click)="checkSamples()"
+          ngbTooltip="Alt+Z"
+          class="btn btn-glow btn-dark bg-dark me-1"
+          type="button">
+          @if (isCheckSamples) {
+            <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
+          }
+          @if (!isCheckSamples) {
+            <span><i data-feather="terminal"></i></span>
+          }
+          {{ 'CodeEditor.CheckSamples' | translate }}
+        </button>
+      }
+      <div class="d-flex">
+        @if (!isSelectedLangText()) {
           <button
-            (click)="checkSamples()"
-            ngbTooltip="Alt+Z"
+            ngbTooltip="Alt+X"
+            (click)="run()"
             class="btn btn-glow btn-dark bg-dark me-1"
             type="button">
-            @if (isCheckSamples) {
+            @if (isRunning) {
               <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
             }
-            @if (!isCheckSamples) {
+            @if (!isRunning) {
               <span><i data-feather="terminal"></i></span>
             }
-            {{ 'CodeEditor.CheckSamples' | translate }}
+            {{ 'CodeEditor.Run' | translate }}
           </button>
         }
-        <div class="d-flex">
-          @if (!isSelectedLangText()) {
-            <button
-              ngbTooltip="Alt+X"
-              (click)="run()"
-              class="btn btn-glow btn-dark bg-dark me-1"
-              type="button">
-              @if (isRunning) {
-                <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
+
+        @if (answerForInputEnabled) {
+          <kepcoin-spend-swal
+            (success)="answerForInput($event)"
+            [customContent]="true"
+            [purchaseUrl]="'problems/' + problem?.id + '/answer-for-input/'"
+            [requestBody]="{input_data: editorForm.get('input').value}"
+            [value]="1"
+          >
+            <button class="btn btn-glow btn-dark bg-dark me-1" type="button">
+              @if (isAnswerForInput) {
+                <span
+                  class="spinner-border spinner-border-sm"
+                  role="status">
+                </span>
               }
-              @if (!isRunning) {
-                <span><i data-feather="terminal"></i></span>
+              @if (!isAnswerForInput) {
+                <span>
+                  <i data-feather="check-square"></i>
+                </span>
               }
-              {{ 'CodeEditor.Run' | translate }}
+              {{ 'CodeEditor.AnswerForInput' | translate }}
             </button>
-          }
+          </kepcoin-spend-swal>
+        }
 
-          @if (answerForInputEnabled) {
-            <kepcoin-spend-swal
-              (success)="answerForInput($event)"
-              [customContent]="true"
-              [purchaseUrl]="'problems/' + problem?.id + '/answer-for-input/'"
-              [requestBody]="{input_data: editorForm.get('input').value}"
-              [value]="1"
-            >
-              <button class="btn btn-glow btn-dark bg-dark me-1" type="button">
-                @if (isAnswerForInput) {
-                  <span
-                    class="spinner-border spinner-border-sm"
-                    role="status">
-                  </span>
-                }
-                @if (!isAnswerForInput) {
-                  <span>
-                    <i data-feather="check-square"></i>
-                  </span>
-                }
-                {{ 'CodeEditor.AnswerForInput' | translate }}
-              </button>
-            </kepcoin-spend-swal>
-          }
-
-          @if (submitUrl) {
-            <button
-              ngbTooltip="Alt+Enter"
-              (click)="submit()"
-              [disabled]="!editorForm.valid"
-              class="btn btn-glow btn-dark bg-dark"
-              type="submit">
-              <i data-feather="send"></i>
-              {{ 'CodeEditor.Submit' | translate }}
-            </button>
-          }
-        </div>
-      </div>
-
-      <div class="card-footer d-md-none d-block text-end">
         @if (submitUrl) {
           <button
             ngbTooltip="Alt+Enter"
@@ -206,73 +189,74 @@
           </button>
         }
       </div>
-    </kep-card>
-  </ng-scrollbar>
-</sidebar>
+    </div>
 
-<sidebar [hideOnEsc]="true" [name]="checkSamplesResultSidebarName" class="check-samples-result">
-  <ng-scrollbar autoWidthDisabled="false">
-    <div (keydown)="onKeyDown($event)" class="card results-card full-height position-relative">
-      @if (isCheckSamples) {
-        <div class="card-body" [style.height.px]="200">
-          <spinner [name]="checkSamplesResultSidebarName"></spinner>
-        </div>
-      } @else {
-        <div class="card-header">
-          <div class="card-title">
-            {{ 'Result' | translate }}
-          </div>
-        </div>
-        <hr class="mt-0 mb-0">
-        <div class="card-body">
-          <!--          <ngb-accordion [closeOthers]="false" [destroyOnHide]="false">-->
-          <!--            @for (result of checkSamplesResult; track result.input){-->
-          <!--              <ngb-panel [cardClass]="'collapse-margin'" [id]="'result' + $index">-->
-          <!--                <ng-template ngbPanelTitle>-->
-          <!--                  <div class="fw-semibold d-flex justify-content-between">-->
-          <!--                    <span>TC #{{ $index + 1 }}</span>-->
-          <!--                    <span [class]="{-->
-          <!--                      'text-success': result.verdict == Verdicts.Accepted,-->
-          <!--                      'text-danger': result.verdict != Verdicts.Accepted,-->
-          <!--                    }">{{ result.verdict | verdictShortTitle }}</span>-->
-          <!--                  </div>-->
-          <!--                </ng-template>-->
-          <!--                <ng-template ngbPanelContent>-->
-          <!--                  @if (result.input) {-->
-          <!--                    <div class="meta">-->
-          <!--                      <div class="fw-medium">Input:</div>-->
-          <!--                      <div>{{ result.input }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-
-          <!--                  @if (result.answer) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Answer:</div>-->
-          <!--                      <div>{{ result.answer }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-
-          <!--                  @if (result.output) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Output:</div>-->
-          <!--                      <div>{{ result.output }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-
-          <!--                  @if (result.error) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Error:</div>-->
-          <!--                      <div><pre>{{ result.error }}</pre></div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-          <!--                </ng-template>-->
-          <!--              </ngb-panel>-->
-          <!--            }-->
-          <!--          </ngb-accordion>-->
-        </div>
+    <div class="card-footer d-md-none d-block text-end">
+      @if (submitUrl) {
+        <button
+          ngbTooltip="Alt+Enter"
+          (click)="submit()"
+          [disabled]="!editorForm.valid"
+          class="btn btn-glow btn-dark bg-dark"
+          type="submit">
+          <i data-feather="send"></i>
+          {{ 'CodeEditor.Submit' | translate }}
+        </button>
       }
     </div>
-  </ng-scrollbar>
-</sidebar>
+  </kep-card>
+</ng-template>
+
+<ng-template #resultCard>
+  <div (keydown)="onKeyDown($event)" class="card results-card full-height position-relative">
+    @if (isCheckSamples) {
+      <div class="card-body" [style.height.px]="200">
+        <spinner [name]="checkSamplesResultSidebarName"></spinner>
+      </div>
+    } @else {
+      <div class="card-header">
+        <div class="card-title">
+          {{ 'Result' | translate }}
+        </div>
+      </div>
+      <hr class="mt-0 mb-0">
+      <div class="card-body">
+        <!-- Results rendering can be added here -->
+      </div>
+    }
+  </div>
+</ng-template>
+
+@if (!inline) {
+  <sidebar [hideOnEsc]="true" [name]="sidebarName" class="code-editor-sidebar">
+    <a
+      (click)="toggleSidebar()"
+      class="btn-toggle d-flex align-items-center justify-content-center">
+      <i [data-feather]="'terminal'"></i>
+    </a>
+
+    <ng-scrollbar>
+      <ng-container *ngTemplateOutlet="editorCard"></ng-container>
+    </ng-scrollbar>
+  </sidebar>
+
+  <sidebar [hideOnEsc]="true" [name]="checkSamplesResultSidebarName" class="check-samples-result">
+    <ng-scrollbar autoWidthDisabled="false">
+      <ng-container *ngTemplateOutlet="resultCard"></ng-container>
+    </ng-scrollbar>
+  </sidebar>
+} @else {
+  <div class="code-editor-inline" [ngClass]="customClass">
+    <div class="code-editor-inline__editor">
+      <ng-container *ngTemplateOutlet="editorCard"></ng-container>
+    </div>
+
+    @if (isCheckSamples || checkSamplesResult.length) {
+      <div class="code-editor-inline__results">
+        <ng-container *ngTemplateOutlet="resultCard"></ng-container>
+      </div>
+    }
+  </div>
+}
 
 <ng-select-css></ng-select-css>

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.scss
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.scss
@@ -123,3 +123,39 @@
     }
   }
 }
+
+.code-editor-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+}
+
+.code-editor-inline__editor {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.code-editor-inline__editor kep-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+}
+
+.code-editor-inline__editor kep-card .card-body {
+  flex: 1;
+  overflow: auto;
+}
+
+.code-editor-inline__results {
+  border-radius: 1rem;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+  overflow: hidden;
+}
+
+.code-editor-inline__results .card {
+  height: 100%;
+  box-shadow: none;
+}

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.ts
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewEncapsulation } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Language, TranslateService } from '@ngx-translate/core';
 import { LanguageService } from 'app/modules/problems/services/language.service';
@@ -16,6 +16,8 @@ import { AuthService } from '@auth';
 import { paramsMapper } from '@shared/utils';
 import { NgxSpinnerService } from 'ngx-spinner';
 import { findAvailableLang } from "@problems/utils";
+import { fromEvent, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 interface CheckSamplesResultOne {
   verdict: number;
@@ -32,7 +34,7 @@ interface CheckSamplesResultOne {
   encapsulation: ViewEncapsulation.None,
   standalone: false,
 })
-export class CodeEditorModalComponent implements OnInit {
+export class CodeEditorModalComponent implements OnInit, OnDestroy {
 
   @Input() submitUrl: string;
   @Input() submitParams: any = {};
@@ -42,6 +44,7 @@ export class CodeEditorModalComponent implements OnInit {
   @Input() answerForInputEnabled = false;
   @Input() availableLanguages: Array<AvailableLanguage> = [];
   @Input() problem: Problem;
+  @Input() inline = false;
   @Output() submittedEvent = new EventEmitter<null>();
 
   public canSubmit = true;
@@ -66,6 +69,9 @@ export class CodeEditorModalComponent implements OnInit {
 
   public checkSamplesResult: Array<CheckSamplesResultOne> = [];
   protected readonly Verdicts = Verdicts;
+  public editorHeight = 480;
+
+  private destroy$ = new Subject<void>();
 
   constructor(
     public api: ApiService,
@@ -83,17 +89,28 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   get sidebarIsOpened() {
-    return this.coreSidebarService.getSidebarRegistry(this.sidebarName).isOpened;
+    if (this.inline) {
+      return true;
+    }
+    const sidebar = this.coreSidebarService.getSidebarRegistry(this.sidebarName);
+    return sidebar?.isOpened || false;
   }
 
   get resultSidebarIsOpened() {
-    return this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName).isOpened;
+    if (this.inline) {
+      return true;
+    }
+    const sidebar = this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName);
+    return sidebar?.isOpened || false;
   }
 
   ngOnInit(): void {
     this.langService.getLanguage().subscribe(
       (lang: string) => {
         this.editorForm.get('lang').setValue(lang);
+        if (this.inline) {
+          this.init();
+        }
       }
     );
 
@@ -131,26 +148,48 @@ export class CodeEditorModalComponent implements OnInit {
       }
     );
 
-    this.swipeService.swipeLeft$.subscribe(
-      (event) => {
-        if (Math.abs(event.deltaX) + event.pageX + 100 >= window.innerWidth) {
-          this.openSidebar();
+    if (this.inline) {
+      this.updateEditorHeight();
+      fromEvent(window, 'resize')
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(() => this.updateEditorHeight());
+    } else {
+      this.swipeService.swipeLeft$.subscribe(
+        (event) => {
+          if (Math.abs(event.deltaX) + event.pageX + 100 >= window.innerWidth) {
+            this.openSidebar();
+          }
         }
-      }
-    );
+      );
 
-    this.swipeService.swipeRight$.subscribe(
-      (event) => {
-        if (Math.abs(event.deltaX) >= 100) {
-          this.closeSidebar();
+      this.swipeService.swipeRight$.subscribe(
+        (event) => {
+          if (Math.abs(event.deltaX) >= 100) {
+            this.closeSidebar();
+          }
         }
-      }
-    );
+      );
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private updateEditorHeight() {
+    if (!this.inline) {
+      return;
+    }
+    const viewportHeight = window.innerHeight || 0;
+    this.editorHeight = Math.max(viewportHeight - 280, 360);
   }
 
   init() {
+    if (!this.availableLanguages?.length) {
+      return;
+    }
     const editorLang = this.editorForm.get('lang').value as AttemptLangs;
-    console.log(editorLang)
     const code = this.templateCodeService.get(this.uniqueName, editorLang)
       || findAvailableLang(this.availableLanguages, editorLang)?.codeTemplate
       || this.availableLanguages[0].codeTemplate;
@@ -215,7 +254,9 @@ export class CodeEditorModalComponent implements OnInit {
       return;
     }
 
-    this.toggleSidebar();
+    if (!this.inline) {
+      this.toggleSidebar();
+    }
     this.canSubmit = false;
     const data = {
       sourceCode: this.editorForm.get('code').value,
@@ -238,6 +279,9 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   toggleSidebar(): void {
+    if (this.inline) {
+      return;
+    }
     if (!this.sidebarIsOpened) {
       this.openSidebar();
     } else {
@@ -246,6 +290,9 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   openSidebar() {
+    if (this.inline) {
+      return;
+    }
     if (this.sidebarIsOpened) {
       return;
     }
@@ -254,6 +301,9 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   closeSidebar() {
+    if (this.inline) {
+      return;
+    }
     if (!this.sidebarIsOpened) {
       return;
     }
@@ -262,6 +312,9 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   openResultSidebar() {
+    if (this.inline) {
+      return;
+    }
     if (this.resultSidebarIsOpened) {
       return;
     }
@@ -269,6 +322,9 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   closeResultSidebar() {
+    if (this.inline) {
+      return;
+    }
     if (!this.resultSidebarIsOpened) {
       return;
     }
@@ -298,7 +354,9 @@ export class CodeEditorModalComponent implements OnInit {
     }
     this.spinner.show(this.checkSamplesResultSidebarName);
     this.isCheckSamples = true;
-    this.openResultSidebar();
+    if (!this.inline) {
+      this.openResultSidebar();
+    }
     const data = {
       lang: this.editorForm.controls.lang.value,
       sourceCode: this.editorForm.controls.code.value,


### PR DESCRIPTION
## Summary
- add a reusable problem layout wrapper that keeps the header fixed and body constrained
- rebuild the problem detail view with a split 100vh workspace, inline code editor, and refreshed metadata sections
- extend the code editor modal to support inline usage with responsive height and embedded results handling

## Testing
- npm run lint *(fails: ng command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ec03e34f84832f9a8e1a24cec29c1f