### PR TITLE
feat(problem): redesign detail layout with inline editor

### DIFF
--- a/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.html
+++ b/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.html
@@ -1,0 +1,6 @@
+<div class="problem-detail-layout page">
+  <app-header></app-header>
+  <main class="problem-detail-layout__content">
+    <router-outlet></router-outlet>
+  </main>
+</div>

--- a/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.scss
+++ b/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.scss
@@ -1,0 +1,13 @@
+.problem-detail-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background-color: inherit;
+}
+
+.problem-detail-layout__content {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}

--- a/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.ts
+++ b/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { HeaderComponent } from '@core/layouts/components/header/header.component';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-problem-detail-layout',
+  templateUrl: './problem-detail-layout.component.html',
+  styleUrl: './problem-detail-layout.component.scss',
+  standalone: true,
+  imports: [
+    HeaderComponent,
+    RouterOutlet,
+  ]
+})
+export class ProblemDetailLayoutComponent {
+}

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -1,9 +1,9 @@
-<div class="content-wrapper container-xxl p-0">
-  <div class="content-body">
+<div class="problem-page">
+  <div class="problem-page__header">
     <app-content-header [contentHeader]="contentHeader">
-      <div class="btn-group" role="group">
+      <div class="problem-page__switch-buttons" role="group">
         <button
-          class="btn btn-primary-light btn-wave"
+          class="btn btn-icon btn-light"
           type="button"
           (click)="goToPreviousProblem()"
           ngbTooltip="{{ 'PreviousProblem' | translate }}"
@@ -11,7 +11,7 @@
           <kep-icon name="left"/>
         </button>
         <button
-          class="btn btn-primary-light btn-wave"
+          class="btn btn-icon btn-light"
           type="button"
           (click)="goToNextProblem()"
           ngbTooltip="{{ 'NextProblem' | translate }}"
@@ -20,133 +20,132 @@
         </button>
       </div>
     </app-content-header>
