### PR TITLE
feat: redesign problem detail layout

### DIFF
--- a/src/app/modules/problems/components/problem-code-editor/problem-code-editor.component.html
+++ b/src/app/modules/problems/components/problem-code-editor/problem-code-editor.component.html
@@ -1,0 +1,245 @@
+<kep-card
+  class="problem-code-editor-card"
+  customClass="problem-code-editor-card"
+  [cardHeight]="'100%'"
+>
+  <div
+    class="problem-code-editor"
+    tabindex="0"
+    (keydown)="onKeyDown($event)"
+  >
+    <div class="problem-code-editor__header">
+      <div class="problem-code-editor__title">
+        <h5 class="mb-0">{{ 'CodeEditor.Editor' | translate }}</h5>
+        <div class="problem-code-editor__hotkeys text-muted">
+          <span>Alt + Enter</span>
+          <small>{{ 'CodeEditor.Submit' | translate }}</small>
+        </div>
+      </div>
+      <div class="problem-code-editor__selectors">
+        <div class="problem-code-editor__selector">
+          <label class="form-label">{{ 'Language' | translate }}</label>
+          <ng-select
+            [clearable]="false"
+            [formControl]="editorForm.controls.lang"
+            (change)="langChange($event)"
+          >
+            @for (availableLanguage of availableLanguages; track availableLanguage) {
+              <ng-option [value]="availableLanguage.lang">
+                {{ availableLanguage.langFull || availableLanguage.lang }}
+              </ng-option>
+            }
+          </ng-select>
+        </div>
+
+        @if (sampleTests?.length) {
+          <div class="problem-code-editor__selector">
+            <label class="form-label">{{ 'CodeEditor.SampleTest' | translate }}</label>
+            <ng-select
+              [clearable]="false"
+              [formControl]="editorForm.controls.testCaseNumber"
+              (change)="onSampleTestChange()"
+            >
+              @for (sampleTest of sampleTests; track sampleTest; let i = $index) {
+                <ng-option [value]="i + 1">
+                  TC #{{ i + 1 }}
+                </ng-option>
+              }
+            </ng-select>
+          </div>
+        }
+      </div>
+    </div>
+
+    <div class="problem-code-editor__body">
+      <div class="problem-code-editor__editor">
+        <monaco-editor
+          [formControl]="editorForm.controls.code"
+          [lang]="editorForm.controls.lang.value"
+          [height]="'100%'"
+        ></monaco-editor>
+      </div>
+
+      <div class="problem-code-editor__panels">
+        <div class="problem-code-editor__panel" [class.problem-code-editor__panel--disabled]="isSelectedLangText()">
+          <div class="problem-code-editor__panel-header">
+            <h6 class="mb-0">{{ 'CodeEditor.Input' | translate }}</h6>
+          </div>
+          <textarea
+            class="form-control"
+            rows="5"
+            [readonly]="isSelectedLangText()"
+            [formControl]="editorForm.controls.input"
+          ></textarea>
+        </div>
+
+        <div class="problem-code-editor__panel">
+          <div class="problem-code-editor__panel-header">
+            <h6 class="mb-0">{{ 'CodeEditor.Output' | translate }}</h6>
+          </div>
+          <textarea
+            class="form-control"
+            rows="5"
+            readonly
+            [formControl]="editorForm.controls.output"
+          ></textarea>
+        </div>
+
+        <div class="problem-code-editor__panel">
+          <div class="problem-code-editor__panel-header d-flex align-items-center justify-content-between">
+            <h6 class="mb-0">{{ 'CodeEditor.Answer' | translate }}</h6>
+            @if (answerForInputEnabled) {
+              <kepcoin-spend-swal
+                (success)="answerForInput($event)"
+                [customContent]="true"
+                [purchaseUrl]="'problems/' + problem?.id + '/answer-for-input/'"
+                [requestBody]="{input_data: editorForm.get('input').value}"
+                [value]="1"
+              >
+                <button class="btn btn-outline-dark btn-sm" type="button">
+                  @if (isAnswerForInput) {
+                    <span class="spinner-border spinner-border-sm" role="status"></span>
+                  } @else {
+                    <i data-feather="check-square"></i>
+                  }
+                  {{ 'CodeEditor.AnswerForInput' | translate }}
+                </button>
+              </kepcoin-spend-swal>
+            }
+          </div>
+          <textarea
+            class="form-control"
+            rows="5"
+            readonly
+            [formControl]="editorForm.controls.answer"
+          ></textarea>
+        </div>
+      </div>
+    </div>
+
+    <div class="problem-code-editor__actions">
+      <div class="problem-code-editor__actions-left">
+        @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
+          <kepcoin-spend-swal
+            (success)="checkSamplesPurchaseSuccess()"
+            [customContent]="true"
+            [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
+            [value]="100"
+          >
+            <button class="btn btn-outline-dark" type="button">
+              {{ 'CodeEditor.CheckSamples' | translate }}
+            </button>
+          </kepcoin-spend-swal>
+        } @else {
+          <button
+            class="btn btn-outline-dark"
+            type="button"
+            (click)="checkSamples()"
+            [disabled]="isCheckSamples"
+            ngbTooltip="Alt+Z"
+          >
+            @if (isCheckSamples) {
+              <span class="spinner-border spinner-border-sm" role="status"></span>
+            } @else {
+              <i data-feather="terminal"></i>
+            }
+            {{ 'CodeEditor.CheckSamples' | translate }}
+          </button>
+        }
+
+        @if (!isSelectedLangText()) {
+          <button
+            class="btn btn-outline-dark"
+            type="button"
+            (click)="run()"
+            [disabled]="isRunning"
+            ngbTooltip="Alt+X"
+          >
+            @if (isRunning) {
+              <span class="spinner-border spinner-border-sm" role="status"></span>
+            } @else {
+              <i data-feather="play"></i>
+            }
+            {{ 'CodeEditor.Run' | translate }}
+          </button>
+        }
+      </div>
+
+      <div class="problem-code-editor__actions-right">
+        <button
+          class="btn btn-primary"
+          type="button"
+          (click)="submit()"
+          [disabled]="!editorForm.valid || !canSubmit"
+          ngbTooltip="Alt+Enter"
+        >
+          <i data-feather="send"></i>
+          {{ 'CodeEditor.Submit' | translate }}
+        </button>
+      </div>
+    </div>
+
+    @if (showResultsPanel) {
+      <div class="problem-code-editor__results">
+        <div class="problem-code-editor__results-header d-flex justify-content-between align-items-center">
+          <h6 class="mb-0">{{ 'Result' | translate }}</h6>
+          <button class="btn btn-sm btn-link" type="button" (click)="showResultsPanel = false">
+            {{ 'Close' | translate }}
+          </button>
+        </div>
+        @if (isCheckSamples) {
+          <div class="problem-code-editor__results-loading">
+            <spinner></spinner>
+          </div>
+        } @else if (checkSamplesResult?.length) {
+          <div class="problem-code-editor__results-list">
+            @for (result of checkSamplesResult; track result; let i = $index) {
+              <div class="problem-code-editor__result-item" [ngClass]="{
+                'problem-code-editor__result-item--accepted': result.verdict === Verdicts.Accepted,
+                'problem-code-editor__result-item--failed': result.verdict !== Verdicts.Accepted
+              }">
+                <div class="problem-code-editor__result-header">
+                  <span class="fw-semibold">TC #{{ i + 1 }}</span>
+                  <span class="badge" [ngClass]="{
+                    'bg-success': result.verdict === Verdicts.Accepted,
+                    'bg-danger': result.verdict !== Verdicts.Accepted
+                  }">
+                    {{ result.verdict | verdictShortTitle }}
+                  </span>
+                </div>
+                @if (result.input) {
+                  <div class="problem-code-editor__result-section">
+                    <div class="problem-code-editor__result-label">{{ 'CodeEditor.Input' | translate }}</div>
+                    <pre>{{ result.input }}</pre>
+                  </div>
+                }
+                @if (result.answer) {
+                  <div class="problem-code-editor__result-section">
+                    <div class="problem-code-editor__result-label">{{ 'CodeEditor.Answer' | translate }}</div>
+                    <pre>{{ result.answer }}</pre>
+                  </div>
+                }
+                @if (result.output) {
+                  <div class="problem-code-editor__result-section">
+                    <div class="problem-code-editor__result-label">{{ 'CodeEditor.Output' | translate }}</div>
+                    <pre>{{ result.output }}</pre>
+                  </div>
+                }
+                @if (result.error) {
+                  <div class="problem-code-editor__result-section">
+                    <div class="problem-code-editor__result-label">Error</div>
+                    <pre>{{ result.error }}</pre>
+                  </div>
+                }
+              </div>
+            }
+          </div>
+        } @else {
+          <div class="problem-code-editor__results-empty text-muted">
+            {{ 'NoData' | translate }}
+          </div>
+        }
+      </div>
+    }
+  </div>
+</kep-card>

