### PR TITLE
feat: redesign problem detail layout

### DIFF
--- a/src/@core/layouts/problem-layout/problem-layout.component.html
+++ b/src/@core/layouts/problem-layout/problem-layout.component.html
@@ -1,0 +1,8 @@
+<div class="problem-layout">
+  <header class="problem-layout__header">
+    <app-header></app-header>
+  </header>
+  <main class="problem-layout__content">
+    <router-outlet></router-outlet>
+  </main>
+</div>

--- a/src/@core/layouts/problem-layout/problem-layout.component.scss
+++ b/src/@core/layouts/problem-layout/problem-layout.component.scss
@@ -1,0 +1,19 @@
+.problem-layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  background: var(--bs-body-bg);
+
+  &__header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+  }
+
+  &__content {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/src/@core/layouts/problem-layout/problem-layout.component.ts
+++ b/src/@core/layouts/problem-layout/problem-layout.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { HeaderComponent } from '@core/layouts/components/header/header.component';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-problem-layout',
+  standalone: true,
+  imports: [HeaderComponent, RouterOutlet],
+  templateUrl: './problem-layout.component.html',
+  styleUrls: ['./problem-layout.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProblemLayoutComponent {}

--- a/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.html
+++ b/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.html
@@ -1,0 +1,187 @@
+<div
+  class="workspace"
+  [formGroup]="editorForm"
+  (keydown)="onKeyDown($event)"
+>
+  <div class="workspace__header">
+    <div class="workspace__title">
+      {{ 'CodeEditor.Editor' | translate }}
+    </div>
+    <div class="workspace__controls">
+      <div class="workspace__select">
+        <label class="workspace__label">{{ 'Language' | translate }}</label>
+        <ng-select
+          class="workspace__ng-select"
+          (change)="langChange($event)"
+          [clearable]="false"
+          [formControl]="editorForm.controls.lang"
+        >
+          @for (availableLanguage of availableLanguages; track availableLanguage) {
+            <ng-option [value]="availableLanguage.lang">
+              {{ availableLanguage.langFull || availableLanguage.lang }}
+            </ng-option>
+          }
+        </ng-select>
+      </div>
+      @if (sampleTests.length > 0) {
+        <div class="workspace__select">
+          <label class="workspace__label">{{ 'CodeEditor.SampleTest' | translate }}</label>
+          <ng-select
+            class="workspace__ng-select"
+            [clearable]="false"
+            formControlName="testCaseNumber"
+          >
+            @for (sampleTest of sampleTests; track sampleTest; let i = $index) {
+              <ng-option [value]="i + 1">
+                {{ i + 1 }}
+              </ng-option>
+            }
+          </ng-select>
+        </div>
+      }
+    </div>
+  </div>
+
+  <div class="workspace__body">
+    <div class="workspace__editor">
+      <monaco-editor
+        [formControl]="editorForm.controls.code"
+        [height]="editorHeight"
+        [lang]="editorForm.controls.lang.value"
+      ></monaco-editor>
+    </div>
+    <div class="workspace__panel">
+      @if (!isSelectedLangText()) {
+        <div class="workspace__panel-section">
+          <label class="workspace__label">{{ 'CodeEditor.Input' | translate }}</label>
+          <textarea
+            class="form-control"
+            formControlName="input"
+            rows="6"
+          ></textarea>
+        </div>
+      }
+
+      @if (!isSelectedLangText()) {
+        <div class="workspace__panel-section">
+          <label class="workspace__label">{{ 'CodeEditor.Output' | translate }}</label>
+          <textarea
+            class="form-control"
+            formControlName="output"
+            rows="5"
+            readonly
+          ></textarea>
+        </div>
+      }
+
+      <div class="workspace__panel-section">
+        <label class="workspace__label">{{ 'CodeEditor.Answer' | translate }}</label>
+        <textarea
+          class="form-control"
+          formControlName="answer"
+          rows="5"
+          readonly
+        ></textarea>
+      </div>
+    </div>
+  </div>
+
+  <div class="workspace__footer">
+    <div class="workspace__footer-left">
+      @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
+        <kepcoin-spend-swal
+          (success)="checkSamplesPurchaseSuccess()"
+          [customContent]="true"
+          [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
+          [value]="100"
+        >
+          <button class="btn btn-outline-secondary btn-sm" type="button">
+            {{ 'CodeEditor.CheckSamples' | translate }}
+            <i data-feather="shopping-cart"></i>
+          </button>
+        </kepcoin-spend-swal>
+      } @else {
+        <button
+          (click)="checkSamples()"
+          class="btn btn-outline-secondary btn-sm"
+          [disabled]="isCheckSamples"
+          type="button"
+        >
+          @if (isCheckSamples) {
+            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+          }
+          {{ 'CodeEditor.CheckSamples' | translate }}
+        </button>
+      }
+    </div>
+    <div class="workspace__footer-right">
+      @if (!isSelectedLangText()) {
+        <button
+          class="btn btn-outline-primary btn-sm"
+          (click)="run()"
+          [disabled]="isRunning"
+          type="button"
+        >
+          @if (isRunning) {
+            <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+          }
+          {{ 'CodeEditor.Run' | translate }}
+        </button>
+      }
+
+      @if (answerForInputEnabled) {
+        <kepcoin-spend-swal
+          (success)="answerForInput($event)"
+          [customContent]="true"
+          [purchaseUrl]="'problems/' + problem?.id + '/answer-for-input/'"
+          [requestBody]="{input_data: editorForm.get('input')?.value}"
+          [value]="1"
+        >
+          <button class="btn btn-outline-primary btn-sm" type="button">
+            @if (isAnswerForInput) {
+              <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+            }
+            {{ 'CodeEditor.AnswerForInput' | translate }}
+          </button>
+        </kepcoin-spend-swal>
+      }
+
+      @if (submitUrl) {
+        <button
+          class="btn btn-primary btn-sm"
+          (click)="submit()"
+          [disabled]="!editorForm.valid || !canSubmit"
+          type="button"
+        >
+          {{ 'CodeEditor.Submit' | translate }}
+        </button>
+      }
+    </div>
+  </div>
+
+  @if (showResultsPanel && checkSamplesResult.length > 0) {
+    <div class="workspace__results">
+      <div class="workspace__results-header">
+        <h6 class="workspace__results-title">{{ 'CodeEditor.CheckSamples' | translate }}</h6>
+        <button class="btn btn-icon btn-sm" type="button" (click)="closeResultsPanel()">
+          <i data-feather="x"></i>
+        </button>
+      </div>
+      <div class="workspace__results-body">
+        @for (result of checkSamplesResult; track trackResult($index, result); let i = $index) {
+          <div class="workspace__result-row" [class.workspace__result-row--accepted]="result.verdict === Verdicts.OK">
+            <div class="workspace__result-index">#{{ i + 1 }}</div>
+            <div class="workspace__result-content">
+              <div class="workspace__result-label">{{ 'CodeEditor.Input' | translate }}:</div>
+              <pre class="workspace__result-pre">{{ result.input }}</pre>
+              <div class="workspace__result-label">{{ 'CodeEditor.Output' | translate }}:</div>
+              <pre class="workspace__result-pre">{{ result.output }}</pre>
+              <div class="workspace__result-label">{{ 'CodeEditor.Answer' | translate }}:</div>
+              <pre class="workspace__result-pre">{{ result.answer }}</pre>
+            </div>
+          </div>
+        }
+      </div>
+    </div>
+  }
+</div>

--- a/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.scss
+++ b/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.scss
@@ -1,0 +1,192 @@
+.workspace {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: 1.5rem;
+  background: var(--bs-body-bg);
+  color: inherit;
+  gap: 1rem;
+
+  &__header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 1rem;
+  }
+
+  &__title {
+    font-weight: 600;
+    font-size: 1.1rem;
+  }
+
+  &__controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  &__select {
+    min-width: 180px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__label {
+    font-size: 0.75rem;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
+    color: var(--bs-secondary-color);
+  }
+
+  &__body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    gap: 1rem;
+  }
+
+  &__editor {
+    flex: 1;
+    min-height: 0;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: 0.75rem;
+    overflow: hidden;
+    background: var(--bs-tertiary-bg);
+
+    @supports (backdrop-filter: blur(0)) {
+      background: color-mix(in srgb, var(--bs-body-bg) 92%, transparent);
+    }
+  }
+
+  &__panel {
+    width: 280px;
+    min-width: 240px;
+    max-width: 320px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    overflow: auto;
+    padding: 1rem;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: 0.75rem;
+    background: var(--bs-tertiary-bg);
+  }
+
+  &__panel-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    textarea {
+      resize: vertical;
+      min-height: 80px;
+    }
+  }
+
+  &__footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    padding-top: 0.5rem;
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+  }
+
+  &__footer-right,
+  &__footer-left {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  &__results {
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: 0.75rem;
+    background: var(--bs-tertiary-bg);
+    overflow: hidden;
+  }
+
+  &__results-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  }
+
+  &__results-title {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 600;
+  }
+
+  &__results-body {
+    max-height: 280px;
+    overflow: auto;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  &__result-row {
+    border-radius: 0.5rem;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    padding: 0.75rem;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.75rem;
+
+    &--accepted {
+      border-color: rgba(var(--bs-success-rgb), 0.6);
+    }
+  }
+
+  &__result-index {
+    font-weight: 600;
+    color: var(--bs-primary);
+  }
+
+  &__result-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__result-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    color: var(--bs-secondary-color);
+  }
+
+  &__result-pre {
+    margin: 0;
+    font-family: var(--bs-font-monospace);
+    background: rgba(0, 0, 0, 0.04);
+    padding: 0.5rem;
+    border-radius: 0.5rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  @media (max-width: 1200px) {
+    &__body {
+      flex-direction: column;
+    }
+
+    &__panel {
+      width: 100%;
+      max-width: none;
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: space-between;
+    }
+
+    &__panel-section {
+      flex: 1 1 220px;
+    }
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.ts
+++ b/src/app/modules/problems/pages/problem/problem-workspace/problem-workspace.component.ts
@@ -1,0 +1,379 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, HostListener, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
+import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
+import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { CValidators } from '@shared/c-validators/c-validators';
+import { AttemptLangs, Verdicts } from '@problems/constants';
+import { AvailableLanguage, Problem, SampleTest } from '@problems/models/problems.models';
+import { ApiService } from '@core/data-access/api.service';
+import { WebsocketService } from '@shared/services/websocket';
+import { LanguageService } from '@problems/services/language.service';
+import { TemplateCodeService } from '@shared/services/template-code.service';
+import { ToastrService } from 'ngx-toastr';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { paramsMapper } from '@shared/utils';
+import { findAvailableLang } from '@problems/utils';
+import { KepcoinSpendSwalModule } from '@shared/components/kepcoin-spend-swal/kepcoin-spend-swal.module';
+import { AuthService } from '@auth';
+
+interface CheckSamplesResultOne {
+  verdict: number;
+  input: string;
+  output: string;
+  answer: string;
+}
+
+@Component({
+  selector: 'app-problem-workspace',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    TranslateModule,
+    MonacoEditorComponent,
+    NgSelectModule,
+    NgbTooltipModule,
+    KepcoinSpendSwalModule,
+  ],
+  templateUrl: './problem-workspace.component.html',
+  styleUrls: ['./problem-workspace.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProblemWorkspaceComponent implements OnInit, OnDestroy, OnChanges {
+  @Input() submitUrl: string | null = null;
+  @Input() submitParams: Record<string, unknown> = {};
+  @Input() sampleTests: Array<SampleTest> = [];
+  @Input() uniqueName = '';
+  @Input() answerForInputEnabled = false;
+  @Input() availableLanguages: Array<AvailableLanguage> = [];
+  @Input() problem: Problem | null = null;
+
+  @Output() submitted = new EventEmitter<void>();
+
+  public canSubmit = true;
+  public isRunning = false;
+  public isAnswerForInput = false;
+  public isCheckSamples = false;
+  public checkSamplesResult: Array<CheckSamplesResultOne> = [];
+  public showResultsPanel = false;
+  public prevKeyCode: string | null = null;
+  public editorHeight = 560;
+
+  public readonly editorForm = new FormGroup({
+    code: new FormControl<string>('', [CValidators.maxLength({ value: 65536 })]),
+    input: new FormControl<string>('', [CValidators.maxLength({ value: 2048 })]),
+    lang: new FormControl<AttemptLangs | null>(null),
+    output: new FormControl<string>('', []),
+    answer: new FormControl<string>('', []),
+    testCaseNumber: new FormControl<number | null>(null),
+  });
+
+  protected readonly AttemptLangs = AttemptLangs;
+  protected readonly Verdicts = Verdicts;
+
+  private readonly destroy$ = new Subject<void>();
+  private initialized = false;
+
+  constructor(
+    private readonly api: ApiService,
+    private readonly toastr: ToastrService,
+    private readonly translateService: TranslateService,
+    private readonly wsService: WebsocketService,
+    private readonly langService: LanguageService,
+    private readonly templateCodeService: TemplateCodeService,
+    public readonly authService: AuthService,
+    private readonly cdr: ChangeDetectorRef,
+  ) {}
+
+  ngOnInit(): void {
+    this.updateEditorHeight();
+    this.langService.getLanguage().pipe(takeUntil(this.destroy$)).subscribe(
+      (lang: AttemptLangs) => {
+        this.editorForm.get('lang')?.setValue(lang, { emitEvent: false });
+        this.initialized = true;
+        this.initEditor();
+      }
+    );
+
+    this.editorForm.get('code')?.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(
+      (code: string | null) => {
+        const lang = this.editorForm.get('lang')?.value;
+        if (!this.uniqueName || !lang) {
+          return;
+        }
+        this.templateCodeService.save(this.uniqueName, lang, code || '');
+      }
+    );
+
+    this.wsService.on('custom-test-result').pipe(takeUntil(this.destroy$)).subscribe(
+      (result: any) => {
+        let output = (result.output || '') + (result.error || '');
+        output += `\n=========\nTime: ${result.time}ms`;
+        output += `\nMemory: ${result.memory}KB`;
+        this.isRunning = false;
+        this.editorForm.get('output')?.setValue(output);
+        this.cdr.markForCheck();
+      }
+    );
+
+    this.wsService.on('answer-for-input-result').pipe(takeUntil(this.destroy$)).subscribe(
+      (result: { answer: string }) => {
+        this.editorForm.get('answer')?.setValue('Answer:\n' + result.answer);
+        this.isAnswerForInput = false;
+        this.cdr.markForCheck();
+      }
+    );
+
+    this.wsService.on('check-sample-tests-result').pipe(takeUntil(this.destroy$)).subscribe(
+      (result: Array<CheckSamplesResultOne>) => {
+        this.checkSamplesResult = result;
+        this.isCheckSamples = false;
+        this.showResultsPanel = true;
+        this.cdr.markForCheck();
+      }
+    );
+
+    this.editorForm.get('testCaseNumber')?.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(
+      () => this.onSampleTestChange()
+    );
+  }
+
+  @HostListener('window:resize')
+  onResize() {
+    this.updateEditorHeight();
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if ('availableLanguages' in changes && this.initialized) {
+      this.ensureLanguageSelected();
+      this.initEditor();
+    }
+
+    if ('sampleTests' in changes && this.sampleTests?.length) {
+      this.onSampleTestChange();
+    }
+
+    if ('problem' in changes) {
+      this.ensureLanguageSelected();
+      this.initEditor();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  langChange(lang: AttemptLangs) {
+    this.langService.setLanguage(lang);
+    this.editorForm.get('lang')?.setValue(lang, { emitEvent: false });
+    this.initEditor();
+  }
+
+  run() {
+    if (this.isRunning) {
+      return;
+    }
+    this.isRunning = true;
+    this.editorForm.get('output')?.setValue('');
+    const data = {
+      sourceCode: this.editorForm.get('code')?.value,
+      lang: this.editorForm.get('lang')?.value,
+      inputData: this.editorForm.get('input')?.value,
+    };
+
+    this.api.post('problems/custom-test/', data).subscribe(
+      (result: any) => {
+        this.wsService.send('custom-test-add', result.id);
+      },
+      () => {
+        this.isRunning = false;
+        this.cdr.markForCheck();
+      }
+    );
+
+    setTimeout(() => {
+      this.isRunning = false;
+      this.cdr.markForCheck();
+    }, 5000);
+  }
+
+  submit() {
+    if (!this.canSubmit || !this.submitUrl) {
+      return;
+    }
+
+    this.canSubmit = false;
+    const data = {
+      sourceCode: this.editorForm.get('code')?.value,
+      lang: this.editorForm.get('lang')?.value,
+      ...this.submitParams,
+    };
+
+    this.api.post(this.submitUrl, data).subscribe(
+      () => {
+        const text = this.translateService.instant('SubmittedSuccess');
+        this.toastr.success('', text);
+        this.submitted.emit();
+        this.canSubmit = true;
+        this.cdr.markForCheck();
+      },
+      () => {
+        this.canSubmit = true;
+        this.toastr.error(this.translateService.instant('Error'));
+        this.cdr.markForCheck();
+      }
+    );
+  }
+
+  answerForInput(result: { id: number }) {
+    if (this.isAnswerForInput) {
+      return;
+    }
+    this.isAnswerForInput = true;
+    this.wsService.send('answer-for-input-add', result.id);
+    setTimeout(() => {
+      this.isAnswerForInput = false;
+      this.cdr.markForCheck();
+    }, 15000);
+  }
+
+  checkSamples() {
+    if (this.isCheckSamples || !this.problem) {
+      return;
+    }
+    this.isCheckSamples = true;
+    this.showResultsPanel = true;
+    const data = {
+      lang: this.editorForm.controls.lang.value,
+      sourceCode: this.editorForm.controls.code.value,
+    };
+    this.api.post(`problems/${this.problem.id}/check-sample-tests`, paramsMapper(data)).subscribe(
+      (result) => {
+        this.wsService.send('check-sample-tests-add', result.id);
+      },
+      () => {
+        this.isCheckSamples = false;
+        this.cdr.markForCheck();
+      }
+    );
+    setTimeout(() => {
+      this.isCheckSamples = false;
+      this.cdr.markForCheck();
+    }, 15000);
+  }
+
+  onKeyDown(event: KeyboardEvent) {
+    if (this.prevKeyCode === 'AltLeft' && event.code === 'Enter') {
+      this.submit();
+    }
+    if (this.prevKeyCode === 'AltLeft' && event.code === 'KeyX') {
+      this.run();
+    }
+    if (this.prevKeyCode === 'AltLeft' && event.code === 'KeyZ') {
+      this.checkSamples();
+    }
+    this.prevKeyCode = event.code;
+  }
+
+  closeResultsPanel() {
+    this.showResultsPanel = false;
+  }
+
+  checkSamplesPurchaseSuccess() {
+    if (this.authService.currentUserValue?.permissions) {
+      this.authService.currentUserValue.permissions.canUseCheckSamples = true;
+    }
+  }
+
+  isSelectedLangText() {
+    return this.editorForm.get('lang')?.value === AttemptLangs.TEXT;
+  }
+
+  trackResult(index: number, item: CheckSamplesResultOne) {
+    return `${index}-${item.verdict}-${item.input}`;
+  }
+
+  private initEditor() {
+    if (!this.availableLanguages?.length) {
+      return;
+    }
+
+    this.ensureLanguageSelected();
+    const editorLang = this.editorForm.get('lang')?.value as AttemptLangs | null;
+    if (!editorLang) {
+      return;
+    }
+
+    const saved = this.templateCodeService.get(this.uniqueName, editorLang);
+    const template = findAvailableLang(this.availableLanguages, editorLang)?.codeTemplate
+      || this.availableLanguages[0]?.codeTemplate
+      || '';
+
+    const currentCode = this.editorForm.get('code')?.value;
+    if (!currentCode) {
+      this.editorForm.get('code')?.setValue(saved || template, { emitEvent: false });
+    } else if (saved && currentCode !== saved) {
+      this.editorForm.get('code')?.setValue(saved, { emitEvent: false });
+    }
+
+    if (!this.sampleTests?.length) {
+      this.editorForm.get('testCaseNumber')?.setValue(null, { emitEvent: false });
+    } else if (!this.editorForm.get('testCaseNumber')?.value) {
+      this.editorForm.get('testCaseNumber')?.setValue(1, { emitEvent: false });
+      this.onSampleTestChange();
+    } else {
+      this.onSampleTestChange();
+    }
+
+    this.cdr.markForCheck();
+  }
+
+  private ensureLanguageSelected() {
+    if (!this.availableLanguages?.length) {
+      return;
+    }
+    const langControl = this.editorForm.get('lang');
+    const current = langControl?.value;
+    if (current && findAvailableLang(this.availableLanguages, current)) {
+      return;
+    }
+
+    const defaultLang = this.availableLanguages[0]?.lang as AttemptLangs | undefined;
+    if (defaultLang) {
+      langControl?.setValue(defaultLang, { emitEvent: false });
+      this.langService.setLanguage(defaultLang);
+    }
+  }
+
+  private onSampleTestChange() {
+    if (!this.sampleTests?.length) {
+      return;
+    }
+    const testCaseNumber = this.editorForm.get('testCaseNumber')?.value;
+    if (!testCaseNumber) {
+      this.editorForm.get('input')?.setValue('');
+      this.editorForm.get('answer')?.setValue('');
+      return;
+    }
+
+    const sampleTest = this.sampleTests[testCaseNumber - 1];
+    if (!sampleTest) {
+      return;
+    }
+    this.editorForm.get('input')?.setValue(sampleTest.input || '');
+    this.editorForm.get('answer')?.setValue(sampleTest.output || '');
+    this.editorForm.get('output')?.setValue('');
+    this.cdr.markForCheck();
+  }
+
+  private updateEditorHeight() {
+    const reservedSpace = 220;
+    this.editorHeight = Math.max(window.innerHeight - reservedSpace, 320);
+    this.cdr.markForCheck();
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -1,177 +1,165 @@
-<div class="content-wrapper container-xxl p-0">
-  <div class="content-body">
-    <app-content-header [contentHeader]="contentHeader">
-      <div class="btn-group" role="group">
-        <button
-          class="btn btn-primary-light btn-wave"
-          type="button"
-          (click)="goToPreviousProblem()"
-          ngbTooltip="{{ 'PreviousProblem' | translate }}"
-        >
-          <kep-icon name="left"/>
-        </button>
-        <button
-          class="btn btn-primary-light btn-wave"
-          type="button"
-          (click)="goToNextProblem()"
-          ngbTooltip="{{ 'NextProblem' | translate }}"
-        >
-          <kep-icon name="right"/>
-        </button>
+@if (problem as resolvedProblem) {
+<div class="problem-page">
+  <div class="problem-page__toolbar">
+    <div class="problem-page__toolbar-group">
+      <button
+        class="btn btn-icon btn-outline-primary"
+        type="button"
+        ngbTooltip="{{ 'PreviousProblem' | translate }}"
+        (click)="goToPreviousProblem()"
+      >
+        <kep-icon name="left"/>
+      </button>
+      <button
+        class="btn btn-icon btn-outline-primary"
+        type="button"
+        ngbTooltip="{{ 'NextProblem' | translate }}"
+        (click)="goToNextProblem()"
+      >
+        <kep-icon name="right"/>
+      </button>
+    </div>
+    <div class="problem-page__title">
+      <h1 class="problem-page__title-text">{{ resolvedProblem.title }}</h1>
+      <div class="problem-page__meta">
+        <span class="problem-page__meta-item">#{{ resolvedProblem.id }}</span>
+        <span class="problem-page__meta-separator">•</span>
+        <span class="problem-page__meta-item">{{ resolvedProblem.difficultyTitle }}</span>
+        <span class="problem-page__meta-separator">•</span>
+        <span class="problem-page__meta-item">{{ 'Problems.Solved' | translate }}: {{ resolvedProblem.solved }}</span>
+        <span class="problem-page__meta-separator">•</span>
+        <span class="problem-page__meta-item">{{ 'Problems.Attempts' | translate }}: {{ resolvedProblem.attemptsCount }}</span>
       </div>
-    </app-content-header>
-    <section  class="mt-2">
-      <div class="row">
-        <div class="col-lg-9 col-md-12 col-sm-12">
-          <kep-card>
-            <div class="card-header">
-              <ul
-                #navWithIcons="ngbNav"
-                (activeIdChange)="activeIdChange($event)" [(activeId)]="activeId" [destroyOnHide]="false"
-                class="nav-tabs" ngbNav>
-                <li [ngbNavItem]="1">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
-                    {{ 'Problem' | translate }}
-                  </a>
-                  <ng-template ngbNavContent>
-                    <problem-description [problem]="problem"></problem-description>
-                  </ng-template>
-                </li>
+    </div>
+    <div class="problem-page__limits">
+      <div class="problem-page__limit">{{ 'Problems.TimeLimit' | translate }}: {{ resolvedProblem.timeLimit }} ms</div>
+      <div class="problem-page__limit">{{ 'Problems.MemoryLimit' | translate }}: {{ resolvedProblem.memoryLimit }} MB</div>
+    </div>
+  </div>
 
-                <li [ngbNavItem]="2">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
-                    {{ 'Attempts' | translate }}
-                  </a>
-                  <ng-template ngbNavContent>
-                    <problem-attempts
-                      (hackSubmitted)="activeId = 3;"
-                      [problem]="problem"
-                      [submitEvent]="submitEvent?.asObservable()"
-                    >
-                    </problem-attempts>
-                  </ng-template>
-                </li>
+  <div class="problem-page__layout">
+    <section class="problem-page__statement">
+      <div class="problem-page__statement-scroll">
+        <div class="problem-page__links">
+          <a class="problem-page__link" routerLink="/practice/problems">
+            <kep-icon size="small-4" name="list"/>
+            {{ 'Problems.Problems' | translate }}
+          </a>
 
-                @if (problem.hasCheckInput) {
-                  <li [ngbNavItem]="3" destroyOnHide="true">
-                    <a class="nav-link" ngbNavLink>
-                      <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
-                      {{ 'Hacks' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-hacks [problem]="problem"></problem-hacks>
-                    </ng-template>
-                  </li>
-                }
+          @if (studyPlanId) {
+            <a class="problem-page__link" [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
+              <kep-icon size="small-4" name="book-open"/>
+              {{ 'StudyPlan' | translate }}
+            </a>
+          }
 
-                @if (studyPlanId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
-                      <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (contestId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.ContestProblems | resourceById:contestId">
-                      <kep-icon name="contest" color="primary" type="duotone"/>
-                      {{ 'Contest' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-              </ul>
-
-              @if (isAuthenticated) {
-                <button (click)="codeEditorSidebarToggle()" class="btn btn-sm btn-primary">{{ 'Submit' | translate }}
-                </button>
-              }
-            </div>
-
-            <div class="card-footer">
-              <div [ngbNavOutlet]="navWithIcons"></div>
-            </div>
-          </kep-card>
-
-          @if (currentUser?.permissions.canCreateProblems) {
-            <div class="card">
-              <div class="card-header">
-                <div class="card-title">
-                  Check input
-                </div>
-              </div>
-              <div class="card-body">
-                <monaco-editor
-                  [lang]="'py'"
-                  class="mt-1"
-                  [ngModelOptions]="{standalone: true}"
-                  [(ngModel)]="checkInput"
-                ></monaco-editor>
-                <div class="btn mt-2 btn-primary btn-sm" (click)="saveCheckInput()">Save</div>
-              </div>
-            </div>
+          @if (contestId) {
+            <a class="problem-page__link" [routerLink]="Resources.ContestProblems | resourceById:contestId">
+              <kep-icon size="small-4" name="contest"/>
+              {{ 'Contest' | translate }}
+            </a>
           }
         </div>
 
-        <div class="col-lg-3 col-md-12 col-sm-12">
-          <problem-sidebar [problem]="problem"></problem-sidebar>
+        <ul
+          #navWithIcons="ngbNav"
+          class="problem-page__tabs"
+          ngbNav
+          [(activeId)]="activeId"
+          (activeIdChange)="activeIdChange($event)"
+          [destroyOnHide]="false"
+        >
+          <li [ngbNavItem]="1">
+            <a class="nav-link" ngbNavLink>
+              <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
+              {{ 'Problem' | translate }}
+            </a>
+            <ng-template ngbNavContent>
+              <problem-description [problem]="resolvedProblem"></problem-description>
+            </ng-template>
+          </li>
 
-          @if (isAuthenticated) {
-            <problem-submit-card
-              [availableLanguages]="problem.availableLanguages"
-              [submitUrl]="'problems/' + problem.id + '/submit/'"
-              (submitted)="onSubmit()"
-            />
+          <li [ngbNavItem]="2">
+            <a class="nav-link" ngbNavLink>
+              <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
+              {{ 'Attempts' | translate }}
+            </a>
+            <ng-template ngbNavContent>
+              <problem-attempts
+                [problem]="resolvedProblem"
+                [submitEvent]="submitEvent?.asObservable()"
+                (hackSubmitted)="activeId = 3;"
+              ></problem-attempts>
+            </ng-template>
+          </li>
+
+          @if (resolvedProblem.hasCheckInput) {
+            <li [ngbNavItem]="3" destroyOnHide="true">
+              <a class="nav-link" ngbNavLink>
+                <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
+                {{ 'Hacks' | translate }}
+              </a>
+              <ng-template ngbNavContent>
+                <problem-hacks [problem]="resolvedProblem"></problem-hacks>
+              </ng-template>
+            </li>
           }
+        </ul>
+
+        <div class="problem-page__tab-content" [ngbNavOutlet]="navWithIcons"></div>
+
+        <div class="problem-page__sidebar">
+          <problem-sidebar [problem]="resolvedProblem"></problem-sidebar>
         </div>
 
+        @if (currentUser?.permissions.canCreateProblems) {
+          <div class="problem-page__check-input">
+            <div class="problem-page__check-input-header">Check input</div>
+            <monaco-editor
+              [lang]="AttemptLangs.PY"
+              [height]="220"
+              class="problem-page__check-input-editor"
+              [ngModelOptions]="{standalone: true}"
+              [(ngModel)]="checkInput"
+            ></monaco-editor>
+            <button class="btn btn-sm btn-primary mt-1" type="button" (click)="saveCheckInput()">
+              {{ 'Save' | translate }}
+            </button>
+          </div>
+        }
       </div>
+    </section>
 
-      @if (problem && isAuthenticated) {
-        <code-editor-modal
-          [customClass]="'tour-step-2'"
-          [uniqueName]="'problem-' + problem.id"
-          [sampleTests]="problem.sampleTests"
-          [submitUrl]="'problems/' + problem.id + '/submit/'"
-          [problem]="problem"
-          [answerForInputEnabled]="problem.hasSolution && problem.hasCheckInput"
-          [availableLanguages]="problem.availableLanguages"
-          (submittedEvent)="onSubmit()"></code-editor-modal>
+    <section class="problem-page__workspace">
+      @if (isAuthenticated) {
+        <app-problem-workspace
+          class="problem-page__workspace-editor"
+          [problem]="resolvedProblem"
+          [sampleTests]="resolvedProblem.sampleTests || []"
+          [availableLanguages]="resolvedProblem.availableLanguages || []"
+          [submitUrl]="'problems/' + resolvedProblem.id + '/submit/'"
+          [uniqueName]="'problem-' + resolvedProblem.id"
+          [answerForInputEnabled]="resolvedProblem.hasSolution && resolvedProblem.hasCheckInput"
+          (submitted)="onSubmit()"
+        ></app-problem-workspace>
+
+        <div class="problem-page__file-submit">
+          <problem-submit-card
+            [availableLanguages]="resolvedProblem.availableLanguages || []"
+            [submitUrl]="'problems/' + resolvedProblem.id + '/submit/'"
+            (submitted)="onSubmit()"
+          ></problem-submit-card>
+        </div>
+      } @else {
+        <div class="problem-page__auth-overlay">
+          <h5>{{ 'Auth.Login' | translate }}</h5>
+          <a class="btn btn-primary" routerLink="/login">{{ 'Auth.Login' | translate }}</a>
+        </div>
       }
     </section>
   </div>
 </div>
+}
 
 <tour-css></tour-css>
 <ng-select-css></ng-select-css>
-
-<!--<div class="col-lg-6 col-md-12 col-sm-12">-->
-<!--  <kep-card>-->
-<!--    <div class="card-header p-2">-->
-<!--      <div class="card-title">-->
-<!--        <kep-icon name="square-brackets" color="primary" type="duotone"/>-->
-<!--        {{ 'Code' | translate }}-->
-<!--      </div>-->
-<!--    </div>-->
-
-<!--    <ng-select-->
-<!--      [appendTo]="'body'"-->
-<!--      [clearable]="false">-->
-<!--      @for (availableLanguage of problem.availableLanguages; track availableLanguage) {-->
-<!--        <ng-option-->
-<!--          [value]="availableLanguage.lang">-->
-<!--          {{ availableLanguage.langFull || availableLanguage.lang }}-->
-<!--        </ng-option>-->
-<!--      }-->
-<!--    </ng-select>-->
-<!--    <monaco-editor lang="py"/>-->
-<!--  </kep-card>-->
-<!--</div>-->

--- a/src/app/modules/problems/pages/problem/problem.component.scss
+++ b/src/app/modules/problems/pages/problem/problem.component.scss
@@ -1,19 +1,222 @@
-.card .card-header {
-  padding: 1rem !important;
-  padding-bottom: 0 !important;
-  align-items: center;
-}
-
-.problem-container {
+.problem-page {
+  display: flex;
+  flex-direction: column;
   height: 100%;
+  min-height: 0;
+  padding: 1.5rem 1.5rem 0;
+  background: var(--bs-body-bg);
+  color: inherit;
+
+  &__toolbar {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 1.5rem;
+    align-items: center;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  }
+
+  &__toolbar-group {
+    display: flex;
+    gap: 0.75rem;
+  }
+
+  &__title {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  &__title-text {
+    margin: 0;
+    font-size: clamp(1.4rem, 2vw, 1.8rem);
+    font-weight: 600;
+    line-height: 1.2;
+  }
+
+  &__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+    font-size: 0.85rem;
+    color: var(--bs-secondary-color);
+  }
+
+  &__meta-separator {
+    opacity: 0.4;
+  }
+
+  &__limits {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-size: 0.8rem;
+    color: var(--bs-secondary-color);
+    text-align: right;
+  }
+
+  &__layout {
+    flex: 1;
+    min-height: 0;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(420px, 45%);
+    gap: 1.5rem;
+    padding: 1.5rem 0 1.5rem;
+  }
+
+  &__statement {
+    position: relative;
+    overflow: hidden;
+    border-radius: 1rem;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    background: var(--bs-tertiary-bg);
+    backdrop-filter: blur(6px);
+    min-height: 0;
+  }
+
+  &__statement-scroll {
+    height: 100%;
+    overflow-y: auto;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  &__links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  &__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    font-weight: 500;
+    padding: 0.4rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(var(--bs-primary-rgb), 0.08);
+    color: var(--bs-primary);
+    text-decoration: none;
+    transition: background 0.2s ease;
+
+    &:hover {
+      background: rgba(var(--bs-primary-rgb), 0.16);
+    }
+  }
+
+  &__tabs {
+    display: flex;
+    flex-wrap: wrap;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    padding-bottom: 0.75rem;
+    gap: 0.5rem;
+  }
+
+  &__tab-content {
+    flex: 1;
+    min-height: 0;
+  }
+
+  &__sidebar {
+    border-radius: 0.75rem;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    background: color-mix(in srgb, var(--bs-body-bg) 90%, transparent);
+    padding: 1rem;
+  }
+
+  &__check-input {
+    border-radius: 0.75rem;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+    padding: 1rem;
+    background: color-mix(in srgb, var(--bs-body-bg) 92%, transparent);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+
+  &__check-input-header {
+    font-weight: 600;
+  }
+
+  &__check-input-editor {
+    border-radius: 0.5rem;
+    overflow: hidden;
+    border: 1px solid rgba(0, 0, 0, 0.05);
+  }
+
+  &__workspace {
+    position: relative;
+    overflow: hidden;
+    border-radius: 1rem;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    background: var(--bs-tertiary-bg);
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  &__workspace-editor {
+    flex: 1;
+    min-height: 0;
+  }
+
+  &__file-submit {
+    padding: 1rem 1.5rem 1.5rem;
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+  }
+
+  &__auth-overlay {
+    margin: auto;
+    text-align: center;
+    padding: 2rem;
+    max-width: 320px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    background: rgba(var(--bs-body-color-rgb), 0.03);
+    border-radius: 1rem;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  @media (max-width: 1400px) {
+    &__layout {
+      grid-template-columns: minmax(0, 1fr) minmax(360px, 45%);
+    }
+  }
+
+  @media (max-width: 1200px) {
+    padding: 1rem;
+
+    &__layout {
+      grid-template-columns: 1fr;
+    }
+
+    &__workspace,
+    &__statement {
+      min-height: 60vh;
+    }
+  }
+
+  @media (max-width: 768px) {
+    &__toolbar {
+      grid-template-columns: 1fr;
+      text-align: left;
+    }
+
+    &__limits {
+      flex-direction: row;
+      justify-content: space-between;
+      text-align: left;
+    }
+  }
 }
 
-/* Стили для блока с кодом */
-pre {
-  background-color: #f8f9fa;
-  padding: 1rem;
-  border-radius: 0.3rem;
-  overflow-x: auto;
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
 }
-
-/* Дополнительные стили можно добавить по необходимости */

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -3,6 +3,7 @@ import { Params } from '@angular/router';
 import { AuthUser } from '@auth';
 import { Subject } from 'rxjs';
 import { Problem } from '@problems/models/problems.models';
+import { AttemptLangs } from '@problems/constants';
 import { ProblemsApiService } from '../../services/problems-api.service';
 import { ApiService } from '@core/data-access/api.service';
 import { CoreCommonModule } from '@core/common.module';
@@ -10,20 +11,13 @@ import { NgbNavModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { ProblemDescriptionComponent } from '@problems/pages/problem/problem-description/problem-description.component';
 import { ProblemAttemptsComponent } from '@problems/pages/problem/problem-attempts/problem-attempts.component';
 import { ProblemHacksComponent } from '@problems/pages/problem/problem-hacks/problem-hacks.component';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
-import { CodeEditorModule } from '@shared/components/code-editor/code-editor.module';
 import { ProblemSidebarComponent } from '@problems/pages/problem/problem-sidebar/problem-sidebar.component';
-import { TourModule } from '@shared/third-part-modules/tour/tour.module';
-import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
-import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
 import { BasePageComponent } from '@core/common/classes/base-page.component';
-import { SidebarService } from '@shared/ui/sidebar/sidebar.service';
-import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
-import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
-
 import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
 import { take } from 'rxjs/operators';
 import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
+import { ProblemWorkspaceComponent } from './problem-workspace/problem-workspace.component';
+import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
 
 @Component({
   selector: 'app-problem',
@@ -32,26 +26,21 @@ import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
   standalone: true,
   imports: [
     CoreCommonModule,
-    ContentHeaderModule,
     NgbNavModule,
+    NgbTooltipModule,
     ProblemDescriptionComponent,
     ProblemAttemptsComponent,
     ProblemHacksComponent,
-    MonacoEditorModule,
-    CodeEditorModule,
     ProblemSidebarComponent,
-    TourModule,
-    NgSelectModule,
-    MonacoEditorComponent,
-    KepCardComponent,
-
     ProblemSubmitCardComponent,
-    NgbTooltipModule,
+    ProblemWorkspaceComponent,
+    MonacoEditorComponent,
     ResourceByIdPipe,
   ]
 })
 export class ProblemComponent extends BasePageComponent implements OnInit {
   public problem: Problem;
+  protected readonly AttemptLangs = AttemptLangs;
 
   public activeId = 1;
   public studyPlanId: number;
@@ -62,16 +51,16 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
   constructor(
     public service: ProblemsApiService,
     public api: ApiService,
-    protected coreSidebarService: SidebarService,
   ) {
     super();
   }
 
   ngOnInit(): void {
-    if (this._queryParams.tab === 'hacks') {
-      this.activeId = 3;
-    } else if (this._queryParams.tab === 'attempts') {
+    const currentPath = this.route.snapshot.routeConfig?.path;
+    if (currentPath === 'attempts' || this._queryParams.tab === 'attempts') {
       this.activeId = 2;
+    } else if (currentPath === 'hacks' || this._queryParams.tab === 'hacks') {
+      this.activeId = 3;
     }
 
     this.route.data.subscribe(({ problem }) => {
@@ -136,12 +125,7 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     );
   }
 
-  codeEditorSidebarToggle() {
-    this.coreSidebarService.getSidebarRegistry('codeEditorSidebar').toggleOpen();
-  }
-
   onSubmit() {
-    console.log(4142);
     this.activeId = 2;
     this.submitEvent.next(null);
   }

--- a/src/app/modules/problems/problems.routing.ts
+++ b/src/app/modules/problems/problems.routing.ts
@@ -2,6 +2,7 @@ import { Route } from '@angular/router';
 import { ProblemResolver } from "@problems/problems.resolver";
 import { ProblemGuard } from "@problems/problems.guard";
 import { AuthGuard } from "@auth";
+import { ProblemLayoutComponent } from '@core/layouts/problem-layout/problem-layout.component';
 
 export default [
   {
@@ -22,36 +23,42 @@ export default [
   // },
   {
     path: 'problem/:id',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/attempts',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/hacks',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
+    component: ProblemLayoutComponent,
+    children: [
+      {
+        path: '',
+        loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: {
+          title: 'Problems.Problem',
+        },
+        resolve: {
+          problem: ProblemResolver,
+        },
+        canActivate: [ProblemGuard],
+      },
+      {
+        path: 'attempts',
+        loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: {
+          title: 'Problems.Problem',
+        },
+        resolve: {
+          problem: ProblemResolver,
+        },
+        canActivate: [ProblemGuard],
+      },
+      {
+        path: 'hacks',
+        loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: {
+          title: 'Problems.Problem',
+        },
+        resolve: {
+          problem: ProblemResolver,
+        },
+        canActivate: [ProblemGuard],
+      },
+    ]
   },
   // {
   //   path: 'problem/:id/og-image',


### PR DESCRIPTION
## Summary
- add a dedicated problem layout with header-only chrome
- rebuild the problem page to provide a LeetCode-style two-panel workspace and inline editor
- introduce a reusable problem workspace component and route the problem pages through the new layout

## Testing
- npm run lint *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0989f4dc832f9a7cd37249fed1fc