### PR TITLE
feat(problems): redesign problem detail layout

### DIFF
--- a/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.html
+++ b/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.html
@@ -1,0 +1,17 @@
+<div class="problem-layout">
+  <header class="problem-layout__header">
+    <ng-content select="[problemLayoutHeader]"></ng-content>
+  </header>
+  <div class="problem-layout__body">
+    <section class="problem-layout__column problem-layout__column--left">
+      <div class="problem-layout__scroll">
+        <ng-content select="[problemLayoutLeft]"></ng-content>
+      </div>
+    </section>
+    <aside class="problem-layout__column problem-layout__column--right">
+      <div class="problem-layout__scroll">
+        <ng-content select="[problemLayoutRight]"></ng-content>
+      </div>
+    </aside>
+  </div>
+</div>

--- a/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.scss
+++ b/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.scss
@@ -1,0 +1,75 @@
+.problem-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--bs-body-bg);
+  color: inherit;
+
+  &__header {
+    flex-shrink: 0;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    padding: 1rem 2rem 1rem 2rem;
+    background: inherit;
+
+    &:empty {
+      display: none;
+      padding: 0;
+      border-bottom: 0;
+    }
+  }
+
+  &__body {
+    flex: 1 1 auto;
+    display: flex;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  &__column {
+    flex: 1 1 0;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid rgba(0, 0, 0, 0.05);
+    background: inherit;
+
+    &--right {
+      max-width: 50%;
+      border-right: 0;
+      border-left: 1px solid rgba(0, 0, 0, 0.05);
+    }
+  }
+
+  &__scroll {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 1.5rem 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+}
+
+@media (max-width: 1199.98px) {
+  .problem-layout {
+    &__body {
+      flex-direction: column;
+    }
+
+    &__column {
+      border-right: 0;
+      border-left: 0;
+
+      &--right {
+        max-width: 100%;
+        border-left: 0;
+        border-top: 1px solid rgba(0, 0, 0, 0.05);
+      }
+    }
+
+    &__scroll {
+      padding: 1.25rem 1.5rem;
+    }
+  }
+}

--- a/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.ts
+++ b/src/@core/layouts/problem-detail-layout/problem-detail-layout.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'problem-detail-layout',
+  standalone: true,
+  templateUrl: './problem-detail-layout.component.html',
+  styleUrls: ['./problem-detail-layout.component.scss']
+})
+export class ProblemDetailLayoutComponent {}