-    <section  class="mt-2">
-      <div class="row">
-        <div class="col-lg-9 col-md-12 col-sm-12">
-          <kep-card>
-            <div class="card-header">
-              <ul
-                #navWithIcons="ngbNav"
-                (activeIdChange)="activeIdChange($event)" [(activeId)]="activeId" [destroyOnHide]="false"
-                class="nav-tabs" ngbNav>
-                <li [ngbNavItem]="1">
+  </div>
+
+  <div class="problem-page__body">
+    <section class="problem-page__statement">
+      <div class="problem-page__statement-scroll">
+        <problem-sidebar class="problem-page__sidebar" [problem]="problem"></problem-sidebar>
+
+        <kep-card class="problem-page__panel">
+          <div class="problem-page__tabs-header">
+            <ul
+              #navWithIcons="ngbNav"
+              class="problem-page__tabs nav-tabs"
+              ngbNav
+              [(activeId)]="activeId"
+              (activeIdChange)="activeIdChange($event)"
+              [destroyOnHide]="false"
+            >
+              <li [ngbNavItem]="1">
+                <a class="nav-link" ngbNavLink>
+                  <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
+                  {{ 'Problem' | translate }}
+                </a>
+                <ng-template ngbNavContent>
+                  <problem-description [problem]="problem"></problem-description>
+                </ng-template>
+              </li>
+
+              <li [ngbNavItem]="2">
+                <a class="nav-link" ngbNavLink>
+                  <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
+                  {{ 'Attempts' | translate }}
+                </a>
+                <ng-template ngbNavContent>
+                  <problem-attempts
+                    (hackSubmitted)="navigateToTab(3)"
+                    [problem]="problem"
+                    [submitEvent]="submitEvent?.asObservable()"
+                  ></problem-attempts>
+                </ng-template>
+              </li>
+
+              @if (problem.hasCheckInput) {
+                <li [ngbNavItem]="3" destroyOnHide="true">
                   <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
-                    {{ 'Problem' | translate }}
+                    <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
+                    {{ 'Hacks' | translate }}
                   </a>
                   <ng-template ngbNavContent>
-                    <problem-description [problem]="problem"></problem-description>
+                    <problem-hacks [problem]="problem"></problem-hacks>
                   </ng-template>
                 </li>
-
-                <li [ngbNavItem]="2">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
-                    {{ 'Attempts' | translate }}
-                  </a>
-                  <ng-template ngbNavContent>
-                    <problem-attempts
-                      (hackSubmitted)="activeId = 3;"
-                      [problem]="problem"
-                      [submitEvent]="submitEvent?.asObservable()"
-                    >
-                    </problem-attempts>
-                  </ng-template>
-                </li>
-
-                @if (problem.hasCheckInput) {
-                  <li [ngbNavItem]="3" destroyOnHide="true">
-                    <a class="nav-link" ngbNavLink>
-                      <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
-                      {{ 'Hacks' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-hacks [problem]="problem"></problem-hacks>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (studyPlanId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
-                      <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (contestId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.ContestProblems | resourceById:contestId">
-                      <kep-icon name="contest" color="primary" type="duotone"/>
-                      {{ 'Contest' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-              </ul>
-
-              @if (isAuthenticated) {
-                <button (click)="codeEditorSidebarToggle()" class="btn btn-sm btn-primary">{{ 'Submit' | translate }}
-                </button>
               }
-            </div>
 
-            <div class="card-footer">
-              <div [ngbNavOutlet]="navWithIcons"></div>
+              @if (studyPlanId) {
+                <li class="problem-page__tabs-link">
+                  <a class="nav-link" [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
+                    <span [data-feather]="'activity'"></span>
+                    {{ 'StudyPlan' | translate }}
+                  </a>
+                </li>
+              }
+
+              @if (contestId) {
+                <li class="problem-page__tabs-link">
+                  <a class="nav-link" [routerLink]="Resources.ContestProblems | resourceById:contestId">
+                    <kep-icon name="contest" color="primary" type="duotone"/>
+                    {{ 'Contest' | translate }}
+                  </a>
+                </li>
+              }
+            </ul>
+          </div>
+
+          <div class="problem-page__tabs-content">
+            <div [ngbNavOutlet]="navWithIcons"></div>
+          </div>
+        </kep-card>
+
+        @if (currentUser?.permissions.canCreateProblems) {
+          <kep-card class="problem-page__panel">
+            <div class="problem-page__panel-title">
+              Check input
+            </div>
+            <div class="problem-page__panel-body">
+              <monaco-editor
+                [lang]="'py'"
+                class="mt-1"
+                [ngModelOptions]="{standalone: true}"
+                [(ngModel)]="checkInput"
+              ></monaco-editor>
+              <button class="btn btn-primary btn-sm mt-2" type="button" (click)="saveCheckInput()">
+                Save
+              </button>
             </div>
           </kep-card>
-
-          @if (currentUser?.permissions.canCreateProblems) {
-            <div class="card">
-              <div class="card-header">
-                <div class="card-title">
-                  Check input
-                </div>
-              </div>
-              <div class="card-body">
-                <monaco-editor
-                  [lang]="'py'"
-                  class="mt-1"
-                  [ngModelOptions]="{standalone: true}"
-                  [(ngModel)]="checkInput"
-                ></monaco-editor>
-                <div class="btn mt-2 btn-primary btn-sm" (click)="saveCheckInput()">Save</div>
-              </div>
-            </div>
-          }
-        </div>
-
-        <div class="col-lg-3 col-md-12 col-sm-12">
-          <problem-sidebar [problem]="problem"></problem-sidebar>
-
-          @if (isAuthenticated) {
-            <problem-submit-card
-              [availableLanguages]="problem.availableLanguages"
-              [submitUrl]="'problems/' + problem.id + '/submit/'"
-              (submitted)="onSubmit()"
-            />
-          }
-        </div>
-
+        }
       </div>
-
-      @if (problem && isAuthenticated) {
-        <code-editor-modal
-          [customClass]="'tour-step-2'"
-          [uniqueName]="'problem-' + problem.id"
-          [sampleTests]="problem.sampleTests"
-          [submitUrl]="'problems/' + problem.id + '/submit/'"
-          [problem]="problem"
-          [answerForInputEnabled]="problem.hasSolution && problem.hasCheckInput"
-          [availableLanguages]="problem.availableLanguages"
-          (submittedEvent)="onSubmit()"></code-editor-modal>
-      }
     </section>
+
+    <aside class="problem-page__workspace">
+      <div class="problem-page__workspace-scroll">
+        @if (problem && isAuthenticated) {
+          <code-editor-modal
+            class="problem-page__editor"
+            [customClass]="'tour-step-2'"
+            [uniqueName]="'problem-' + problem.id"
+            [sampleTests]="problem.sampleTests"
+            [submitUrl]="'problems/' + problem.id + '/submit/'"
+            [problem]="problem"
+            [answerForInputEnabled]="problem.hasSolution && problem.hasCheckInput"
+            [availableLanguages]="problem.availableLanguages"
+            [displayMode]="'inline'"
+            (submittedEvent)="onSubmit()"
+          ></code-editor-modal>
+        }
+
+        @if (isAuthenticated) {
+          <problem-submit-card
+            class="problem-page__submit-card"
+            [availableLanguages]="problem.availableLanguages"
+            [submitUrl]="'problems/' + problem.id + '/submit/'"
+            (submitted)="onSubmit()"
+          ></problem-submit-card>
+        }
+      </div>
+    </aside>
   </div>
 </div>
 

--- a/src/app/modules/problems/pages/problem/problem.component.scss
+++ b/src/app/modules/problems/pages/problem/problem.component.scss
@@ -1,19 +1,172 @@
-.card .card-header {
-  padding: 1rem !important;
-  padding-bottom: 0 !important;
-  align-items: center;
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
-.problem-container {
-  height: 100%;
+.problem-page {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
-/* Стили для блока с кодом */
-pre {
-  background-color: #f8f9fa;
-  padding: 1rem;
-  border-radius: 0.3rem;
+.problem-page__header {
+  padding: 1.5rem 2rem 0;
+}
+
+.problem-page__switch-buttons {
+  display: inline-flex;
+  gap: 0.75rem;
+}
+
+.problem-page__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  padding: 1.5rem 2rem 2rem;
+}
+
+.problem-page__statement,
+.problem-page__workspace {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.problem-page__statement-scroll,
+.problem-page__workspace-scroll {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.problem-page__statement-scroll {
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.problem-page__workspace-scroll {
+  overflow-y: auto;
+  padding-left: 0.5rem;
+}
+
+.problem-page__sidebar {
+  width: 100%;
+}
+
+.problem-page__panel {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.problem-page__tabs-header {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: inherit;
+  padding: 1rem 1.5rem 0;
+}
+
+.problem-page__tabs {
+  display: flex;
+  flex-wrap: nowrap;
+  gap: 0.5rem;
+  border-bottom: 0;
   overflow-x: auto;
+  padding-bottom: 0.5rem;
+  margin: 0;
+  list-style: none;
 }
 
-/* Дополнительные стили можно добавить по необходимости */
+.problem-page__tabs .nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  color: var(--bs-body-color);
+  background: rgba(0, 0, 0, 0.05);
+  white-space: nowrap;
+}
+
+.dark-layout .problem-page__tabs .nav-link {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.problem-page__tabs .nav-link.active {
+  background: var(--bs-primary);
+  color: #fff;
+}
+
+.problem-page__tabs-link .nav-link {
+  background: transparent;
+  color: var(--bs-primary);
+  padding-inline: 0.75rem;
+}
+
+.problem-page__tabs-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 0 1.5rem 1.5rem;
+  overflow: visible;
+}
+
+.problem-page__panel-title {
+  font-weight: 600;
+  padding: 1.5rem 1.5rem 0;
+}
+
+.problem-page__panel-body {
+  padding: 0 1.5rem 1.5rem;
+}
+
+.problem-page__editor {
+  flex: 1 1 auto;
+}
+
+.problem-page__submit-card {
+  flex: 0 0 auto;
+}
+
+@media (max-width: 1199.98px) {
+  .problem-page__body {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 991.98px) {
+  .problem-page__body {
+    grid-template-columns: minmax(0, 1fr);
+    padding-inline: 1.25rem;
+  }
+
+  .problem-page__workspace-scroll,
+  .problem-page__statement-scroll {
+    overflow: visible;
+    padding: 0;
+  }
+
+  .problem-page__header {
+    padding-inline: 1.25rem;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .problem-page__tabs {
+    gap: 0.25rem;
+  }
+
+  .problem-page__switch-buttons {
+    gap: 0.5rem;
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Params } from '@angular/router';
+import { NavigationEnd, Params } from '@angular/router';
 import { AuthUser } from '@auth';
 import { Subject } from 'rxjs';
 import { Problem } from '@problems/models/problems.models';
@@ -17,12 +17,11 @@ import { TourModule } from '@shared/third-part-modules/tour/tour.module';
 import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
 import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
 import { BasePageComponent } from '@core/common/classes/base-page.component';
-import { SidebarService } from '@shared/ui/sidebar/sidebar.service';
 import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 
 import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
-import { take } from 'rxjs/operators';
+import { filter, take, takeUntil } from 'rxjs/operators';
 import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
@@ -59,20 +58,25 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
 
   public submitEvent = new Subject();
   public checkInput = '';
+  private isSyncingActiveTab = false;
   constructor(
     public service: ProblemsApiService,
     public api: ApiService,
-    protected coreSidebarService: SidebarService,
   ) {
     super();
   }
 
   ngOnInit(): void {
-    if (this._queryParams.tab === 'hacks') {
-      this.activeId = 3;
-    } else if (this._queryParams.tab === 'attempts') {
-      this.activeId = 2;
-    }
+    this.updateActiveTabFromUrl(this.router.url, this._queryParams?.tab);
+
+    this.router.events
+      .pipe(
+        takeUntil(this._unsubscribeAll),
+        filter((event): event is NavigationEnd => event instanceof NavigationEnd)
+      )
+      .subscribe(event => {
+        this.updateActiveTabFromUrl(event.urlAfterRedirects, this._queryParams?.tab);
+      });
 
     this.route.data.subscribe(({ problem }) => {
       this.problem = problem;
@@ -117,13 +121,11 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
   }
 
   activeIdChange(index: number) {
-    if (index === 1) {
-      this.updateQueryParams({ tab: null });
-    } else if (index === 2) {
-      this.updateQueryParams({ tab: 'attempts' });
-    } else if (index === 3) {
-      this.updateQueryParams({ tab: 'hacks' });
+    if (this.isSyncingActiveTab) {
+      return;
     }
+
+    this.navigateToTab(index);
   }
 
   saveCheckInput() {
@@ -136,13 +138,8 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     );
   }
 
-  codeEditorSidebarToggle() {
-    this.coreSidebarService.getSidebarRegistry('codeEditorSidebar').toggleOpen();
-  }
-
   onSubmit() {
-    console.log(4142);
-    this.activeId = 2;
+    this.navigateToTab(2);
     this.submitEvent.next(null);
   }
 
@@ -173,5 +170,45 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     this.router.navigate(['/practice/problems/problem', problemId], {
       queryParams: this.route.snapshot.queryParams,
     });
+  }
+
+  private updateActiveTabFromUrl(url: string, tabParam?: string) {
+    let nextActiveId = 1;
+
+    if (url.includes('/hacks')) {
+      nextActiveId = 3;
+    } else if (url.includes('/attempts')) {
+      nextActiveId = 2;
+    } else if (tabParam === 'hacks') {
+      nextActiveId = 3;
+    } else if (tabParam === 'attempts') {
+      nextActiveId = 2;
+    }
+
+    if (this.activeId === nextActiveId) {
+      return;
+    }
+
+    this.isSyncingActiveTab = true;
+    this.activeId = nextActiveId;
+    setTimeout(() => (this.isSyncingActiveTab = false));
+  }
+
+  navigateToTab(index: number) {
+    if (!this.problem) {
+      return;
+    }
+
+    const commands: Array<any> = ['/practice/problems/problem', this.problem.id];
+    if (index === 2) {
+      commands.push('attempts');
+    } else if (index === 3) {
+      commands.push('hacks');
+    }
+
+    const queryParams = { ...this.route.snapshot.queryParams };
+    delete queryParams['tab'];
+
+    this.router.navigate(commands, { queryParams });
   }
 }

--- a/src/app/modules/problems/problems.routing.ts
+++ b/src/app/modules/problems/problems.routing.ts
@@ -2,6 +2,7 @@ import { Route } from '@angular/router';
 import { ProblemResolver } from "@problems/problems.resolver";
 import { ProblemGuard } from "@problems/problems.guard";
 import { AuthGuard } from "@auth";
+import { ProblemDetailLayoutComponent } from '@core/layouts/problem-detail-layout/problem-detail-layout.component';
 
 export default [
   {
@@ -22,36 +23,37 @@ export default [
   // },
   {
     path: 'problem/:id',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
+    component: ProblemDetailLayoutComponent,
+    canActivate: [ProblemGuard],
     resolve: {
       problem: ProblemResolver,
     },
-    canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/attempts',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
     data: {
       title: 'Problems.Problem',
     },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/hacks',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
+    children: [
+      {
+        path: '',
+        loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: {
+          title: 'Problems.Problem',
+        },
+      },
+      {
+        path: 'attempts',
+        loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: {
+          title: 'Problems.Problem',
+        },
+      },
+      {
+        path: 'hacks',
+        loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: {
+          title: 'Problems.Problem',
+        },
+      },
+    ]
   },
   // {
   //   path: 'problem/:id/og-image',

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.html
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.html
@@ -1,278 +1,307 @@
-<sidebar [hideOnEsc]="true" [name]="sidebarName" class="code-editor-sidebar">
-  <a
-    (click)="toggleSidebar()"
-    class="btn-toggle d-flex align-items-center justify-content-center">
-    <i [data-feather]="'terminal'"></i>
-  </a>
-
-  <ng-scrollbar>
-    <kep-card (keydown)="onKeyDown($event)" customClass="full-height position-relative">
-      <div class="card-header">
-        <div class="card-title">
-          {{ 'CodeEditor.Editor' | translate }}
-        </div>
-
-        <div class="d-flex justify-content-between">
-          <button (click)="toggleSidebar()" aria-label="Close" class="btn-close" type="button"></button>
-        </div>
+<ng-template #editorCard>
+  <kep-card (keydown)="onKeyDown($event)" customClass="full-height position-relative">
+    <div class="card-header">
+      <div class="card-title">
+        {{ 'CodeEditor.Editor' | translate }}
       </div>
-      <hr class="mt-0 mb-50">
-      <div [formGroup]="editorForm" class="card-body">
-        <div class="row">
-          <div class="col-lg-8 col-md-7 col-12">
-            <div
-              [ngbTooltip]="editorForm.controls.code.errors | errorMessage"
-              [style.height.%]="100"
-              container="body"
-              tooltipClass="tooltip-danger"
+
+      <div class="d-flex justify-content-between align-items-center">
+        @if (!isInlineMode) {
+          <button (click)="toggleSidebar()" aria-label="Close" class="btn-close" type="button"></button>
+        }
+      </div>
+    </div>
+    <hr class="mt-0 mb-50">
+    <div [formGroup]="editorForm" class="card-body">
+      <div class="row g-2">
+        <div class="col-lg-8 col-md-7 col-12">
+          <div
+            [ngbTooltip]="editorForm.controls.code.errors | errorMessage"
+            [style.height.%]="100"
+            container="body"
+            tooltipClass="tooltip-danger"
+          >
+            <monaco-editor
+              [formControl]="editorForm.controls.code"
+              [height]="editorHeight"
+              [lang]="editorForm.controls.lang.value"
             >
-              <monaco-editor
-                [formControl]="editorForm.controls.code"
-                [height]="480"
-                [lang]="editorForm.controls.lang.value">
-              </monaco-editor>
-            </div>
+            </monaco-editor>
+          </div>
+        </div>
+
+        <div class="col-lg-4 col-md-5 d-none d-md-block">
+          <div class="mb-1">
+            <label class="fw-medium">{{ 'Language' | translate }}: </label>
+            <ng-select
+              (change)="langChange($event)"
+              [clearable]="false"
+              [formControl]="editorForm.controls.lang"
+            >
+              @for (availableLanguage of availableLanguages; track availableLanguage) {
+                <ng-option [value]="availableLanguage.lang">
+                  {{ availableLanguage.langFull || availableLanguage.lang }}
+                </ng-option>
+              }
+            </ng-select>
           </div>
 
-          <div class="col-lg-4 col-md-5 d-none d-md-block">
+          @if (sampleTests.length > 0) {
             <div class="mb-1">
-              <label class="fw-medium">{{ 'Language' | translate }}: </label>
+              <label class="fw-medium">{{ 'CodeEditor.SampleTest' | translate }}: </label>
               <ng-select
-                (change)="langChange($event)"
+                (change)="onSampleTestChange()"
                 [clearable]="false"
-                [formControl]="editorForm.controls.lang">
-                @for (availableLanguage of availableLanguages; track availableLanguage) {
-                  <ng-option
-                    [value]="availableLanguage.lang">
-                    {{ availableLanguage.langFull || availableLanguage.lang }}
+                formControlName="testCaseNumber"
+              >
+                @for (sampleTest of sampleTests; track sampleTest; let i = $index) {
+                  <ng-option value="{{ i + 1 }}">
+                    {{ i + 1 }}
                   </ng-option>
                 }
               </ng-select>
             </div>
+          }
 
-            @if (sampleTests.length > 0) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.SampleTest' | translate }}: </label>
-                <ng-select
-                  (change)="onSampleTestChange()"
-                  [clearable]="false"
-                  formControlName="testCaseNumber"
-                >
-                  @for (sampleTest of sampleTests; track sampleTest; let i = $index) {
-                    <ng-option
-                      value="{{ i + 1 }}">
-                      {{ i + 1 }}
-                    </ng-option>
-                  }
-                </ng-select>
-              </div>
-            }
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Input' | translate }}:</label>
+              <textarea
+                [ngbTooltip]="editorForm.controls.input.errors | errorMessage"
+                class="form-control"
+                formControlName="input"
+                placeholder=""
+                rows="3"
+                tooltipClass="tooltip-danger"
+              ></textarea>
+            </div>
+          }
 
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Input' | translate }}:</label>
-                <textarea
-                  [ngbTooltip]="editorForm.controls.input.errors | errorMessage"
-                  class="form-control"
-                  formControlName="input"
-                  placeholder=""
-                  rows="3"
-                  tooltipClass="tooltip-danger"
-                ></textarea>
-              </div>
-            }
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Output' | translate }}:</label>
+              <textarea
+                class="form-control"
+                formControlName="output"
+                rows="2"
+              ></textarea>
+            </div>
+          }
 
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Output' | translate }}:</label>
-                <textarea
-                  class="form-control"
-                  formControlName="output"
-                  rows="2"
-                ></textarea>
-              </div>
-            }
-
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Answer' | translate }}:</label>
-                <textarea
-                  class="form-control"
-                  formControlName="answer"
-                  rows="2"
-                ></textarea>
-              </div>
-            }
-          </div>
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Answer' | translate }}:</label>
+              <textarea
+                class="form-control"
+                formControlName="answer"
+                rows="2"
+              ></textarea>
+            </div>
+          }
         </div>
       </div>
+    </div>
 
-      <div class="card-footer d-none d-md-flex justify-content-between">
-        @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
-          <kepcoin-spend-swal
-            (success)="checkSamplesPurchaseSuccess()"
-            [customContent]="true"
-            [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
-            [value]="100"
-          >
-            <div new-feature class="position-relative">
-              <button class="btn btn-glow btn-dark bg-dark">
-                {{ 'CodeEditor.CheckSamples' | translate }}
-                <i data-feather="shopping-cart"></i>
-              </button>
-            </div>
-          </kepcoin-spend-swal>
-        } @else {
+    <div class="card-footer d-none d-md-flex justify-content-between">
+      @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
+        <kepcoin-spend-swal
+          (success)="checkSamplesPurchaseSuccess()"
+          [customContent]="true"
+          [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
+          [value]="100"
+        >
+          <div new-feature class="position-relative">
+            <button class="btn btn-glow btn-dark bg-dark">
+              {{ 'CodeEditor.CheckSamples' | translate }}
+              <i data-feather="shopping-cart"></i>
+            </button>
+          </div>
+        </kepcoin-spend-swal>
+      } @else {
+        <button
+          (click)="checkSamples()"
+          ngbTooltip="Alt+Z"
+          class="btn btn-glow btn-dark bg-dark me-1"
+          type="button"
+        >
+          @if (isCheckSamples) {
+            <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
+          }
+          @if (!isCheckSamples) {
+            <span><i data-feather="terminal"></i></span>
+          }
+          {{ 'CodeEditor.CheckSamples' | translate }}
+        </button>
+      }
+      <div class="d-flex">
+        @if (!isSelectedLangText()) {
           <button
-            (click)="checkSamples()"
-            ngbTooltip="Alt+Z"
+            ngbTooltip="Alt+X"
+            (click)="run()"
             class="btn btn-glow btn-dark bg-dark me-1"
-            type="button">
-            @if (isCheckSamples) {
+            type="button"
+          >
+            @if (isRunning) {
               <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
             }
-            @if (!isCheckSamples) {
+            @if (!isRunning) {
               <span><i data-feather="terminal"></i></span>
             }
-            {{ 'CodeEditor.CheckSamples' | translate }}
+            {{ 'CodeEditor.Run' | translate }}
           </button>
         }
-        <div class="d-flex">
-          @if (!isSelectedLangText()) {
-            <button
-              ngbTooltip="Alt+X"
-              (click)="run()"
-              class="btn btn-glow btn-dark bg-dark me-1"
-              type="button">
-              @if (isRunning) {
-                <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
+
+        @if (answerForInputEnabled) {
+          <kepcoin-spend-swal
+            (success)="answerForInput($event)"
+            [customContent]="true"
+            [purchaseUrl]="'problems/' + problem?.id + '/answer-for-input/'"
+            [requestBody]="{input_data: editorForm.get('input').value}"
+            [value]="1"
+          >
+            <button class="btn btn-glow btn-dark bg-dark me-1" type="button">
+              @if (isAnswerForInput) {
+                <span class="spinner-border spinner-border-sm" role="status"></span>
               }
-              @if (!isRunning) {
-                <span><i data-feather="terminal"></i></span>
+              @if (!isAnswerForInput) {
+                <span>
+                  <i data-feather="check-square"></i>
+                </span>
               }
-              {{ 'CodeEditor.Run' | translate }}
+              {{ 'CodeEditor.AnswerForInput' | translate }}
             </button>
-          }
+          </kepcoin-spend-swal>
+        }
 
-          @if (answerForInputEnabled) {
-            <kepcoin-spend-swal
-              (success)="answerForInput($event)"
-              [customContent]="true"
-              [purchaseUrl]="'problems/' + problem?.id + '/answer-for-input/'"
-              [requestBody]="{input_data: editorForm.get('input').value}"
-              [value]="1"
-            >
-              <button class="btn btn-glow btn-dark bg-dark me-1" type="button">
-                @if (isAnswerForInput) {
-                  <span
-                    class="spinner-border spinner-border-sm"
-                    role="status">
-                  </span>
-                }
-                @if (!isAnswerForInput) {
-                  <span>
-                    <i data-feather="check-square"></i>
-                  </span>
-                }
-                {{ 'CodeEditor.AnswerForInput' | translate }}
-              </button>
-            </kepcoin-spend-swal>
-          }
-
-          @if (submitUrl) {
-            <button
-              ngbTooltip="Alt+Enter"
-              (click)="submit()"
-              [disabled]="!editorForm.valid"
-              class="btn btn-glow btn-dark bg-dark"
-              type="submit">
-              <i data-feather="send"></i>
-              {{ 'CodeEditor.Submit' | translate }}
-            </button>
-          }
-        </div>
-      </div>
-
-      <div class="card-footer d-md-none d-block text-end">
         @if (submitUrl) {
           <button
             ngbTooltip="Alt+Enter"
             (click)="submit()"
             [disabled]="!editorForm.valid"
             class="btn btn-glow btn-dark bg-dark"
-            type="submit">
+            type="submit"
+          >
             <i data-feather="send"></i>
             {{ 'CodeEditor.Submit' | translate }}
           </button>
         }
       </div>
-    </kep-card>
-  </ng-scrollbar>
-</sidebar>
+    </div>
 
-<sidebar [hideOnEsc]="true" [name]="checkSamplesResultSidebarName" class="check-samples-result">
-  <ng-scrollbar autoWidthDisabled="false">
-    <div (keydown)="onKeyDown($event)" class="card results-card full-height position-relative">
-      @if (isCheckSamples) {
-        <div class="card-body" [style.height.px]="200">
-          <spinner [name]="checkSamplesResultSidebarName"></spinner>
-        </div>
-      } @else {
-        <div class="card-header">
-          <div class="card-title">
-            {{ 'Result' | translate }}
-          </div>
-        </div>
-        <hr class="mt-0 mb-0">
-        <div class="card-body">
-          <!--          <ngb-accordion [closeOthers]="false" [destroyOnHide]="false">-->
-          <!--            @for (result of checkSamplesResult; track result.input){-->
-          <!--              <ngb-panel [cardClass]="'collapse-margin'" [id]="'result' + $index">-->
-          <!--                <ng-template ngbPanelTitle>-->
-          <!--                  <div class="fw-semibold d-flex justify-content-between">-->
-          <!--                    <span>TC #{{ $index + 1 }}</span>-->
-          <!--                    <span [class]="{-->
-          <!--                      'text-success': result.verdict == Verdicts.Accepted,-->
-          <!--                      'text-danger': result.verdict != Verdicts.Accepted,-->
-          <!--                    }">{{ result.verdict | verdictShortTitle }}</span>-->
-          <!--                  </div>-->
-          <!--                </ng-template>-->
-          <!--                <ng-template ngbPanelContent>-->
-          <!--                  @if (result.input) {-->
-          <!--                    <div class="meta">-->
-          <!--                      <div class="fw-medium">Input:</div>-->
-          <!--                      <div>{{ result.input }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-
-          <!--                  @if (result.answer) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Answer:</div>-->
-          <!--                      <div>{{ result.answer }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-
-          <!--                  @if (result.output) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Output:</div>-->
-          <!--                      <div>{{ result.output }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-
-          <!--                  @if (result.error) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Error:</div>-->
-          <!--                      <div><pre>{{ result.error }}</pre></div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-          <!--                </ng-template>-->
-          <!--              </ngb-panel>-->
-          <!--            }-->
-          <!--          </ngb-accordion>-->
-        </div>
+    <div class="card-footer d-md-none d-block text-end">
+      @if (submitUrl) {
+        <button
+          ngbTooltip="Alt+Enter"
+          (click)="submit()"
+          [disabled]="!editorForm.valid"
+          class="btn btn-glow btn-dark bg-dark"
+          type="submit"
+        >
+          <i data-feather="send"></i>
+          {{ 'CodeEditor.Submit' | translate }}
+        </button>
       }
     </div>
-  </ng-scrollbar>
-</sidebar>
+  </kep-card>
+</ng-template>
+
+<ng-template #resultsCard>
+  <div (keydown)="onKeyDown($event)" class="card results-card full-height position-relative">
+    @if (isCheckSamples) {
+      <div class="card-body" [style.height.px]="200">
+        <spinner [name]="checkSamplesResultSidebarName"></spinner>
+      </div>
+    } @else {
+      <div class="card-header">
+        <div class="card-title">
+          {{ 'Result' | translate }}
+        </div>
+      </div>
+      <hr class="mt-0 mb-0">
+      <div class="card-body">
+        @if (checkSamplesResult.length === 0) {
+          <div class="text-muted small">{{ 'NoData' | translate }}</div>
+        } @else {
+          @for (result of checkSamplesResult; track result; let i = $index) {
+            <div class="mb-2 pb-1 border-bottom">
+              <div class="d-flex justify-content-between fw-semibold mb-1">
+                <span>TC #{{ i + 1 }}</span>
+                <span
+                  [class]="{
+                    'text-success': result.verdict == Verdicts.Accepted,
+                    'text-danger': result.verdict != Verdicts.Accepted
+                  }"
+                >
+                  {{ result.verdict | verdictShortTitle }}
+                </span>
+              </div>
+
+              @if (result.input) {
+                <div class="mb-50">
+                  <div class="fw-medium">{{ 'CodeEditor.Input' | translate }}:</div>
+                  <pre class="result-pre">{{ result.input }}</pre>
+                </div>
+              }
+
+              @if (result.answer) {
+                <div class="mb-50">
+                  <div class="fw-medium">{{ 'CodeEditor.Answer' | translate }}:</div>
+                  <pre class="result-pre">{{ result.answer }}</pre>
+                </div>
+              }
+
+              @if (result.output) {
+                <div class="mb-50">
+                  <div class="fw-medium">{{ 'CodeEditor.Output' | translate }}:</div>
+                  <pre class="result-pre">{{ result.output }}</pre>
+                </div>
+              }
+
+              @if (result.error) {
+                <div class="mb-50">
+                  <div class="fw-medium">{{ 'CodeEditor.Error' | translate }}:</div>
+                  <pre class="result-pre">{{ result.error }}</pre>
+                </div>
+              }
+            </div>
+          }
+        }
+      </div>
+    }
+  </div>
+</ng-template>
+
+@if (isInlineMode) {
+  <div class="code-editor-inline">
+    <ng-scrollbar class="code-editor-inline__scroll">
+      <ng-container *ngTemplateOutlet="editorCard"></ng-container>
+    </ng-scrollbar>
+
+    @if (showInlineResults || isCheckSamples) {
+      <div class="code-editor-inline__results">
+        <ng-container *ngTemplateOutlet="resultsCard"></ng-container>
+      </div>
+    }
+  </div>
+} @else {
+  <sidebar [hideOnEsc]="true" [name]="sidebarName" class="code-editor-sidebar">
+    <a
+      (click)="toggleSidebar()"
+      class="btn-toggle d-flex align-items-center justify-content-center"
+    >
+      <i [data-feather]="'terminal'"></i>
+    </a>
+
+    <ng-scrollbar>
+      <ng-container *ngTemplateOutlet="editorCard"></ng-container>
+    </ng-scrollbar>
+  </sidebar>
+
+  <sidebar [hideOnEsc]="true" [name]="checkSamplesResultSidebarName" class="check-samples-result">
+    <ng-scrollbar autoWidthDisabled="false">
+      <ng-container *ngTemplateOutlet="resultsCard"></ng-container>
+    </ng-scrollbar>
+  </sidebar>
+}
 
 <ng-select-css></ng-select-css>

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.scss
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.scss
@@ -123,3 +123,45 @@
     }
   }
 }
+
+.code-editor-inline {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  gap: 1rem;
+
+  .card {
+    margin-bottom: 0;
+  }
+}
+
+.code-editor-inline__scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+
+  .ng-scroll-content {
+    min-height: 100%;
+  }
+}
+
+.code-editor-inline__results {
+  flex: 0 0 auto;
+}
+
+.results-card .card-body > div:last-child {
+  border-bottom: 0 !important;
+}
+
+.result-pre {
+  background-color: rgba($black, 0.04);
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  white-space: pre-wrap;
+  font-family: var(--bs-font-monospace);
+  font-size: 0.875rem;
+
+  @include dark-layout {
+    background-color: rgba($white, 0.08);
+    color: $white;
+  }
+}

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.ts
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.ts
@@ -22,6 +22,7 @@ interface CheckSamplesResultOne {
   input: string;
   output: string;
   answer: string;
+  error?: string;
 }
 
 @Component({
@@ -42,6 +43,7 @@ export class CodeEditorModalComponent implements OnInit {
   @Input() answerForInputEnabled = false;
   @Input() availableLanguages: Array<AvailableLanguage> = [];
   @Input() problem: Problem;
+  @Input() displayMode: 'sidebar' | 'inline' = 'sidebar';
   @Output() submittedEvent = new EventEmitter<null>();
 
   public canSubmit = true;
@@ -65,6 +67,7 @@ export class CodeEditorModalComponent implements OnInit {
   public prevKeyCode: string;
 
   public checkSamplesResult: Array<CheckSamplesResultOne> = [];
+  public showInlineResults = false;
   protected readonly Verdicts = Verdicts;
 
   constructor(
@@ -83,17 +86,42 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   get sidebarIsOpened() {
-    return this.coreSidebarService.getSidebarRegistry(this.sidebarName).isOpened;
+    if (this.isInlineMode) {
+      return true;
+    }
+    const sidebar = this.coreSidebarService.getSidebarRegistry(this.sidebarName);
+    return sidebar ? sidebar.isOpened : false;
   }
 
   get resultSidebarIsOpened() {
-    return this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName).isOpened;
+    if (this.isInlineMode) {
+      return this.showInlineResults;
+    }
+    const sidebar = this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName);
+    return sidebar ? sidebar.isOpened : false;
+  }
+
+  get isInlineMode() {
+    return this.displayMode === 'inline';
+  }
+
+  get editorHeight() {
+    if (!this.isInlineMode) {
+      return 480;
+    }
+    if (typeof window === 'undefined') {
+      return 640;
+    }
+    return Math.max(window.innerHeight - 320, 480);
   }
 
   ngOnInit(): void {
     this.langService.getLanguage().subscribe(
       (lang: string) => {
         this.editorForm.get('lang').setValue(lang);
+        if (this.isInlineMode) {
+          this.init();
+        }
       }
     );
 
@@ -215,7 +243,9 @@ export class CodeEditorModalComponent implements OnInit {
       return;
     }
 
-    this.toggleSidebar();
+    if (!this.isInlineMode) {
+      this.toggleSidebar();
+    }
     this.canSubmit = false;
     const data = {
       sourceCode: this.editorForm.get('code').value,
@@ -238,6 +268,9 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   toggleSidebar(): void {
+    if (this.isInlineMode) {
+      return;
+    }
     if (!this.sidebarIsOpened) {
       this.openSidebar();
     } else {
@@ -246,33 +279,48 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   openSidebar() {
+    if (this.isInlineMode) {
+      this.init();
+      return;
+    }
     if (this.sidebarIsOpened) {
       return;
     }
-    this.coreSidebarService.getSidebarRegistry(this.sidebarName).toggleOpen();
+    this.coreSidebarService.getSidebarRegistry(this.sidebarName)?.toggleOpen();
     this.init();
   }
 
   closeSidebar() {
+    if (this.isInlineMode) {
+      return;
+    }
     if (!this.sidebarIsOpened) {
       return;
     }
     this.closeResultSidebar();
-    this.coreSidebarService.getSidebarRegistry(this.sidebarName).toggleOpen();
+    this.coreSidebarService.getSidebarRegistry(this.sidebarName)?.toggleOpen();
   }
 
   openResultSidebar() {
+    if (this.isInlineMode) {
+      this.showInlineResults = true;
+      return;
+    }
     if (this.resultSidebarIsOpened) {
       return;
     }
-    this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName).toggleOpen();
+    this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName)?.toggleOpen();
   }
 
   closeResultSidebar() {
+    if (this.isInlineMode) {
+      this.showInlineResults = false;
+      return;
+    }
     if (!this.resultSidebarIsOpened) {
       return;
     }
-    this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName).toggleOpen();
+    this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName)?.toggleOpen();
   }
 
   onKeyDown(event) {


### PR DESCRIPTION
## Summary
- add a dedicated problem detail layout that wraps the page with the standard header
- rebuild the problem page into a split workspace with scrolling statement and inline submission tools
- extend the shared code editor to support an inline mode with embedded results

## Testing
- npm run build *(fails: missing @angular/cli binary in node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68ec03e34f84832f9a8e1a24cec29c1f