--- a/src/app/modules/problems/components/problem-code-editor/problem-code-editor.component.scss
+++ b/src/app/modules/problems/components/problem-code-editor/problem-code-editor.component.scss
@@ -1,0 +1,206 @@
+@import 'styles/kep-imports';
+
+:host {
+  display: block;
+  height: 100%;
+}
+
+.problem-code-editor-card {
+  height: 100%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.problem-code-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  height: 100%;
+}
+
+.problem-code-editor__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  @include media-breakpoint-up(md) {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+  }
+}
+
+.problem-code-editor__title {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.problem-code-editor__hotkeys {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  line-height: 1.1;
+
+  span {
+    font-weight: 600;
+  }
+}
+
+.problem-code-editor__selectors {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  @include media-breakpoint-up(md) {
+    flex-direction: row;
+  }
+}
+
+.problem-code-editor__selector {
+  flex: 1;
+  min-width: 200px;
+}
+
+.problem-code-editor__body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 0;
+}
+
+.problem-code-editor__editor {
+  flex: 1 1 auto;
+  min-height: 0;
+
+  monaco-editor {
+    display: block;
+    height: 100%;
+  }
+}
+
+.problem-code-editor__panels {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.problem-code-editor__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background-color: rgba($primary, 0.04);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  transition: background-color 0.2s ease;
+
+  textarea {
+    resize: vertical;
+  }
+
+  &--disabled {
+    opacity: 0.6;
+  }
+}
+
+.problem-code-editor__panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.problem-code-editor__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  @include media-breakpoint-up(md) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .btn {
+    min-width: 140px;
+  }
+}
+
+.problem-code-editor__actions-left {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.problem-code-editor__actions-right {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.problem-code-editor__results {
+  border: 1px solid rgba($black, 0.08);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  background-color: rgba($primary, 0.02);
+  max-height: 280px;
+  overflow: auto;
+}
+
+.problem-code-editor__results-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.problem-code-editor__result-item {
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  border: 1px solid transparent;
+  background-color: $white;
+
+  @include dark-layout {
+    background-color: rgba($white, 0.05);
+  }
+
+  &--accepted {
+    border-color: rgba($success, 0.4);
+  }
+
+  &--failed {
+    border-color: rgba($danger, 0.4);
+  }
+
+  pre {
+    margin-bottom: 0;
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+}
+
+.problem-code-editor__result-section {
+  margin-top: 0.5rem;
+}
+
+.problem-code-editor__result-label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.problem-code-editor__results-loading,
+.problem-code-editor__results-empty {
+  padding: 1.5rem 0;
+  text-align: center;
+}
+
+@media (max-width: 767.98px) {
+  .problem-code-editor-card {
+    padding: 1rem;
+  }
+
+  .problem-code-editor__panel textarea {
+    min-height: 160px;
+  }
+}

--- a/src/app/modules/problems/components/problem-code-editor/problem-code-editor.component.ts
+++ b/src/app/modules/problems/components/problem-code-editor/problem-code-editor.component.ts
@@ -1,0 +1,296 @@
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { AvailableLanguage, Problem, SampleTest } from '@problems/models/problems.models';
+import { AttemptLangs, Verdicts } from '@problems/constants';
+import { ApiService } from '@core/data-access/api.service';
+import { ToastrService } from 'ngx-toastr';
+import { TranslateService } from '@ngx-translate/core';
+import { WebsocketService } from '@shared/services/websocket';
+import { LanguageService } from '@problems/services/language.service';
+import { TemplateCodeService } from '@shared/services/template-code.service';
+import { AuthService } from '@auth';
+import { CValidators } from '@shared/c-validators/c-validators';
+import { paramsMapper } from '@shared/utils';
+import { findAvailableLang } from '@problems/utils';
+import { CoreCommonModule } from '@core/common.module';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
+import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
+import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule } from '@ngx-translate/core';
+import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { KepcoinSpendSwalModule } from '@shared/components/kepcoin-spend-swal/kepcoin-spend-swal.module';
+import { NgbAccordionModule } from '@ng-bootstrap/ng-bootstrap';
+import { VerdictShortTitlePipe } from '@problems/pipes/verdict-short-title.pipe';
+import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
+
+interface CheckSamplesResultOne {
+  verdict: number;
+  input: string;
+  output: string;
+  answer: string;
+  error?: string;
+}
+
+@Component({
+  selector: 'problem-code-editor',
+  standalone: true,
+  imports: [
+    CoreCommonModule,
+    ReactiveFormsModule,
+    KepCardComponent,
+    MonacoEditorComponent,
+    NgSelectModule,
+    TranslateModule,
+    NgbTooltipModule,
+    KepcoinSpendSwalModule,
+    NgbAccordionModule,
+    VerdictShortTitlePipe,
+    SpinnerComponent,
+  ],
+  templateUrl: './problem-code-editor.component.html',
+  styleUrl: './problem-code-editor.component.scss'
+})
+export class ProblemCodeEditorComponent implements OnInit, OnChanges {
+  @Input() submitUrl: string;
+  @Input() submitParams: any = {};
+  @Input() sampleTests: Array<SampleTest> = [];
+  @Input() uniqueName = 'problem-code-editor';
+  @Input() answerForInputEnabled = false;
+  @Input() availableLanguages: Array<AvailableLanguage> = [];
+  @Input() problem: Problem;
+
+  @Output() submitted = new EventEmitter<void>();
+
+  public canSubmit = true;
+  public isRunning = false;
+  public isAnswerForInput = false;
+  public isCheckSamples = false;
+  public showResultsPanel = false;
+
+  public editorForm = new FormGroup({
+    code: new FormControl('', [CValidators.maxLength({ value: 65536 })]),
+    input: new FormControl('', [CValidators.maxLength({ value: 2048 })]),
+    lang: new FormControl('', []),
+    output: new FormControl('', []),
+    answer: new FormControl('', []),
+    testCaseNumber: new FormControl(1),
+  });
+
+  public checkSamplesResult: Array<CheckSamplesResultOne> = [];
+  public readonly AttemptLangs = AttemptLangs;
+  protected readonly Verdicts = Verdicts;
+
+  constructor(
+    public api: ApiService,
+    public toastr: ToastrService,
+    public translateService: TranslateService,
+    public wsService: WebsocketService,
+    public langService: LanguageService,
+    public templateCodeService: TemplateCodeService,
+    public authService: AuthService,
+  ) {
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if ('availableLanguages' in changes && this.availableLanguages?.length && !this.editorForm.controls.lang.value) {
+      this.editorForm.controls.lang.setValue(this.availableLanguages[0].lang, { emitEvent: false });
+    }
+
+    if ('sampleTests' in changes) {
+      this.onSampleTestChange();
+    }
+  }
+
+  ngOnInit(): void {
+    this.langService.getLanguage().subscribe(
+      (lang: AttemptLangs) => {
+        if (!this.availableLanguages?.length) {
+          return;
+        }
+        const available = findAvailableLang(this.availableLanguages, lang) || this.availableLanguages[0];
+        const targetLang = available?.lang || lang;
+        this.editorForm.controls.lang.setValue(targetLang, { emitEvent: false });
+        if (available?.lang !== lang) {
+          this.langService.setLanguage(targetLang);
+        }
+        this.init();
+      }
+    );
+
+    this.wsService.on('custom-test-result').subscribe(
+      (result: any) => {
+        let output = result.output + result.error;
+        output += `\n=========\nTime: ${ result.time }ms`;
+        output += `\nMemory: ${ result.memory }KB`;
+        this.isRunning = false;
+        this.editorForm.controls.output.setValue(output);
+      }
+    );
+
+    this.wsService.on('answer-for-input-result').subscribe(
+      (result: { answer: string }) => {
+        this.editorForm.controls.answer.setValue('Answer:\n' + result.answer);
+        this.isAnswerForInput = false;
+      }
+    );
+
+    this.wsService.on('check-sample-tests-result').subscribe(
+      (result: Array<CheckSamplesResultOne>) => {
+        this.checkSamplesResult = result;
+        this.isCheckSamples = false;
+        this.showResultsPanel = true;
+      }
+    );
+
+    this.editorForm.controls.code.valueChanges.subscribe(
+      (code: string) => {
+        if (!this.uniqueName) {
+          return;
+        }
+        const lang = this.editorForm.controls.lang.value as AttemptLangs;
+        if (!lang) {
+          return;
+        }
+        this.templateCodeService.save(this.uniqueName, lang, code || '');
+      }
+    );
+  }
+
+  init(): void {
+    if (!this.availableLanguages?.length) {
+      return;
+    }
+    const editorLang = this.editorForm.controls.lang.value as AttemptLangs;
+    const stored = this.templateCodeService.get(this.uniqueName, editorLang);
+    const fallback = findAvailableLang(this.availableLanguages, editorLang)?.codeTemplate
+      || this.availableLanguages[0]?.codeTemplate
+      || '';
+    this.editorForm.controls.code.setValue(stored || fallback || '', { emitEvent: false });
+    if (stored) {
+      this.templateCodeService.save(this.uniqueName, editorLang, stored);
+    }
+    this.onSampleTestChange();
+  }
+
+  langChange(lang: AttemptLangs): void {
+    this.langService.setLanguage(lang);
+    this.init();
+  }
+
+  onSampleTestChange(): void {
+    if (!this.sampleTests?.length) {
+      this.editorForm.controls.testCaseNumber.setValue(null, { emitEvent: false });
+      return;
+    }
+    const testCaseNumber = this.editorForm.controls.testCaseNumber.value || 1;
+    const sampleTest = this.sampleTests[testCaseNumber - 1] || this.sampleTests[0];
+    this.editorForm.controls.input.setValue(sampleTest?.input || '');
+    this.editorForm.controls.answer.setValue(sampleTest?.output || '');
+    this.editorForm.controls.output.setValue('');
+  }
+
+  run(): void {
+    if (this.isRunning) {
+      return;
+    }
+    this.isRunning = true;
+    this.editorForm.controls.output.setValue('');
+    const data = {
+      sourceCode: this.editorForm.controls.code.value,
+      lang: this.editorForm.controls.lang.value,
+      inputData: this.editorForm.controls.input.value,
+    };
+
+    this.api.post('problems/custom-test/', data).subscribe(
+      (result: any) => {
+        this.wsService.send('custom-test-add', result.id);
+      }
+    );
+
+    setTimeout(() => {
+      this.isRunning = false;
+    }, 5000);
+  }
+
+  answerForInput(result: { id: number }): void {
+    if (this.isAnswerForInput) {
+      return;
+    }
+    this.isAnswerForInput = true;
+    this.wsService.send('answer-for-input-add', result.id);
+    setTimeout(() => {
+      this.isAnswerForInput = false;
+    }, 15000);
+  }
+
+  submit(): void {
+    if (!this.canSubmit || !this.submitUrl) {
+      return;
+    }
+    this.canSubmit = false;
+    const data = {
+      sourceCode: this.editorForm.controls.code.value,
+      lang: this.editorForm.controls.lang.value,
+      ...this.submitParams,
+    };
+
+    this.api.post(this.submitUrl, data).subscribe(
+      () => {
+        const text = this.translateService.instant('SubmittedSuccess');
+        this.toastr.success('', text);
+        this.submitted.emit();
+        this.canSubmit = true;
+      },
+      () => {
+        this.canSubmit = true;
+      }
+    );
+  }
+
+  isSelectedLangText(): boolean {
+    return this.editorForm.controls.lang.value === AttemptLangs.TEXT;
+  }
+
+  onKeyDown(event: KeyboardEvent): void {
+    if (event.altKey && event.code === 'Enter') {
+      event.preventDefault();
+      this.submit();
+    }
+    if (event.altKey && event.code === 'KeyX') {
+      event.preventDefault();
+      this.run();
+    }
+    if (event.altKey && event.code === 'KeyZ') {
+      event.preventDefault();
+      this.checkSamples();
+    }
+  }
+
+  checkSamplesPurchaseSuccess(): void {
+    if (this.authService.currentUserValue?.permissions) {
+      this.authService.currentUserValue.permissions.canUseCheckSamples = true;
+    }
+  }
+
+  checkSamples(): void {
+    if (this.isCheckSamples || !this.problem) {
+      return;
+    }
+    this.isCheckSamples = true;
+    this.showResultsPanel = true;
+    const data = {
+      lang: this.editorForm.controls.lang.value,
+      sourceCode: this.editorForm.controls.code.value,
+    };
+    this.api.post(`problems/${ this.problem.id }/check-sample-tests`, paramsMapper(data)).subscribe(
+      (result) => {
+        this.wsService.send('check-sample-tests-add', result.id);
+      },
+      () => {
+        this.isCheckSamples = false;
+      }
+    );
+    setTimeout(() => this.isCheckSamples = false, 15000);
+  }
+}

--- a/src/app/modules/problems/layouts/problem-detail-layout/problem-detail-layout.component.html
+++ b/src/app/modules/problems/layouts/problem-detail-layout/problem-detail-layout.component.html
@@ -1,0 +1,20 @@
+<div class="problem-detail-layout">
+  <div class="problem-detail-layout__header">
+    <ng-content select="[problem-detail-header]"></ng-content>
+  </div>
+  <div class="problem-detail-layout__body">
+    <div class="problem-detail-layout__column problem-detail-layout__column--left">
+      <div class="problem-detail-layout__column-inner">
+        <ng-content select="[problem-detail-left]"></ng-content>
+      </div>
+    </div>
+    <div class="problem-detail-layout__column problem-detail-layout__column--right">
+      <div class="problem-detail-layout__column-inner">
+        <ng-content select="[problem-detail-right]"></ng-content>
+      </div>
+    </div>
+  </div>
+  <div class="problem-detail-layout__footer">
+    <ng-content select="[problem-detail-footer]"></ng-content>
+  </div>
+</div>

--- a/src/app/modules/problems/layouts/problem-detail-layout/problem-detail-layout.component.scss
+++ b/src/app/modules/problems/layouts/problem-detail-layout/problem-detail-layout.component.scss
@@ -1,0 +1,58 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.problem-detail-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: calc(100vh - var(--problem-layout-offset, 0px));
+  min-height: calc(100vh - var(--problem-layout-offset, 0px));
+}
+
+.problem-detail-layout__header,
+.problem-detail-layout__footer {
+  flex: 0 0 auto;
+}
+
+.problem-detail-layout__body {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 1rem;
+  min-height: 0;
+}
+
+.problem-detail-layout__column {
+  position: relative;
+  min-height: 0;
+}
+
+.problem-detail-layout__column-inner {
+  height: 100%;
+  overflow: auto;
+}
+
+@media (max-width: 1199.98px) {
+  .problem-detail-layout__body {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 991.98px) {
+  .problem-detail-layout {
+    height: auto;
+    min-height: 0;
+  }
+
+  .problem-detail-layout__body {
+    grid-template-columns: 1fr;
+    grid-auto-rows: auto;
+  }
+
+  .problem-detail-layout__column-inner {
+    max-height: none;
+    overflow: visible;
+  }
+}

--- a/src/app/modules/problems/layouts/problem-detail-layout/problem-detail-layout.component.ts
+++ b/src/app/modules/problems/layouts/problem-detail-layout/problem-detail-layout.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { NgClass } from '@angular/common';
+
+@Component({
+  selector: 'problem-detail-layout',
+  standalone: true,
+  imports: [NgClass],
+  templateUrl: './problem-detail-layout.component.html',
+  styleUrl: './problem-detail-layout.component.scss'
+})
+export class ProblemDetailLayoutComponent {
+}

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -1,177 +1,254 @@
-<div class="content-wrapper container-xxl p-0">
-  <div class="content-body">
-    <app-content-header [contentHeader]="contentHeader">
-      <div class="btn-group" role="group">
-        <button
-          class="btn btn-primary-light btn-wave"
-          type="button"
-          (click)="goToPreviousProblem()"
-          ngbTooltip="{{ 'PreviousProblem' | translate }}"
-        >
-          <kep-icon name="left"/>
-        </button>
-        <button
-          class="btn btn-primary-light btn-wave"
-          type="button"
-          (click)="goToNextProblem()"
-          ngbTooltip="{{ 'NextProblem' | translate }}"
-        >
-          <kep-icon name="right"/>
-        </button>
-      </div>
-    </app-content-header>
-    <section  class="mt-2">
-      <div class="row">
-        <div class="col-lg-9 col-md-12 col-sm-12">
-          <kep-card>
-            <div class="card-header">
-              <ul
-                #navWithIcons="ngbNav"
-                (activeIdChange)="activeIdChange($event)" [(activeId)]="activeId" [destroyOnHide]="false"
-                class="nav-tabs" ngbNav>
-                <li [ngbNavItem]="1">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
-                    {{ 'Problem' | translate }}
-                  </a>
-                  <ng-template ngbNavContent>
-                    <problem-description [problem]="problem"></problem-description>
-                  </ng-template>
-                </li>
-
-                <li [ngbNavItem]="2">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
-                    {{ 'Attempts' | translate }}
-                  </a>
-                  <ng-template ngbNavContent>
-                    <problem-attempts
-                      (hackSubmitted)="activeId = 3;"
-                      [problem]="problem"
-                      [submitEvent]="submitEvent?.asObservable()"
-                    >
-                    </problem-attempts>
-                  </ng-template>
-                </li>
-
-                @if (problem.hasCheckInput) {
-                  <li [ngbNavItem]="3" destroyOnHide="true">
-                    <a class="nav-link" ngbNavLink>
-                      <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
-                      {{ 'Hacks' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-hacks [problem]="problem"></problem-hacks>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (studyPlanId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
-                      <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (contestId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.ContestProblems | resourceById:contestId">
-                      <kep-icon name="contest" color="primary" type="duotone"/>
-                      {{ 'Contest' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-              </ul>
-
-              @if (isAuthenticated) {
-                <button (click)="codeEditorSidebarToggle()" class="btn btn-sm btn-primary">{{ 'Submit' | translate }}
-                </button>
-              }
-            </div>
-
-            <div class="card-footer">
-              <div [ngbNavOutlet]="navWithIcons"></div>
-            </div>
-          </kep-card>
-
-          @if (currentUser?.permissions.canCreateProblems) {
-            <div class="card">
-              <div class="card-header">
-                <div class="card-title">
-                  Check input
-                </div>
-              </div>
-              <div class="card-body">
-                <monaco-editor
-                  [lang]="'py'"
-                  class="mt-1"
-                  [ngModelOptions]="{standalone: true}"
-                  [(ngModel)]="checkInput"
-                ></monaco-editor>
-                <div class="btn mt-2 btn-primary btn-sm" (click)="saveCheckInput()">Save</div>
-              </div>
-            </div>
-          }
+<div class="problem-page content-wrapper container-xxl p-0" *ngIf="problem as problemData">
+  <problem-detail-layout>
+    <div problem-detail-header>
+      <div class="problem-page__header">
+        <div class="problem-page__breadcrumb">
+          <a [routerLink]="['/practice/problems']" class="problem-page__breadcrumb-link">{{ 'Problems' | translate }}</a>
+          <span class="problem-page__breadcrumb-separator">/</span>
+          <span class="problem-page__breadcrumb-current">#{{ problemData.id }}</span>
         </div>
 
-        <div class="col-lg-3 col-md-12 col-sm-12">
-          <problem-sidebar [problem]="problem"></problem-sidebar>
+        <div class="problem-page__title-row">
+          <div class="problem-page__title-block">
+            <div class="problem-page__title-line">
+              <span class="problem-page__id">#{{ problemData.id }}</span>
+              <h1 class="problem-page__title">{{ problemData.title }}</h1>
+              <span class="badge problem-page__difficulty bg-{{ problemData.difficulty | problemDifficultyColor }}">
+                {{ problemData.difficultyTitle }}
+              </span>
+            </div>
 
-          @if (isAuthenticated) {
+            <div class="problem-page__summary">
+              <div class="problem-page__summary-item">
+                <span class="problem-page__summary-label">{{ 'Attempts' | translate }}</span>
+                <span class="problem-page__summary-value">{{ problemData.attemptsCount | number }}</span>
+              </div>
+              <div class="problem-page__summary-item">
+                <span class="problem-page__summary-label">{{ 'Solved' | translate }}</span>
+                <span class="problem-page__summary-value text-success">{{ problemData.solved | number }}</span>
+              </div>
+              <div class="problem-page__summary-item">
+                <span class="problem-page__summary-label">{{ 'NotSolved' | translate }}</span>
+                <span class="problem-page__summary-value text-danger">{{ problemData.notSolved | number }}</span>
+              </div>
+            </div>
+
+            @if (problemData.tags?.length) {
+              <div class="problem-page__tags">
+                @for (tag of problemData.tags; track tag.id) {
+                  <span class="problem-page__tag">{{ tag.name }}</span>
+                }
+              </div>
+            }
+          </div>
+
+          <div class="problem-page__header-actions">
+            <div class="btn-group" role="group">
+              <button
+                class="btn btn-icon btn-outline-primary"
+                type="button"
+                (click)="goToPreviousProblem()"
+                ngbTooltip="{{ 'PreviousProblem' | translate }}"
+              >
+                <kep-icon name="left"/>
+              </button>
+              <button
+                class="btn btn-icon btn-outline-primary"
+                type="button"
+                (click)="goToNextProblem()"
+                ngbTooltip="{{ 'NextProblem' | translate }}"
+              >
+                <kep-icon name="right"/>
+              </button>
+            </div>
+            <button
+              class="btn btn-outline-secondary"
+              type="button"
+              (click)="openStatisticsModal(statisticsModal)"
+            >
+              <i data-feather="bar-chart"></i>
+              {{ 'Statistics' | translate }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div problem-detail-left>
+      <div class="problem-page__left-pane">
+        <div class="problem-page__info-card">
+          <problem-info-card [problem]="problemData" [hideCodeGolf]="true"></problem-info-card>
+        </div>
+
+        <kep-card customClass="problem-page__tabs-card">
+          <div class="problem-page__tabs">
+            <ul
+              #navWithIcons="ngbNav"
+              (activeIdChange)="activeIdChange($event)"
+              [(activeId)]="activeId"
+              [destroyOnHide]="false"
+              class="problem-page__tab-list"
+              ngbNav
+            >
+              <li [ngbNavItem]="1">
+                <a class="problem-page__tab-link" ngbNavLink>
+                  <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
+                  {{ 'Problem' | translate }}
+                </a>
+                <ng-template ngbNavContent>
+                  <problem-description [problem]="problemData"></problem-description>
+                </ng-template>
+              </li>
+
+              <li [ngbNavItem]="2">
+                <a class="problem-page__tab-link" ngbNavLink>
+                  <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
+                  {{ 'Attempts' | translate }}
+                </a>
+                <ng-template ngbNavContent>
+                  <problem-attempts
+                    (hackSubmitted)="activeId = 3;"
+                    [problem]="problemData"
+                    [submitEvent]="submitEvent?.asObservable()"
+                  >
+                  </problem-attempts>
+                </ng-template>
+              </li>
+
+              @if (problemData.hasCheckInput) {
+                <li [ngbNavItem]="3" destroyOnHide="true">
+                  <a class="problem-page__tab-link" ngbNavLink>
+                    <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
+                    {{ 'Hacks' | translate }}
+                  </a>
+                  <ng-template ngbNavContent>
+                    <problem-hacks [problem]="problemData"></problem-hacks>
+                  </ng-template>
+                </li>
+              }
+
+              @if (studyPlanId) {
+                <li [ngbNavItem]="4">
+                  <a
+                    class="problem-page__tab-link"
+                    ngbNavLink
+                    [routerLink]="Resources.StudyPlan | resourceById:studyPlanId"
+                  >
+                    <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
+                  </a>
+                  <ng-template ngbNavContent>
+                    <problem-description [problem]="problemData"></problem-description>
+                  </ng-template>
+                </li>
+              }
+
+              @if (contestId) {
+                <li [ngbNavItem]="5">
+                  <a
+                    class="problem-page__tab-link"
+                    ngbNavLink
+                    [routerLink]="Resources.ContestProblems | resourceById:contestId"
+                  >
+                    <kep-icon name="contest" color="primary" type="duotone"/>
+                    {{ 'Contest' | translate }}
+                  </a>
+                  <ng-template ngbNavContent>
+                    <problem-description [problem]="problemData"></problem-description>
+                  </ng-template>
+                </li>
+              }
+            </ul>
+          </div>
+          <div class="problem-page__tab-content">
+            <div [ngbNavOutlet]="navWithIcons"></div>
+          </div>
+        </kep-card>
+
+        @if (isAuthenticated) {
+          <div class="problem-page__submit-card">
             <problem-submit-card
-              [availableLanguages]="problem.availableLanguages"
-              [submitUrl]="'problems/' + problem.id + '/submit/'"
+              [availableLanguages]="problemData.availableLanguages"
+              [submitUrl]="'problems/' + problemData.id + '/submit/'"
               (submitted)="onSubmit()"
             />
-          }
-        </div>
+          </div>
+        }
 
+        @if (currentUser?.permissions.canCreateProblems) {
+          <kep-card customClass="problem-page__check-input-card">
+            <div class="problem-page__check-input-header">
+              <div class="problem-page__check-input-title">Check input</div>
+              <button class="btn btn-sm btn-outline-primary" type="button" (click)="saveCheckInput()">
+                {{ 'Save' | translate }}
+              </button>
+            </div>
+            <monaco-editor
+              [lang]="'py'"
+              [height]="300"
+              class="problem-page__check-editor"
+              [ngModelOptions]="{standalone: true}"
+              [(ngModel)]="checkInput"
+            ></monaco-editor>
+          </kep-card>
+        }
       </div>
+    </div>
 
-      @if (problem && isAuthenticated) {
-        <code-editor-modal
-          [customClass]="'tour-step-2'"
-          [uniqueName]="'problem-' + problem.id"
-          [sampleTests]="problem.sampleTests"
-          [submitUrl]="'problems/' + problem.id + '/submit/'"
-          [problem]="problem"
-          [answerForInputEnabled]="problem.hasSolution && problem.hasCheckInput"
-          [availableLanguages]="problem.availableLanguages"
-          (submittedEvent)="onSubmit()"></code-editor-modal>
-      }
-    </section>
-  </div>
+    <div problem-detail-right>
+      <div class="problem-page__right-pane">
+        @if (problemData && isAuthenticated) {
+          <problem-code-editor
+            [uniqueName]="'problem-' + problemData.id"
+            [sampleTests]="problemData.sampleTests"
+            [submitUrl]="'problems/' + problemData.id + '/submit/'"
+            [problem]="problemData"
+            [answerForInputEnabled]="problemData.hasSolution && problemData.hasCheckInput"
+            [availableLanguages]="problemData.availableLanguages"
+            (submitted)="onSubmit()"
+          ></problem-code-editor>
+        } @else {
+          <kep-card customClass="problem-page__signin-card">
+            <div class="problem-page__signin">
+              <h5>Log in to solve this problem</h5>
+              <p class="text-muted">Create an account or sign in to submit your code.</p>
+              <a class="btn btn-primary" [routerLink]="['/auth/login']">{{ 'Login' | translate }}</a>
+            </div>
+          </kep-card>
+        }
+      </div>
+    </div>
+
+    <div problem-detail-footer>
+      <tour-css></tour-css>
+      <ng-select-css></ng-select-css>
+    </div>
+  </problem-detail-layout>
 </div>
 
-<tour-css></tour-css>
-<ng-select-css></ng-select-css>
-
-<!--<div class="col-lg-6 col-md-12 col-sm-12">-->
-<!--  <kep-card>-->
-<!--    <div class="card-header p-2">-->
-<!--      <div class="card-title">-->
-<!--        <kep-icon name="square-brackets" color="primary" type="duotone"/>-->
-<!--        {{ 'Code' | translate }}-->
-<!--      </div>-->
-<!--    </div>-->
-
-<!--    <ng-select-->
-<!--      [appendTo]="'body'"-->
-<!--      [clearable]="false">-->
-<!--      @for (availableLanguage of problem.availableLanguages; track availableLanguage) {-->
-<!--        <ng-option-->
-<!--          [value]="availableLanguage.lang">-->
-<!--          {{ availableLanguage.langFull || availableLanguage.lang }}-->
-<!--        </ng-option>-->
-<!--      }-->
-<!--    </ng-select>-->
-<!--    <monaco-editor lang="py"/>-->
-<!--  </kep-card>-->
-<!--</div>-->
+<ng-template #statisticsModal let-modal>
+  <div class="modal-header">
+    <h4 class="modal-title">{{ 'Statistics' | translate }}</h4>
+    <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss()"></button>
+  </div>
+  <div class="modal-body">
+    @if (isStatisticsLoading) {
+      <div class="d-flex justify-content-center py-4">
+        <div class="spinner-border text-primary" role="status">
+          <span class="visually-hidden">{{ 'Loading' | translate }}</span>
+        </div>
+      </div>
+    } @else if (statistics) {
+      <problem-sidebar-statistics
+        [problem]="problem"
+        [statistics]="statistics"
+      ></problem-sidebar-statistics>
+      <div class="mt-3">
+        <problem-sidebar-top-attempts [topAttempts]="statistics.topAttempts"></problem-sidebar-top-attempts>
+      </div>
+    } @else {
+      <div class="text-center text-muted py-4">
+        {{ 'NoData' | translate }}
+      </div>
+    }
+  </div>
+</ng-template>

--- a/src/app/modules/problems/pages/problem/problem.component.scss
+++ b/src/app/modules/problems/pages/problem/problem.component.scss
@@ -1,19 +1,248 @@
-.card .card-header {
-  padding: 1rem !important;
-  padding-bottom: 0 !important;
+@import 'styles/kep-imports';
+
+:host {
+  --problem-layout-offset: 5rem;
+  display: block;
+}
+
+.problem-page {
+  height: 100%;
+  padding: 1.5rem 2rem;
+
+  @include media-breakpoint-down(lg) {
+    padding: 1rem;
+  }
+}
+
+.problem-page__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 0 0 0.5rem;
+  border-bottom: 1px solid rgba($black, 0.05);
+}
+
+.problem-page__breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.problem-page__breadcrumb-link {
+  color: $primary;
+  font-weight: 600;
+}
+
+.problem-page__breadcrumb-current {
+  font-weight: 500;
+}
+
+.problem-page__title-row {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  @include media-breakpoint-up(lg) {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+}
+
+.problem-page__title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 960px;
+}
+
+.problem-page__title-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.problem-page__id {
+  font-weight: 700;
+  color: $primary;
+}
+
+.problem-page__title {
+  margin: 0;
+  font-size: clamp(1.5rem, 2.6vw, 2rem);
+  font-weight: 700;
+}
+
+.problem-page__difficulty {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+}
+
+.problem-page__summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.problem-page__summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.problem-page__summary-label {
+  font-size: 0.85rem;
+  color: rgba($black, 0.6);
+}
+
+.problem-page__summary-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.problem-page__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.problem-page__tag {
+  background: rgba($primary, 0.08);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.problem-page__header-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-end;
+
+  @include media-breakpoint-up(md) {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .btn-group {
+    display: flex;
+  }
+
+  .btn-icon {
+    width: 42px;
+    height: 42px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+.problem-page__left-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding-right: 1rem;
+
+  @include media-breakpoint-down(lg) {
+    padding-right: 0;
+  }
+}
+
+.problem-page__tabs-card {
+  padding: 1.5rem;
+}
+
+.problem-page__tab-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  border-bottom: 1px solid rgba($black, 0.05);
+  padding-bottom: 0.75rem;
+
+  .nav-item {
+    margin-bottom: 0;
+  }
+}
+
+.problem-page__tab-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  background: rgba($primary, 0.06);
+  color: $body-color;
+  font-weight: 600;
+
+  &.active,
+  &:hover {
+    background: $primary;
+    color: $white;
+  }
+}
+
+.problem-page__tab-content {
+  margin-top: 1.5rem;
+}
+
+.problem-page__submit-card {
+  max-width: 420px;
+}
+
+.problem-page__check-input-card {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.problem-page__check-input-header {
+  display: flex;
+  justify-content: space-between;
   align-items: center;
 }
 
-.problem-container {
+.problem-page__check-input-title {
+  font-weight: 600;
+}
+
+.problem-page__check-editor {
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.problem-page__right-pane {
   height: 100%;
 }
 
-/* Стили для блока с кодом */
-pre {
-  background-color: #f8f9fa;
-  padding: 1rem;
-  border-radius: 0.3rem;
-  overflow-x: auto;
+.problem-page__signin-card {
+  padding: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
 }
 
-/* Дополнительные стили можно добавить по необходимости */
+.problem-page__signin {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (max-width: 991.98px) {
+  :host {
+    --problem-layout-offset: 0px;
+  }
+
+  .problem-page {
+    padding: 1rem 0.75rem;
+  }
+
+  .problem-page__header {
+    border-bottom: none;
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, TemplateRef } from '@angular/core';
 import { Params } from '@angular/router';
 import { AuthUser } from '@auth';
 import { Subject } from 'rxjs';
@@ -6,24 +6,24 @@ import { Problem } from '@problems/models/problems.models';
 import { ProblemsApiService } from '../../services/problems-api.service';
 import { ApiService } from '@core/data-access/api.service';
 import { CoreCommonModule } from '@core/common.module';
-import { NgbNavModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModal, NgbModalModule, NgbNavModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { ProblemDescriptionComponent } from '@problems/pages/problem/problem-description/problem-description.component';
 import { ProblemAttemptsComponent } from '@problems/pages/problem/problem-attempts/problem-attempts.component';
 import { ProblemHacksComponent } from '@problems/pages/problem/problem-hacks/problem-hacks.component';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
-import { CodeEditorModule } from '@shared/components/code-editor/code-editor.module';
-import { ProblemSidebarComponent } from '@problems/pages/problem/problem-sidebar/problem-sidebar.component';
 import { TourModule } from '@shared/third-part-modules/tour/tour.module';
-import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
-import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
 import { BasePageComponent } from '@core/common/classes/base-page.component';
-import { SidebarService } from '@shared/ui/sidebar/sidebar.service';
-import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
-
 import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
 import { take } from 'rxjs/operators';
 import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
+import { ProblemDetailLayoutComponent } from '@problems/layouts/problem-detail-layout/problem-detail-layout.component';
+import { ProblemCodeEditorComponent } from '@problems/components/problem-code-editor/problem-code-editor.component';
+import { ProblemInfoCardComponent } from '@problems/components/problem-info-card/problem-info-card.component';
+import { ProblemsPipesModule } from '@problems/pipes/problems-pipes.module';
+import { ProblemSidebarStatisticsComponent } from '@problems/pages/problem/problem-sidebar/problem-sidebar-statistics/problem-sidebar-statistics.component';
+import { ProblemSidebarTopAttemptsComponent } from '@problems/pages/problem/problem-sidebar/problem-sidebar-top-attempts/problem-sidebar-top-attempts.component';
+import { ProblemStatistics } from '@problems/pages/problem/problem-sidebar/problem-statistics.model';
+import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
 
 @Component({
   selector: 'app-problem',
@@ -32,22 +32,23 @@ import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
   standalone: true,
   imports: [
     CoreCommonModule,
-    ContentHeaderModule,
     NgbNavModule,
     ProblemDescriptionComponent,
     ProblemAttemptsComponent,
     ProblemHacksComponent,
-    MonacoEditorModule,
-    CodeEditorModule,
-    ProblemSidebarComponent,
     TourModule,
-    NgSelectModule,
-    MonacoEditorComponent,
     KepCardComponent,
-
     ProblemSubmitCardComponent,
     NgbTooltipModule,
     ResourceByIdPipe,
+    ProblemDetailLayoutComponent,
+    ProblemCodeEditorComponent,
+    ProblemInfoCardComponent,
+    ProblemsPipesModule,
+    NgbModalModule,
+    ProblemSidebarStatisticsComponent,
+    ProblemSidebarTopAttemptsComponent,
+    MonacoEditorComponent,
   ]
 })
 export class ProblemComponent extends BasePageComponent implements OnInit {
@@ -59,10 +60,13 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
 
   public submitEvent = new Subject();
   public checkInput = '';
+  public statistics: ProblemStatistics | null = null;
+  public isStatisticsLoading = false;
+
   constructor(
     public service: ProblemsApiService,
     public api: ApiService,
-    protected coreSidebarService: SidebarService,
+    private readonly modalService: NgbModal,
   ) {
     super();
   }
@@ -136,12 +140,7 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     );
   }
 
-  codeEditorSidebarToggle() {
-    this.coreSidebarService.getSidebarRegistry('codeEditorSidebar').toggleOpen();
-  }
-
   onSubmit() {
-    console.log(4142);
     this.activeId = 2;
     this.submitEvent.next(null);
   }
@@ -172,6 +171,31 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     }
     this.router.navigate(['/practice/problems/problem', problemId], {
       queryParams: this.route.snapshot.queryParams,
+    });
+  }
+
+  openStatisticsModal(content: TemplateRef<unknown>) {
+    if (!this.problem) {
+      return;
+    }
+
+    this.isStatisticsLoading = true;
+    this.statistics = null;
+
+    this.modalService.open(content, {
+      size: 'lg',
+      scrollable: true,
+    });
+
+    this.service.getProblemStatistics(this.problem.id).subscribe({
+      next: (result: ProblemStatistics) => {
+        this.statistics = result;
+        this.isStatisticsLoading = false;
+      },
+      error: () => {
+        this.statistics = null;
+        this.isStatisticsLoading = false;
+      }
     });
   }
 }

--- a/src/app/shared/third-part-modules/monaco-editor/monaco-editor.component.ts
+++ b/src/app/shared/third-part-modules/monaco-editor/monaco-editor.component.ts
@@ -20,7 +20,7 @@ import { AppStateService } from "@core/services/app-state.service";
 @Component({
   selector: 'monaco-editor',
   template: `
-    <ngx-monaco-editor [style.height.px]="height" [options]="options" [(ngModel)]="value"></ngx-monaco-editor>`,
+    <ngx-monaco-editor [style.height]="heightStyle" [options]="options" [(ngModel)]="value"></ngx-monaco-editor>`,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -38,7 +38,7 @@ export class MonacoEditorComponent implements ControlValueAccessor, OnInit, OnCh
   @ViewChild(EditorComponent) editorComponent: EditorComponent;
 
   @Input() lang: AttemptLangs;
-  @Input() height = 300;
+  @Input() height: number | string = 300;
   @Input() tabSize = 4;
 
   public options = {
@@ -58,6 +58,13 @@ export class MonacoEditorComponent implements ControlValueAccessor, OnInit, OnCh
     protected languageService: LanguageService,
     protected appStateService: AppStateService,
   ) {
+  }
+
+  get heightStyle(): string {
+    if (typeof this.height === 'number') {
+      return `${ this.height }px`;
+    }
+    return this.height || '300px';
   }
 
   ngOnInit() {


### PR DESCRIPTION
## Summary
- create a dedicated problem detail layout with a LeetCode-style split view
- add a full-height inline problem code editor component with sample test results
- refresh the problem page UI and allow the Monaco editor to fill the available height

## Testing
- npm install *(fails: peer dependency conflict with @fullcalendar/angular requiring Angular <=16)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0989f4dc832f9a7cd37249fed1fc