--- a/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.html
+++ b/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.html
@@ -1,0 +1,171 @@
+<div class="workspace" [formGroup]="editorForm">
+  <div class="workspace__header">
+    <div class="workspace__header-left">
+      <div class="workspace__field">
+        <label class="workspace__label">{{ 'Language' | translate }}</label>
+        <ng-select
+          (change)="langChange($event)"
+          [clearable]="false"
+          formControlName="lang"
+        >
+          @for (language of availableLanguages; track language) {
+            <ng-option [value]="language.lang">
+              {{ language.langFull || language.lang }}
+            </ng-option>
+          }
+        </ng-select>
+      </div>
+      @if (sampleTests?.length) {
+        <div class="workspace__field">
+          <label class="workspace__label">{{ 'CodeEditor.SampleTest' | translate }}</label>
+          <ng-select
+            (change)="onSampleTestChange()"
+            [clearable]="false"
+            formControlName="testCaseNumber"
+          >
+            @for (sampleTest of sampleTests; track sampleTest; let i = $index) {
+              <ng-option [value]="i + 1">
+                {{ 'CodeEditor.SampleTest' | translate }} #{{ i + 1 }}
+              </ng-option>
+            }
+          </ng-select>
+        </div>
+      }
+    </div>
+
+    <div class="workspace__actions">
+      <div class="workspace__action-group">
+        @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
+          <kepcoin-spend-swal
+            (success)="checkSamples()"
+            [customContent]="true"
+            [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
+            [value]="100"
+          >
+            <button type="button" class="btn btn-outline-dark btn-sm" [disabled]="isCheckSamples">
+              @if (isCheckSamples) {
+                <span class="spinner-border spinner-border-sm" role="status"></span>
+              }
+              {{ 'CodeEditor.CheckSamples' | translate }}
+            </button>
+          </kepcoin-spend-swal>
+        } @else {
+          <button type="button" class="btn btn-outline-dark btn-sm" (click)="checkSamples()" [disabled]="isCheckSamples">
+            @if (isCheckSamples) {
+              <span class="spinner-border spinner-border-sm" role="status"></span>
+            }
+            <i data-feather="terminal"></i>
+            <span class="ms-1">{{ 'CodeEditor.CheckSamples' | translate }}</span>
+          </button>
+        }
+
+        @if (!isSelectedLangText()) {
+          <button type="button" class="btn btn-outline-dark btn-sm" (click)="run()" [disabled]="isRunning">
+            @if (isRunning) {
+              <span class="spinner-border spinner-border-sm" role="status"></span>
+            }
+            <i data-feather="play"></i>
+            <span class="ms-1">{{ 'CodeEditor.Run' | translate }}</span>
+          </button>
+        }
+      </div>
+
+      <div class="workspace__action-group">
+        @if (answerForInputEnabled && !isSelectedLangText()) {
+          <kepcoin-spend-swal
+            (success)="answerForInput($event)"
+            [customContent]="true"
+            [purchaseUrl]="'problems/' + problem?.id + '/answer-for-input/'"
+            [requestBody]="{ input_data: editorForm.get('input').value }"
+            [value]="1"
+          >
+            <button type="button" class="btn btn-outline-primary btn-sm" [disabled]="isAnswerForInput">
+              @if (isAnswerForInput) {
+                <span class="spinner-border spinner-border-sm" role="status"></span>
+              }
+              <i data-feather="check-square"></i>
+              <span class="ms-1">{{ 'CodeEditor.AnswerForInput' | translate }}</span>
+            </button>
+          </kepcoin-spend-swal>
+        }
+
+        <button
+          type="button"
+          class="btn btn-primary btn-sm"
+          (click)="submit()"
+          [disabled]="isSubmitting || !submitUrl || !editorForm.valid"
+        >
+          @if (isSubmitting) {
+            <span class="spinner-border spinner-border-sm" role="status"></span>
+          }
+          <i data-feather="send"></i>
+          <span class="ms-1">{{ 'CodeEditor.Submit' | translate }}</span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div class="workspace__editor">
+    <monaco-editor
+      formControlName="code"
+      [lang]="editorForm.controls.lang.value"
+      [options]="editorOptions"
+    ></monaco-editor>
+  </div>
+
+  <div class="workspace__io" [class.workspace__io--single]="isSelectedLangText()">
+    <div class="workspace__panel" *ngIf="!isSelectedLangText()">
+      <label class="workspace__label">{{ 'CodeEditor.Input' | translate }}</label>
+      <textarea class="form-control" formControlName="input" rows="4"></textarea>
+    </div>
+    <div class="workspace__panel" *ngIf="!isSelectedLangText()">
+      <label class="workspace__label">{{ 'CodeEditor.Output' | translate }}</label>
+      <textarea class="form-control" formControlName="output" rows="4" readonly></textarea>
+    </div>
+    <div class="workspace__panel" *ngIf="answerForInputEnabled && !isSelectedLangText()">
+      <label class="workspace__label">{{ 'CodeEditor.Answer' | translate }}</label>
+      <textarea class="form-control" formControlName="answer" rows="4" readonly></textarea>
+    </div>
+  </div>
+
+  <div class="workspace__results" *ngIf="checkSamplesResult?.length">
+    <h6 class="workspace__results-title">{{ 'Result' | translate }}</h6>
+    <div class="workspace__results-grid">
+      @for (result of checkSamplesResult; track result; let i = $index) {
+        <div class="workspace__result-card" [ngClass]="{
+          'workspace__result-card--accepted': result.verdict === Verdicts.Accepted,
+          'workspace__result-card--failed': result.verdict !== Verdicts.Accepted
+        }">
+          <div class="workspace__result-header">
+            <span class="workspace__result-index">TC #{{ i + 1 }}</span>
+            <span class="workspace__result-verdict">
+              {{ result.verdict | verdictShortTitle }}
+            </span>
+          </div>
+          @if (result.input) {
+            <div class="workspace__result-section">
+              <div class="workspace__result-label">{{ 'CodeEditor.Input' | translate }}</div>
+              <pre class="workspace__result-value">{{ result.input }}</pre>
+            </div>
+          }
+          @if (result.answer) {
+            <div class="workspace__result-section">
+              <div class="workspace__result-label">{{ 'CodeEditor.Answer' | translate }}</div>
+              <pre class="workspace__result-value">{{ result.answer }}</pre>
+            </div>
+          }
+          @if (result.output) {
+            <div class="workspace__result-section">
+              <div class="workspace__result-label">{{ 'CodeEditor.Output' | translate }}</div>
+              <pre class="workspace__result-value">{{ result.output }}</pre>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  </div>
+
+  <div class="workspace__spinner" *ngIf="isCheckSamples">
+    <spinner [name]="resultSpinnerName"></spinner>
+  </div>
+</div>

--- a/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.scss
+++ b/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.scss
@@ -1,0 +1,172 @@
+@import 'styles/kep-imports';
+
+.workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 0;
+
+  &__header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: flex-end;
+  }
+
+  &__header-left {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  &__field {
+    min-width: 180px;
+
+    ng-select {
+      width: 100%;
+    }
+  }
+
+  &__label {
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    font-weight: 600;
+    margin-bottom: 0.35rem;
+    color: rgba(var(--bs-body-color-rgb), 0.75);
+  }
+
+  &__actions {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  &__action-group {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  &__editor {
+    flex: 1 1 auto;
+    min-height: 320px;
+
+    monaco-editor {
+      height: 100%;
+      display: block;
+    }
+  }
+
+  &__io {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+
+    &--single {
+      grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+  }
+
+  &__panel textarea {
+    background-color: rgba(var(--bs-body-color-rgb), 0.02);
+  }
+
+  &__results {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  &__results-title {
+    font-weight: 600;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(var(--bs-body-color-rgb), 0.75);
+  }
+
+  &__results-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  }
+
+  &__result-card {
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    border-radius: 0.75rem;
+    padding: 1rem;
+    background-color: var(--bs-card-bg);
+    box-shadow: 0 8px 18px rgba(15, 15, 15, 0.08);
+
+    &--accepted {
+      border-color: rgba($success, 0.35);
+      background-color: rgba($success, 0.08);
+    }
+
+    &--failed {
+      border-color: rgba($danger, 0.35);
+      background-color: rgba($danger, 0.08);
+    }
+  }
+
+  &__result-header {
+    display: flex;
+    justify-content: space-between;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+  }
+
+  &__result-section {
+    margin-bottom: 0.75rem;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &__result-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.35rem;
+    color: rgba(var(--bs-body-color-rgb), 0.65);
+  }
+
+  &__result-value {
+    background-color: rgba(0, 0, 0, 0.04);
+    border-radius: 0.5rem;
+    padding: 0.75rem;
+    margin: 0;
+    max-height: 180px;
+    overflow: auto;
+    font-family: var(--bs-font-monospace);
+    font-size: 0.85rem;
+    white-space: pre-wrap;
+  }
+
+  &__spinner {
+    display: flex;
+    justify-content: center;
+  }
+}
+
+@media (max-width: 991.98px) {
+  .workspace {
+    &__io {
+      grid-template-columns: repeat(1, minmax(0, 1fr));
+    }
+
+    &__action-group {
+      width: 100%;
+      justify-content: flex-start;
+    }
+
+    &__actions {
+      justify-content: flex-start;
+    }
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.ts
+++ b/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.ts
@@ -1,0 +1,291 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { AvailableLanguage, Problem, SampleTest } from '@problems/models/problems.models';
+import { AttemptLangs, Verdicts } from '@problems/constants';
+import { ApiService } from '@core/data-access/api.service';
+import { WebsocketService } from '@shared/services/websocket';
+import { LanguageService } from '@problems/services/language.service';
+import { TemplateCodeService } from '@shared/services/template-code.service';
+import { CValidators } from '@shared/c-validators/c-validators';
+import { paramsMapper } from '@shared/utils';
+import { ToastrService } from 'ngx-toastr';
+import { TranslateService } from '@ngx-translate/core';
+import { NgxSpinnerService } from 'ngx-spinner';
+import { findAvailableLang } from '@problems/utils';
+import { AuthService } from '@auth';
+import { CoreCommonModule } from '@core/common.module';
+import { NgSelectComponent, NgOptionComponent } from '@ng-select/ng-select';
+import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
+import { KepcoinSpendSwalComponent } from '@shared/components/kepcoin-spend-swal/kepcoin-spend-swal.component';
+import { VerdictShortTitlePipe } from '@problems/pipes/verdict-short-title.pipe';
+
+export interface CheckSamplesResultOne {
+  verdict: number;
+  input: string;
+  output: string;
+  answer: string;
+}
+
+@Component({
+  selector: 'problem-workspace',
+  standalone: true,
+  templateUrl: './problem-workspace.component.html',
+  styleUrls: ['./problem-workspace.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CoreCommonModule,
+    NgSelectComponent,
+    NgOptionComponent,
+    MonacoEditorComponent,
+    KepcoinSpendSwalComponent,
+    VerdictShortTitlePipe,
+  ],
+})
+export class ProblemWorkspaceComponent implements OnInit, OnChanges, OnDestroy {
+  @Input() problem: Problem | null = null;
+  @Input() uniqueName = '';
+  @Input() availableLanguages: Array<AvailableLanguage> = [];
+  @Input() sampleTests: Array<SampleTest> = [];
+  @Input() submitUrl: string | null = null;
+  @Input() submitParams: Record<string, unknown> = {};
+  @Input() answerForInputEnabled = false;
+
+  @Output() submitted = new EventEmitter<void>();
+
+  public readonly AttemptLangs = AttemptLangs;
+  protected readonly Verdicts = Verdicts;
+
+  public readonly editorForm = new FormGroup({
+    code: new FormControl('', [CValidators.maxLength({ value: 65536 })]),
+    input: new FormControl('', [CValidators.maxLength({ value: 2048 })]),
+    lang: new FormControl<AttemptLangs | ''>(''),
+    output: new FormControl(''),
+    answer: new FormControl(''),
+    testCaseNumber: new FormControl(1),
+  });
+
+  public readonly editorOptions = {
+    automaticLayout: true,
+    minimap: { enabled: false },
+    fontSize: 14,
+    scrollBeyondLastLine: false,
+  } as const;
+
+  public isRunning = false;
+  public isSubmitting = false;
+  public isCheckSamples = false;
+  public isAnswerForInput = false;
+
+  public checkSamplesResult: Array<CheckSamplesResultOne> = [];
+
+  private readonly destroy$ = new Subject<void>();
+
+  constructor(
+    private readonly api: ApiService,
+    private readonly wsService: WebsocketService,
+    private readonly langService: LanguageService,
+    private readonly templateCodeService: TemplateCodeService,
+    private readonly toastr: ToastrService,
+    private readonly translateService: TranslateService,
+    private readonly spinner: NgxSpinnerService,
+    public readonly authService: AuthService,
+  ) {}
+
+  ngOnInit(): void {
+    this.langService.getLanguage().pipe(takeUntil(this.destroy$)).subscribe((lang: AttemptLangs) => {
+      if (!lang) {
+        return;
+      }
+      if (this.editorForm.controls.lang.value !== lang) {
+        this.editorForm.controls.lang.setValue(lang, { emitEvent: false });
+        this.initEditorState();
+      }
+    });
+
+    this.wsService.on('custom-test-result').pipe(takeUntil(this.destroy$)).subscribe((result: any) => {
+      const output = `${result.output ?? ''}${result.error ?? ''}\n=========\nTime: ${result.time}ms\nMemory: ${result.memory}KB`;
+      this.editorForm.controls.output.setValue(output);
+      this.isRunning = false;
+    });
+
+    this.wsService.on('answer-for-input-result').pipe(takeUntil(this.destroy$)).subscribe((result: { answer: string }) => {
+      this.editorForm.controls.answer.setValue('Answer:\n' + result.answer);
+      this.isAnswerForInput = false;
+    });
+
+    this.wsService.on('check-sample-tests-result').pipe(takeUntil(this.destroy$)).subscribe((result: Array<CheckSamplesResultOne>) => {
+      this.spinner.hide(this.resultSpinnerName);
+      this.checkSamplesResult = result;
+      this.isCheckSamples = false;
+    });
+
+    this.editorForm.controls.code.valueChanges?.pipe(takeUntil(this.destroy$)).subscribe((code: string) => {
+      const lang = this.editorForm.controls.lang.value;
+      if (!lang || !this.uniqueName) {
+        return;
+      }
+      this.templateCodeService.save(this.uniqueName, lang, code ?? '');
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if ((changes['availableLanguages'] && this.availableLanguages?.length) || changes['uniqueName']) {
+      this.initEditorState();
+    }
+
+    if (changes['sampleTests']) {
+      this.applySampleTest();
+    }
+  }
+
+  run(): void {
+    if (this.isRunning) {
+      return;
+    }
+    this.isRunning = true;
+    this.editorForm.controls.output.setValue('');
+
+    const data = {
+      sourceCode: this.editorForm.controls.code.value,
+      lang: this.editorForm.controls.lang.value,
+      inputData: this.editorForm.controls.input.value,
+    };
+
+    this.api.post('problems/custom-test/', data).subscribe((result: any) => {
+      this.wsService.send('custom-test-add', result.id);
+    }, () => {
+      this.isRunning = false;
+    });
+
+    setTimeout(() => {
+      this.isRunning = false;
+    }, 5000);
+  }
+
+  submit(): void {
+    if (this.isSubmitting || !this.submitUrl || !this.editorForm.valid) {
+      return;
+    }
+    this.isSubmitting = true;
+
+    const data = {
+      sourceCode: this.editorForm.controls.code.value,
+      lang: this.editorForm.controls.lang.value,
+      ...this.submitParams,
+    };
+
+    this.api.post(this.submitUrl, data).subscribe(() => {
+      this.isSubmitting = false;
+      const text = this.translateService.instant('SubmittedSuccess');
+      this.toastr.success('', text);
+      this.submitted.emit();
+    }, () => {
+      this.isSubmitting = false;
+      this.toastr.error(this.translateService.instant('Error'));
+    });
+  }
+
+  answerForInput(result: { id: number }): void {
+    if (this.isAnswerForInput) {
+      return;
+    }
+    this.isAnswerForInput = true;
+    this.wsService.send('answer-for-input-add', result.id);
+    setTimeout(() => {
+      this.isAnswerForInput = false;
+    }, 15000);
+  }
+
+  checkSamples(): void {
+    if (this.isCheckSamples || !this.problem) {
+      return;
+    }
+    this.isCheckSamples = true;
+    this.spinner.show(this.resultSpinnerName);
+    const data = {
+      lang: this.editorForm.controls.lang.value,
+      sourceCode: this.editorForm.controls.code.value,
+    };
+
+    this.api.post(`problems/${this.problem.id}/check-sample-tests`, paramsMapper(data)).subscribe((result) => {
+      this.wsService.send('check-sample-tests-add', result.id);
+    }, () => {
+      this.spinner.hide(this.resultSpinnerName);
+      this.isCheckSamples = false;
+    });
+
+    setTimeout(() => {
+      this.isCheckSamples = false;
+    }, 15000);
+  }
+
+  langChange(lang: AttemptLangs): void {
+    this.langService.setLanguage(lang);
+    this.editorForm.controls.lang.setValue(lang, { emitEvent: false });
+    this.initEditorState();
+  }
+
+  onSampleTestChange(): void {
+    this.applySampleTest();
+  }
+
+  isSelectedLangText(): boolean {
+    return this.editorForm.controls.lang.value === AttemptLangs.TEXT;
+  }
+
+  get resultSpinnerName(): string {
+    return `${this.uniqueName}-check-samples`;
+  }
+
+  private initEditorState(): void {
+    if (!this.availableLanguages?.length) {
+      return;
+    }
+
+    const langControl = this.editorForm.controls.lang;
+    let lang = langControl.value as AttemptLangs;
+    if (!lang) {
+      lang = this.langService.getLanguageValue();
+      langControl.setValue(lang, { emitEvent: false });
+    }
+
+    const availableLang = findAvailableLang(this.availableLanguages, lang) || this.availableLanguages[0];
+    if (!availableLang) {
+      return;
+    }
+
+    if (availableLang.lang !== langControl.value) {
+      langControl.setValue(availableLang.lang as AttemptLangs, { emitEvent: false });
+    }
+
+    const code = this.templateCodeService.get(this.uniqueName, availableLang.lang)
+      || availableLang.codeTemplate;
+
+    if (code !== undefined && code !== null) {
+      this.editorForm.controls.code.setValue(code);
+    }
+
+    this.applySampleTest();
+  }
+
+  private applySampleTest(): void {
+    if (!this.sampleTests?.length) {
+      this.editorForm.controls.testCaseNumber.setValue(null, { emitEvent: false });
+      return;
+    }
+
+    const index = (this.editorForm.controls.testCaseNumber.value ?? 1) - 1;
+    const test = this.sampleTests[index] ?? this.sampleTests[0];
+    this.editorForm.controls.testCaseNumber.setValue((this.sampleTests.indexOf(test) + 1), { emitEvent: false });
+    this.editorForm.controls.input.setValue(test.input ?? '');
+    this.editorForm.controls.answer.setValue(test.output ?? '');
+    this.editorForm.controls.output.setValue('');
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -1,177 +1,193 @@
-<div class="content-wrapper container-xxl p-0">
-  <div class="content-body">
-    <app-content-header [contentHeader]="contentHeader">
-      <div class="btn-group" role="group">
-        <button
-          class="btn btn-primary-light btn-wave"
-          type="button"
-          (click)="goToPreviousProblem()"
-          ngbTooltip="{{ 'PreviousProblem' | translate }}"
-        >
-          <kep-icon name="left"/>
-        </button>
-        <button
-          class="btn btn-primary-light btn-wave"
-          type="button"
-          (click)="goToNextProblem()"
-          ngbTooltip="{{ 'NextProblem' | translate }}"
-        >
-          <kep-icon name="right"/>
-        </button>
+<problem-detail-layout>
+  <div problemLayoutHeader class="problem-header" *ngIf="problem">
+    <div class="problem-header__nav">
+      <button
+        class="btn btn-light btn-icon"
+        type="button"
+        (click)="goToPreviousProblem()"
+        ngbTooltip="{{ 'PreviousProblem' | translate }}"
+      >
+        <kep-icon name="left"></kep-icon>
+      </button>
+      <button
+        class="btn btn-light btn-icon"
+        type="button"
+        (click)="goToNextProblem()"
+        ngbTooltip="{{ 'NextProblem' | translate }}"
+      >
+        <kep-icon name="right"></kep-icon>
+      </button>
+    </div>
+
+    <div class="problem-header__content">
+      <div class="problem-header__breadcrumbs">
+        <a routerLink="/practice/problems" class="problem-header__breadcrumb-link">{{ 'Problems' | translate }}</a>
+        <span>/</span>
+        <span>#{{ problem.id }}</span>
       </div>
-    </app-content-header>
-    <section  class="mt-2">
-      <div class="row">
-        <div class="col-lg-9 col-md-12 col-sm-12">
-          <kep-card>
-            <div class="card-header">
-              <ul
-                #navWithIcons="ngbNav"
-                (activeIdChange)="activeIdChange($event)" [(activeId)]="activeId" [destroyOnHide]="false"
-                class="nav-tabs" ngbNav>
-                <li [ngbNavItem]="1">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
-                    {{ 'Problem' | translate }}
-                  </a>
-                  <ng-template ngbNavContent>
-                    <problem-description [problem]="problem"></problem-description>
-                  </ng-template>
-                </li>
-
-                <li [ngbNavItem]="2">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
-                    {{ 'Attempts' | translate }}
-                  </a>
-                  <ng-template ngbNavContent>
-                    <problem-attempts
-                      (hackSubmitted)="activeId = 3;"
-                      [problem]="problem"
-                      [submitEvent]="submitEvent?.asObservable()"
-                    >
-                    </problem-attempts>
-                  </ng-template>
-                </li>
-
-                @if (problem.hasCheckInput) {
-                  <li [ngbNavItem]="3" destroyOnHide="true">
-                    <a class="nav-link" ngbNavLink>
-                      <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
-                      {{ 'Hacks' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-hacks [problem]="problem"></problem-hacks>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (studyPlanId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
-                      <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (contestId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.ContestProblems | resourceById:contestId">
-                      <kep-icon name="contest" color="primary" type="duotone"/>
-                      {{ 'Contest' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-              </ul>
-
-              @if (isAuthenticated) {
-                <button (click)="codeEditorSidebarToggle()" class="btn btn-sm btn-primary">{{ 'Submit' | translate }}
-                </button>
-              }
-            </div>
-
-            <div class="card-footer">
-              <div [ngbNavOutlet]="navWithIcons"></div>
-            </div>
-          </kep-card>
-
-          @if (currentUser?.permissions.canCreateProblems) {
-            <div class="card">
-              <div class="card-header">
-                <div class="card-title">
-                  Check input
-                </div>
-              </div>
-              <div class="card-body">
-                <monaco-editor
-                  [lang]="'py'"
-                  class="mt-1"
-                  [ngModelOptions]="{standalone: true}"
-                  [(ngModel)]="checkInput"
-                ></monaco-editor>
-                <div class="btn mt-2 btn-primary btn-sm" (click)="saveCheckInput()">Save</div>
-              </div>
-            </div>
-          }
+      <div class="problem-header__title">
+        <span class="problem-header__id">#{{ problem.id }}</span>
+        <h1>{{ problem.title }}</h1>
+        <span class="badge bg-{{ problem.difficulty | problemDifficultyColor }} align-self-start">
+          {{ problem.difficultyTitle }}
+        </span>
+      </div>
+      <div class="problem-header__meta">
+        <div class="problem-header__meta-item">
+          <span class="problem-header__meta-label">{{ 'Solved' | translate }}</span>
+          <span class="problem-header__meta-value">{{ problem.solved | number }}</span>
         </div>
-
-        <div class="col-lg-3 col-md-12 col-sm-12">
-          <problem-sidebar [problem]="problem"></problem-sidebar>
-
-          @if (isAuthenticated) {
-            <problem-submit-card
-              [availableLanguages]="problem.availableLanguages"
-              [submitUrl]="'problems/' + problem.id + '/submit/'"
-              (submitted)="onSubmit()"
-            />
-          }
+        <div class="problem-header__meta-item">
+          <span class="problem-header__meta-label">{{ 'Attempts' | translate }}</span>
+          <span class="problem-header__meta-value">{{ problem.attemptsCount | number }}</span>
         </div>
+        <div class="problem-header__meta-item" *ngIf="problem.tags?.length">
+          <span class="problem-header__meta-label">{{ 'Tags' | translate }}</span>
+          <span class="problem-header__tags">
+            @for (tag of problem.tags; track tag) {
+              <span class="badge rounded-pill bg-light text-dark">{{ tag.name }}</span>
+            }
+          </span>
+        </div>
+      </div>
+    </div>
 
+    <div class="problem-header__actions" *ngIf="isAuthenticated">
+      <button class="btn btn-primary btn-sm" type="button" (click)="activeId = 2">
+        {{ 'Attempts' | translate }}
+      </button>
+    </div>
+  </div>
+
+  <div problemLayoutLeft>
+    <div class="problem-left" *ngIf="problem">
+      <div class="problem-left__tabs">
+        <ul
+          #navWithIcons="ngbNav"
+          ngbNav
+          [(activeId)]="activeId"
+          (activeIdChange)="activeIdChange($event)"
+          [destroyOnHide]="false"
+          class="nav nav-tabs problem-nav"
+        >
+          <li [ngbNavItem]="1">
+            <a ngbNavLink class="nav-link">
+              <kep-icon size="small-4" color="primary" name="problem" type="duotone"></kep-icon>
+              {{ 'Problem' | translate }}
+            </a>
+            <ng-template ngbNavContent>
+              <problem-description [problem]="problem"></problem-description>
+            </ng-template>
+          </li>
+
+          <li [ngbNavItem]="2">
+            <a ngbNavLink class="nav-link">
+              <kep-icon size="small-4" color="warning" name="attempt" type="duotone"></kep-icon>
+              {{ 'Attempts' | translate }}
+            </a>
+            <ng-template ngbNavContent>
+              <problem-attempts
+                [problem]="problem"
+                [submitEvent]="submitEvent?.asObservable()"
+                (hackSubmitted)="activeId = 3"
+              ></problem-attempts>
+            </ng-template>
+          </li>
+
+          @if (problem.hasCheckInput) {
+            <li [ngbNavItem]="3" destroyOnHide="true">
+              <a ngbNavLink class="nav-link">
+                <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"></kep-icon>
+                {{ 'Hacks' | translate }}
+              </a>
+              <ng-template ngbNavContent>
+                <problem-hacks [problem]="problem"></problem-hacks>
+              </ng-template>
+            </li>
+          }
+
+          @if (studyPlanId) {
+            <li [ngbNavItem]="4">
+              <a ngbNavLink [routerLink]="Resources.StudyPlan | resourceById:studyPlanId" class="nav-link">
+                <span [data-feather]="'activity'"></span>
+                {{ 'StudyPlan' | translate }}
+              </a>
+              <ng-template ngbNavContent>
+                <problem-description [problem]="problem"></problem-description>
+              </ng-template>
+            </li>
+          }
+
+          @if (contestId) {
+            <li [ngbNavItem]="5">
+              <a ngbNavLink [routerLink]="Resources.ContestProblems | resourceById:contestId" class="nav-link">
+                <kep-icon name="contest" color="primary" type="duotone"></kep-icon>
+                {{ 'Contest' | translate }}
+              </a>
+              <ng-template ngbNavContent>
+                <problem-description [problem]="problem"></problem-description>
+              </ng-template>
+            </li>
+          }
+        </ul>
       </div>
 
-      @if (problem && isAuthenticated) {
-        <code-editor-modal
-          [customClass]="'tour-step-2'"
+      <div class="problem-left__content">
+        <div [ngbNavOutlet]="navWithIcons"></div>
+      </div>
+
+      <problem-sidebar [problem]="problem"></problem-sidebar>
+
+      @if (currentUser?.permissions.canCreateProblems) {
+        <kep-card>
+          <div class="card-header">
+            <div class="card-title">Check input</div>
+          </div>
+          <div class="card-body">
+            <monaco-editor
+              [lang]="'py'"
+              class="mt-1"
+              [ngModelOptions]="{ standalone: true }"
+              [(ngModel)]="checkInput"
+            ></monaco-editor>
+            <div class="btn btn-primary btn-sm mt-2" (click)="saveCheckInput()">Save</div>
+          </div>
+        </kep-card>
+      }
+    </div>
+  </div>
+
+  <div problemLayoutRight>
+    <div class="problem-right" *ngIf="problem">
+      @if (isAuthenticated) {
+        <problem-workspace
+          [problem]="problem"
           [uniqueName]="'problem-' + problem.id"
           [sampleTests]="problem.sampleTests"
           [submitUrl]="'problems/' + problem.id + '/submit/'"
-          [problem]="problem"
           [answerForInputEnabled]="problem.hasSolution && problem.hasCheckInput"
           [availableLanguages]="problem.availableLanguages"
-          (submittedEvent)="onSubmit()"></code-editor-modal>
+          (submitted)="onSubmit()"
+        ></problem-workspace>
+
+        <problem-submit-card
+          class="problem-right__upload"
+          [availableLanguages]="problem.availableLanguages"
+          [submitUrl]="'problems/' + problem.id + '/submit/'"
+          (submitted)="onSubmit()"
+        ></problem-submit-card>
+      } @else {
+        <kep-card class="problem-right__signin">
+          <div class="card-body text-center">
+            <h5 class="mb-2">{{ 'Auth.Login' | translate }}</h5>
+            <p class="text-muted mb-3">{{ 'LoginText' | translate }}</p>
+            <a class="btn btn-primary" routerLink="/login">{{ 'Login' | translate }}</a>
+          </div>
+        </kep-card>
       }
-    </section>
+    </div>
   </div>
-</div>
+</problem-detail-layout>
 
 <tour-css></tour-css>
 <ng-select-css></ng-select-css>
-
-<!--<div class="col-lg-6 col-md-12 col-sm-12">-->
-<!--  <kep-card>-->
-<!--    <div class="card-header p-2">-->
-<!--      <div class="card-title">-->
-<!--        <kep-icon name="square-brackets" color="primary" type="duotone"/>-->
-<!--        {{ 'Code' | translate }}-->
-<!--      </div>-->
-<!--    </div>-->
-
-<!--    <ng-select-->
-<!--      [appendTo]="'body'"-->
-<!--      [clearable]="false">-->
-<!--      @for (availableLanguage of problem.availableLanguages; track availableLanguage) {-->
-<!--        <ng-option-->
-<!--          [value]="availableLanguage.lang">-->
-<!--          {{ availableLanguage.langFull || availableLanguage.lang }}-->
-<!--        </ng-option>-->
-<!--      }-->
-<!--    </ng-select>-->
-<!--    <monaco-editor lang="py"/>-->
-<!--  </kep-card>-->
-<!--</div>-->

--- a/src/app/modules/problems/pages/problem/problem.component.scss
+++ b/src/app/modules/problems/pages/problem/problem.component.scss
@@ -1,19 +1,170 @@
-.card .card-header {
-  padding: 1rem !important;
-  padding-bottom: 0 !important;
+.problem-header {
+  display: flex;
   align-items: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+
+  &__nav {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  &__content {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  &__breadcrumbs {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: rgba(var(--bs-body-color-rgb), 0.65);
+  }
+
+  &__breadcrumb-link {
+    text-decoration: none;
+    font-weight: 600;
+    color: inherit;
+  }
+
+  &__title {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+
+    h1 {
+      font-size: clamp(1.5rem, 2vw + 1rem, 2.4rem);
+      margin: 0;
+    }
+  }
+
+  &__id {
+    font-weight: 600;
+    color: rgba(var(--bs-body-color-rgb), 0.65);
+  }
+
+  &__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    font-size: 0.85rem;
+  }
+
+  &__meta-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  &__meta-label {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(var(--bs-body-color-rgb), 0.55);
+    font-size: 0.72rem;
+  }
+
+  &__meta-value {
+    font-weight: 600;
+    font-size: 1rem;
+  }
+
+  &__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  &__actions {
+    display: flex;
+    align-items: center;
+  }
 }
 
-.problem-container {
-  height: 100%;
+.problem-left {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  &__tabs {
+    position: sticky;
+    top: 0;
+    background: inherit;
+    z-index: 5;
+    padding-top: 0.5rem;
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    > * {
+      background: var(--bs-card-bg);
+      border-radius: 1rem;
+      padding: 1.5rem;
+      box-shadow: 0 12px 25px rgba(15, 15, 15, 0.08);
+    }
+  }
 }
 
-/* Стили для блока с кодом */
-pre {
-  background-color: #f8f9fa;
-  padding: 1rem;
-  border-radius: 0.3rem;
-  overflow-x: auto;
+.problem-nav {
+  gap: 0.5rem;
+  border-bottom: none;
+  padding-bottom: 0.5rem;
+
+  .nav-link {
+    border: none;
+    border-radius: 999px;
+    padding: 0.5rem 1rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-weight: 600;
+    color: rgba(var(--bs-body-color-rgb), 0.65);
+
+    &.active {
+      background: var(--bs-primary);
+      color: var(--bs-white);
+      box-shadow: 0 10px 20px rgba(var(--bs-primary-rgb), 0.3);
+    }
+  }
 }
 
-/* Дополнительные стили можно добавить по необходимости */
+.problem-right {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+
+  &__upload,
+  &__signin {
+    box-shadow: 0 12px 25px rgba(15, 15, 15, 0.08);
+    border-radius: 1rem;
+    overflow: hidden;
+  }
+}
+
+.btn-icon {
+  width: 42px;
+  height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  box-shadow: 0 6px 20px rgba(15, 15, 15, 0.08);
+}
+
+@media (max-width: 991.98px) {
+  .problem-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .problem-left__tabs {
+    position: static;
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -10,20 +10,20 @@ import { NgbNavModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { ProblemDescriptionComponent } from '@problems/pages/problem/problem-description/problem-description.component';
 import { ProblemAttemptsComponent } from '@problems/pages/problem/problem-attempts/problem-attempts.component';
 import { ProblemHacksComponent } from '@problems/pages/problem/problem-hacks/problem-hacks.component';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
-import { CodeEditorModule } from '@shared/components/code-editor/code-editor.module';
 import { ProblemSidebarComponent } from '@problems/pages/problem/problem-sidebar/problem-sidebar.component';
 import { TourModule } from '@shared/third-part-modules/tour/tour.module';
 import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
-import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
 import { BasePageComponent } from '@core/common/classes/base-page.component';
-import { SidebarService } from '@shared/ui/sidebar/sidebar.service';
 import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
 import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 
 import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
 import { take } from 'rxjs/operators';
 import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
+import { ProblemDetailLayoutComponent } from '@core/layouts/problem-detail-layout/problem-detail-layout.component';
+import { ProblemWorkspaceComponent } from '@problems/pages/problem/problem-workspace/problem-workspace.component';
+import { ProblemDifficultyColorPipe } from '@problems/pipes/problem-difficulty-color.pipe';
+import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
 
 @Component({
   selector: 'app-problem',
@@ -33,21 +33,22 @@ import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
   imports: [
     CoreCommonModule,
     ContentHeaderModule,
+    ProblemDetailLayoutComponent,
     NgbNavModule,
     ProblemDescriptionComponent,
     ProblemAttemptsComponent,
     ProblemHacksComponent,
-    MonacoEditorModule,
-    CodeEditorModule,
     ProblemSidebarComponent,
     TourModule,
     NgSelectModule,
-    MonacoEditorComponent,
     KepCardComponent,
 
     ProblemSubmitCardComponent,
     NgbTooltipModule,
     ResourceByIdPipe,
+    ProblemWorkspaceComponent,
+    ProblemDifficultyColorPipe,
+    MonacoEditorComponent,
   ]
 })
 export class ProblemComponent extends BasePageComponent implements OnInit {
@@ -62,7 +63,6 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
   constructor(
     public service: ProblemsApiService,
     public api: ApiService,
-    protected coreSidebarService: SidebarService,
   ) {
     super();
   }
@@ -134,10 +134,6 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
         this.toastr.error('Error');
       }
     );
-  }
-
-  codeEditorSidebarToggle() {
-    this.coreSidebarService.getSidebarRegistry('codeEditorSidebar').toggleOpen();
   }
 
   onSubmit() {


### PR DESCRIPTION
## Summary
- add a dedicated problem detail layout that provides split-screen scrolling areas for statement and editor
- build a new inline problem workspace component with Monaco editor, execution controls, and check sample results
- refactor the problem page to use the new layout, refreshed header, and inline editor experience with updated styling

## Testing
- npm run lint *(fails: ng not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0989f4dc832f9a7cd37249fed1fc