### PR TITLE
Add problem favorites toggle and filter option

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -65,6 +65,9 @@ export const localeEn = {
     EXTREMAL: 'Extremal',
   },
   ProblemsSearchPlaceholder: 'Search by problem number or title',
+  ProblemsFavoritesOnly: 'Favorites',
+  AddToFavorites: 'Add to favorites',
+  RemoveFromFavorites: 'Remove from favorites',
   NgSelect: {
     NotFound: 'No options found',
     Loading: 'Loading...',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -54,6 +54,9 @@ export const localeRu = {
   Iq: 'IQ',
   Faq: 'FAQ',
   ProblemsSearchPlaceholder: 'Поиск по номеру или названию задачи',
+  ProblemsFavoritesOnly: 'Избранные',
+  AddToFavorites: 'Добавить в избранное',
+  RemoveFromFavorites: 'Убрать из избранного',
   NgSelect: {
     NotFound: 'Ничего не найдено',
     Loading: 'Загрузка...',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -55,6 +55,9 @@ export const localeUz = {
   Faq: 'FAQ',
   UserStatistics: 'Foydalanuvchi statistikasi',
   ProblemsSearchPlaceholder: 'Masala raqami yoki nomi bo‘yicha qidirish',
+  ProblemsFavoritesOnly: 'Sevimlilar',
+  AddToFavorites: 'Sevimlilarga qo‘shish',
+  RemoveFromFavorites: 'Sevimlilardan olib tashlash',
   NgSelect: {
     NotFound: 'Hech narsa topilmadi',
     Loading: 'Yuklanmoqda...',

--- a/src/app/modules/problems/models/problems.models.ts
+++ b/src/app/modules/problems/models/problems.models.ts
@@ -5,6 +5,7 @@ export interface ProblemUserInfo {
   hasSolved: boolean;
   voteType?: number | null;
   canViewSolution?: boolean;
+  isFavorite?: boolean;
 }
 
 export interface Problem {
@@ -73,6 +74,7 @@ export interface Topic {
 
 export interface ProblemsFilter {
   title: string;
+  search?: string;
   tags: Array<number>;
   difficulty: number;
   status: number;
@@ -83,6 +85,7 @@ export interface ProblemsFilter {
   partialSolvable: boolean;
   category: Categories;
   ordering: string,
+  favorites?: boolean;
 }
 
 export interface StudyPlanDay {

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -1,6 +1,26 @@
 <div class="content-wrapper container-xxl p-0">
   <div class="content-body">
     <app-content-header [contentHeader]="contentHeader">
+      @if (isAuthenticated) {
+        <button
+          class="btn btn-primary-light btn-wave me-1 favorite-toggle"
+          type="button"
+          [disabled]="favoriteLoading"
+          (click)="toggleFavorite()"
+          [attr.aria-label]="problem?.userInfo?.isFavorite ? ('RemoveFromFavorites' | translate) : ('AddToFavorites' | translate)"
+          ngbTooltip="{{ problem?.userInfo?.isFavorite ? ('RemoveFromFavorites' | translate) : ('AddToFavorites' | translate) }}"
+        >
+          @if (favoriteLoading) {
+            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+          } @else {
+            <kep-icon
+              name="star"
+              color="warning"
+              [type]="problem?.userInfo?.isFavorite ? 'solid' : null"
+            />
+          }
+        </button>
+      }
       <div class="btn-group" role="group">
         <button
           class="btn btn-primary-light btn-wave"

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -22,7 +22,7 @@ import { ContentHeaderModule } from '@shared/ui/components/content-header/conten
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 
 import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
-import { take } from 'rxjs/operators';
+import { finalize, take } from 'rxjs/operators';
 import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
 
 @Component({
@@ -59,6 +59,7 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
 
   public submitEvent = new Subject();
   public checkInput = '';
+  public favoriteLoading = false;
   constructor(
     public service: ProblemsApiService,
     public api: ApiService,
@@ -114,6 +115,32 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
         ]
       }
     };
+  }
+
+  toggleFavorite() {
+    if (!this.problem?.userInfo || this.favoriteLoading) {
+      return;
+    }
+
+    const isFavorite = !!this.problem.userInfo.isFavorite;
+    const request$ = isFavorite
+      ? this.service.removeProblemFromFavorites(this.problem.id)
+      : this.service.addProblemToFavorites(this.problem.id);
+
+    this.favoriteLoading = true;
+    request$.pipe(
+      finalize(() => {
+        this.favoriteLoading = false;
+        this.cdr.markForCheck();
+      })
+    ).subscribe({
+      next: () => {
+        this.problem.userInfo.isFavorite = !isFavorite;
+      },
+      error: () => {
+        this.toastr.error('Error');
+      }
+    });
   }
 
   activeIdChange(index: number) {

--- a/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.html
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.html
@@ -9,7 +9,7 @@
   <div class="card-body">
     <form [formGroup]="filterForm">
       <div class="row g-2">
-        <div class="col-lg-6 col-md-12">
+        <div class="col-lg-5 col-md-12">
           <div class="mb-1">
             <input
               class="form-control"
@@ -18,6 +18,22 @@
               placeholder="{{ 'ProblemsSearchPlaceholder' | translate }}"
               type="text"
             />
+          </div>
+        </div>
+
+        <div class="col-lg-1 col-md-6">
+          <div class="mb-1 d-flex align-items-center h-100 favorites-switch">
+            <div class="form-check form-switch mb-0">
+              <input
+                class="form-check-input"
+                type="checkbox"
+                id="problems-favorites-only"
+                formControlName="favorites"
+              >
+              <label class="form-check-label" for="problems-favorites-only">
+                {{ 'ProblemsFavoritesOnly' | translate }}
+              </label>
+            </div>
           </div>
         </div>
 

--- a/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.scss
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.scss
@@ -1,20 +1,19 @@
 @import 'styles/kep-imports';
-//
-//.tags-dropdown {
-//  --bs-dropdown-padding-x: 0;
-//  --bs-dropdown-padding-y: 0;
-//
-//  --bs-dropdown-bg: white;
-//
-//  @include dark-layout {
-//    --bs-dropdown-bg: #{$theme-dark-card-bg};
-//  }
-//}
-//
-//.select-tags {
-//  background: white;
-//
-//  @include dark-layout {
-//    background: inherit;
-//  }
-//}
+
+.favorites-switch {
+  .form-check {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0;
+  }
+
+  .form-check-input {
+    cursor: pointer;
+  }
+
+  .form-check-label {
+    font-size: 0.8125rem;
+    white-space: nowrap;
+  }
+}

--- a/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.ts
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-filter/section-problems-filter.component.ts
@@ -46,6 +46,7 @@ export class SectionProblemsFilterComponent extends BaseComponent implements OnI
     status: new FormControl(),
     ordering: new FormControl(),
     lang: new FormControl(),
+    favorites: new FormControl(false),
   });
 
   public tags: Array<Tag> = [];
@@ -91,11 +92,21 @@ export class SectionProblemsFilterComponent extends BaseComponent implements OnI
       queryParams.tags = [queryParams.tags];
     }
 
+    if (queryParams.favorites !== undefined) {
+      queryParams.favorites = queryParams.favorites === true
+        || queryParams.favorites === 'true'
+        || queryParams.favorites === 1
+        || queryParams.favorites === '1';
+    }
+
     this.filterForm.patchValue(queryParams, {emitEvent: false});
 
     this.filterForm.valueChanges.pipe(takeUntil(this._unsubscribeAll)).subscribe(
-      (filterValue: ProblemsFilter) => {
-        this.filterService.updateFilter(filterValue);
+      (filterValue: Partial<ProblemsFilter>) => {
+        this.filterService.updateFilter({
+          ...filterValue,
+          favorites: filterValue.favorites || false,
+        });
       }
     );
 

--- a/src/app/modules/problems/pages/problems/sections/section-problems-table/section-problems-table.component.ts
+++ b/src/app/modules/problems/pages/problems/sections/section-problems-table/section-problems-table.component.ts
@@ -67,9 +67,11 @@ export class SectionProblemsTableComponent extends BaseTablePageComponent<Proble
       (filter: ProblemsFilter) => {
         this.pageNumber = 1;
         this.reloadPage();
-        this.updateQueryParams({
+        const filterParams = {
           ...filter,
-        }, {
+          favorites: filter.favorites ? true : null,
+        };
+        this.updateQueryParams(filterParams, {
           replaceUrl: true,
         });
       }
@@ -79,16 +81,26 @@ export class SectionProblemsTableComponent extends BaseTablePageComponent<Proble
       queryParams.tags = [queryParams.tags];
     }
 
+    if (queryParams.favorites !== undefined) {
+      queryParams.favorites = queryParams.favorites === true
+        || queryParams.favorites === 'true'
+        || queryParams.favorites === 1
+        || queryParams.favorites === '1';
+    }
+
     this.filterService.updateFilter(queryParams, false);
     setTimeout(() => this.reloadPage());
   }
 
   override getPage(): Observable<PageResult<Problem>> {
+    const filterParams = {
+      ...this.filter,
+      favorites: this.filter.favorites ? true : null,
+      ordering: this.filter.ordering || this.ordering,
+    };
+
     return this.service.getProblems({
-      ...{
-        ...this.filter,
-        ordering: this.filter.ordering || this.ordering,
-      },
+      ...filterParams,
       page: this.pageNumber,
       pageSize: this.pageSize,
     }).pipe(

--- a/src/app/modules/problems/services/problems-api.service.ts
+++ b/src/app/modules/problems/services/problems-api.service.ts
@@ -28,6 +28,11 @@ export class ProblemsApiService {
       // @ts-ignore
       params.tags = params.tags.join(',');
     }
+    if (!params.favorites) {
+      delete params.favorites;
+    } else {
+      params.favorites = true;
+    }
     return this.api.get('problems', params);
   }
 
@@ -132,6 +137,14 @@ export class ProblemsApiService {
 
   problemDislike(problemId: number) {
     return this.api.post(`problems/${problemId}/dislike/`);
+  }
+
+  addProblemToFavorites(problemId: number) {
+    return this.api.post(`problems/${problemId}/add-favorites`);
+  }
+
+  removeProblemFromFavorites(problemId: number) {
+    return this.api.delete(`problems/${problemId}/delete-favorites`);
   }
 
   getTopics() {

--- a/src/app/modules/problems/services/problems-filter.service.ts
+++ b/src/app/modules/problems/services/problems-filter.service.ts
@@ -4,6 +4,7 @@ import { ProblemsFilter } from '../models/problems.models';
 
 export const DEFAULT_FILTER: ProblemsFilter = {
   title: null,
+  search: null,
   tags: [],
   difficulty: null,
   status: null,
@@ -14,6 +15,7 @@ export const DEFAULT_FILTER: ProblemsFilter = {
   partialSolvable: null,
   category: null,
   ordering: null,
+  favorites: false,
 };
 
 @Injectable({


### PR DESCRIPTION
## Summary
- add a favorites toggle button to problem detail pages that calls the new favorite API endpoints
- add a favorites-only filter switch to the problems list, wiring the query params and service calls
- translate the new UI labels into English, Russian, and Uzbek

## Testing
- npm run lint *(fails: ng not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0a267734832fbb0e7c1aa9561772