### PR TITLE
feat: redesign problem detail layout

### DIFF
--- a/src/@core/layouts/problem-layout/problem-layout.component.html
+++ b/src/@core/layouts/problem-layout/problem-layout.component.html
@@ -1,0 +1,6 @@
+<div class="problem-layout">
+  <app-header class="problem-layout__header"></app-header>
+  <main class="problem-layout__main">
+    <router-outlet></router-outlet>
+  </main>
+</div>

--- a/src/@core/layouts/problem-layout/problem-layout.component.scss
+++ b/src/@core/layouts/problem-layout/problem-layout.component.scss
@@ -1,0 +1,13 @@
+.problem-layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--bs-body-bg);
+}
+
+.problem-layout__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--bs-body-bg);
+}

--- a/src/@core/layouts/problem-layout/problem-layout.component.ts
+++ b/src/@core/layouts/problem-layout/problem-layout.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+import { HeaderComponent } from '@core/layouts/components/header/header.component';
+
+@Component({
+  selector: 'app-problem-layout',
+  standalone: true,
+  templateUrl: './problem-layout.component.html',
+  styleUrl: './problem-layout.component.scss',
+  imports: [RouterOutlet, HeaderComponent],
+})
+export class ProblemLayoutComponent {}

--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -652,6 +652,7 @@ export const localeEn = {
     SampleTest: 'Sample test',
     AnswerForInput: 'Answer for input',
     CheckSamples: 'Check on samples',
+    NoResultsYet: 'No sample results yet.',
   },
   Courses: {
     Courses: 'Courses',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -646,6 +646,7 @@ export const localeRu = {
     Test: 'Проверка',
     AnswerForInput: 'Ответ на тест',
     CheckSamples: 'Проверить на тестах',
+    NoResultsYet: 'Результатов пока нет.',
   },
   Courses: {
     Courses: 'Курсы',

--- a/src/app/modules/problems/pages/problem/problem.component.html
+++ b/src/app/modules/problems/pages/problem/problem.component.html
@@ -1,177 +1,169 @@
-<div class="content-wrapper container-xxl p-0">
-  <div class="content-body">
-    <app-content-header [contentHeader]="contentHeader">
-      <div class="btn-group" role="group">
+@if (!problem) {
+  <div class="problem-page problem-page--loading">
+    <spinner></spinner>
+  </div>
+} @else {
+  <div class="problem-page">
+    <div class="problem-page__topbar">
+      <div class="problem-page__meta">
+        <div class="problem-page__breadcrumbs">
+          <a class="problem-page__crumb-link" [routerLink]="['/practice/problems']">{{ 'Problems' | translate }}</a>
+          <span class="problem-page__crumb-separator">/</span>
+          <span class="problem-page__crumb-current">{{ problem.id }}. {{ problem.title }}</span>
+        </div>
+        <h1 class="problem-page__title">
+          <span class="problem-page__title-id">{{ problem.id }}.</span>
+          <span>{{ problem.title }}</span>
+        </h1>
+      </div>
+
+      <div class="problem-page__actions">
         <button
-          class="btn btn-primary-light btn-wave"
+          class="problem-page__nav-btn"
           type="button"
           (click)="goToPreviousProblem()"
           ngbTooltip="{{ 'PreviousProblem' | translate }}"
         >
-          <kep-icon name="left"/>
+          <kep-icon name="left" size="small-4"></kep-icon>
         </button>
         <button
-          class="btn btn-primary-light btn-wave"
+          class="problem-page__nav-btn"
           type="button"
           (click)="goToNextProblem()"
           ngbTooltip="{{ 'NextProblem' | translate }}"
         >
-          <kep-icon name="right"/>
+          <kep-icon name="right" size="small-4"></kep-icon>
         </button>
       </div>
-    </app-content-header>
-    <section  class="mt-2">
-      <div class="row">
-        <div class="col-lg-9 col-md-12 col-sm-12">
-          <kep-card>
-            <div class="card-header">
-              <ul
-                #navWithIcons="ngbNav"
-                (activeIdChange)="activeIdChange($event)" [(activeId)]="activeId" [destroyOnHide]="false"
-                class="nav-tabs" ngbNav>
-                <li [ngbNavItem]="1">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="primary" name="problem" type="duotone"/>
-                    {{ 'Problem' | translate }}
+    </div>
+
+    <div class="problem-page__body">
+      <div class="problem-page__statement">
+        <div class="problem-page__statement-scroll">
+          <problem-sidebar
+            class="problem-page__sidebar"
+            [problem]="problem"
+          ></problem-sidebar>
+
+          <div class="problem-page__tabs">
+            <ul
+              #navWithIcons="ngbNav"
+              class="problem-page__tablist"
+              ngbNav
+              [destroyOnHide]="false"
+              [(activeId)]="activeId"
+              (activeIdChange)="activeIdChange($event)"
+            >
+              <li [ngbNavItem]="1">
+                <a class="problem-page__tab" ngbNavLink>
+                  <kep-icon size="small-4" color="primary" name="problem" type="duotone"></kep-icon>
+                  {{ 'Problem' | translate }}
+                </a>
+                <ng-template ngbNavContent>
+                  <problem-description [problem]="problem"></problem-description>
+                </ng-template>
+              </li>
+
+              <li [ngbNavItem]="2">
+                <a class="problem-page__tab" ngbNavLink>
+                  <kep-icon size="small-4" color="warning" name="attempt" type="duotone"></kep-icon>
+                  {{ 'Attempts' | translate }}
+                </a>
+                <ng-template ngbNavContent>
+                  <problem-attempts
+                    (hackSubmitted)="activeId = 3;"
+                    [problem]="problem"
+                    [submitEvent]="submitEvent?.asObservable()"
+                  >
+                  </problem-attempts>
+                </ng-template>
+              </li>
+
+              @if (problem.hasCheckInput) {
+                <li [ngbNavItem]="3" destroyOnHide="true">
+                  <a class="problem-page__tab" ngbNavLink>
+                    <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"></kep-icon>
+                    {{ 'Hacks' | translate }}
+                  </a>
+                  <ng-template ngbNavContent>
+                    <problem-hacks [problem]="problem"></problem-hacks>
+                  </ng-template>
+                </li>
+              }
+
+              @if (studyPlanId) {
+                <li [ngbNavItem]="4">
+                  <a class="problem-page__tab" ngbNavLink [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
+                    <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
                   </a>
                   <ng-template ngbNavContent>
                     <problem-description [problem]="problem"></problem-description>
                   </ng-template>
                 </li>
+              }
 
-                <li [ngbNavItem]="2">
-                  <a class="nav-link" ngbNavLink>
-                    <kep-icon size="small-4" color="warning" name="attempt" type="duotone"/>
-                    {{ 'Attempts' | translate }}
+              @if (contestId) {
+                <li [ngbNavItem]="5">
+                  <a class="problem-page__tab" ngbNavLink [routerLink]="Resources.ContestProblems | resourceById:contestId">
+                    <kep-icon name="contest" color="primary" type="duotone"></kep-icon>
+                    {{ 'Contest' | translate }}
                   </a>
                   <ng-template ngbNavContent>
-                    <problem-attempts
-                      (hackSubmitted)="activeId = 3;"
-                      [problem]="problem"
-                      [submitEvent]="submitEvent?.asObservable()"
-                    >
-                    </problem-attempts>
+                    <problem-description [problem]="problem"></problem-description>
                   </ng-template>
                 </li>
-
-                @if (problem.hasCheckInput) {
-                  <li [ngbNavItem]="3" destroyOnHide="true">
-                    <a class="nav-link" ngbNavLink>
-                      <kep-icon size="small-4" name="lock-2" color="dark" type="duotone"/>
-                      {{ 'Hacks' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-hacks [problem]="problem"></problem-hacks>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (studyPlanId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.StudyPlan | resourceById:studyPlanId">
-                      <span [data-feather]="'activity'"></span> {{ 'StudyPlan' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-
-                @if (contestId) {
-                  <li [ngbNavItem]="4">
-                    <a ngbNavLink [routerLink]="Resources.ContestProblems | resourceById:contestId">
-                      <kep-icon name="contest" color="primary" type="duotone"/>
-                      {{ 'Contest' | translate }}
-                    </a>
-                    <ng-template ngbNavContent>
-                      <problem-description [problem]="problem"></problem-description>
-                    </ng-template>
-                  </li>
-                }
-              </ul>
-
-              @if (isAuthenticated) {
-                <button (click)="codeEditorSidebarToggle()" class="btn btn-sm btn-primary">{{ 'Submit' | translate }}
-                </button>
               }
-            </div>
+            </ul>
 
-            <div class="card-footer">
-              <div [ngbNavOutlet]="navWithIcons"></div>
-            </div>
-          </kep-card>
+            <div class="problem-page__tab-content" [ngbNavOutlet]="navWithIcons"></div>
+          </div>
 
           @if (currentUser?.permissions.canCreateProblems) {
-            <div class="card">
-              <div class="card-header">
-                <div class="card-title">
-                  Check input
-                </div>
+            <div class="problem-page__check-input">
+              <div class="problem-page__check-header">
+                <div class="problem-page__check-title">Check input</div>
+                <button class="btn btn-sm btn-primary" type="button" (click)="saveCheckInput()">Save</button>
               </div>
-              <div class="card-body">
-                <monaco-editor
-                  [lang]="'py'"
-                  class="mt-1"
-                  [ngModelOptions]="{standalone: true}"
-                  [(ngModel)]="checkInput"
-                ></monaco-editor>
-                <div class="btn mt-2 btn-primary btn-sm" (click)="saveCheckInput()">Save</div>
-              </div>
+              <monaco-editor
+                [lang]="'py'"
+                [height]="300"
+                class="problem-page__check-editor"
+                [ngModelOptions]="{standalone: true}"
+                [(ngModel)]="checkInput"
+              ></monaco-editor>
             </div>
           }
         </div>
+      </div>
 
-        <div class="col-lg-3 col-md-12 col-sm-12">
-          <problem-sidebar [problem]="problem"></problem-sidebar>
+      <div class="problem-page__editor-column">
+        <div class="problem-page__editor">
+          <code-editor-modal
+            [customClass]="'tour-step-2'"
+            [layout]="'inline'"
+            [uniqueName]="'problem-' + problem.id"
+            [sampleTests]="problem.sampleTests"
+            [submitUrl]="'problems/' + problem.id + '/submit/'"
+            [problem]="problem"
+            [answerForInputEnabled]="problem.hasSolution && problem.hasCheckInput"
+            [availableLanguages]="problem.availableLanguages"
+            (submittedEvent)="onSubmit()"
+          ></code-editor-modal>
+        </div>
 
-          @if (isAuthenticated) {
+        @if (isAuthenticated) {
+          <div class="problem-page__uploader">
             <problem-submit-card
               [availableLanguages]="problem.availableLanguages"
               [submitUrl]="'problems/' + problem.id + '/submit/'"
               (submitted)="onSubmit()"
-            />
-          }
-        </div>
-
+            ></problem-submit-card>
+          </div>
+        }
       </div>
-
-      @if (problem && isAuthenticated) {
-        <code-editor-modal
-          [customClass]="'tour-step-2'"
-          [uniqueName]="'problem-' + problem.id"
-          [sampleTests]="problem.sampleTests"
-          [submitUrl]="'problems/' + problem.id + '/submit/'"
-          [problem]="problem"
-          [answerForInputEnabled]="problem.hasSolution && problem.hasCheckInput"
-          [availableLanguages]="problem.availableLanguages"
-          (submittedEvent)="onSubmit()"></code-editor-modal>
-      }
-    </section>
+    </div>
   </div>
-</div>
+}
 
 <tour-css></tour-css>
 <ng-select-css></ng-select-css>
-
-<!--<div class="col-lg-6 col-md-12 col-sm-12">-->
-<!--  <kep-card>-->
-<!--    <div class="card-header p-2">-->
-<!--      <div class="card-title">-->
-<!--        <kep-icon name="square-brackets" color="primary" type="duotone"/>-->
-<!--        {{ 'Code' | translate }}-->
-<!--      </div>-->
-<!--    </div>-->
-
-<!--    <ng-select-->
-<!--      [appendTo]="'body'"-->
-<!--      [clearable]="false">-->
-<!--      @for (availableLanguage of problem.availableLanguages; track availableLanguage) {-->
-<!--        <ng-option-->
-<!--          [value]="availableLanguage.lang">-->
-<!--          {{ availableLanguage.langFull || availableLanguage.lang }}-->
-<!--        </ng-option>-->
-<!--      }-->
-<!--    </ng-select>-->
-<!--    <monaco-editor lang="py"/>-->
-<!--  </kep-card>-->
-<!--</div>-->

--- a/src/app/modules/problems/pages/problem/problem.component.scss
+++ b/src/app/modules/problems/pages/problem/problem.component.scss
@@ -1,19 +1,252 @@
-.card .card-header {
-  padding: 1rem !important;
-  padding-bottom: 0 !important;
+.problem-page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+}
+
+.problem-page--loading {
   align-items: center;
+  justify-content: center;
+  padding: 3rem;
 }
 
-.problem-container {
-  height: 100%;
+.problem-page__topbar {
+  padding: 1.5rem clamp(1rem, 3vw, 3rem);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  border-bottom: 1px solid rgba(var(--bs-body-color-rgb, 34, 41, 47), 0.1);
+  background-color: inherit;
 }
 
-/* Стили для блока с кодом */
-pre {
-  background-color: #f8f9fa;
-  padding: 1rem;
-  border-radius: 0.3rem;
-  overflow-x: auto;
+.problem-page__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
 }
 
-/* Дополнительные стили можно добавить по необходимости */
+.problem-page__breadcrumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: rgba(var(--bs-body-color-rgb, 34, 41, 47), 0.7);
+}
+
+.problem-page__crumb-link {
+  color: inherit;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.problem-page__title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.75rem;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  margin: 0;
+  font-weight: 600;
+}
+
+.problem-page__title-id {
+  color: rgba(var(--bs-body-color-rgb, 34, 41, 47), 0.6);
+}
+
+.problem-page__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.problem-page__nav-btn {
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bs-primary-bg-subtle, rgba(40, 120, 255, 0.08));
+  border: 1px solid transparent;
+  color: var(--bs-primary, #2854ff);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.12);
+  }
+}
+
+.problem-page__body {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem clamp(1rem, 3vw, 3rem) 2rem;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  background-color: inherit;
+}
+
+.problem-page__statement,
+.problem-page__editor-column {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.problem-page__statement-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.problem-page__sidebar {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.problem-page__tabs {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.problem-page__tablist {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  border-bottom: 1px solid rgba(var(--bs-body-color-rgb, 34, 41, 47), 0.08);
+}
+
+.problem-page__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  font-weight: 500;
+  color: rgba(var(--bs-body-color-rgb, 34, 41, 47), 0.75);
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+
+  &.active,
+  &:hover {
+    background-color: var(--bs-primary, #2854ff);
+    color: #fff;
+  }
+}
+
+.problem-page__tab-content {
+  flex: 1;
+  min-height: 0;
+  margin-top: 1.25rem;
+  padding-right: 0.5rem;
+}
+
+.problem-page__check-input {
+  border: 1px solid rgba(var(--bs-body-color-rgb, 34, 41, 47), 0.1);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  background-color: rgba(var(--bs-body-bg-rgb, 255, 255, 255), 0.9);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.problem-page__check-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.problem-page__check-title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.problem-page__check-editor {
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.problem-page__editor {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-radius: 1.25rem;
+  overflow: hidden;
+  background-color: rgba(var(--bs-body-bg-rgb, 255, 255, 255), 0.9);
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+}
+
+.problem-page__uploader {
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 1199.98px) {
+  .problem-page__body {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+  }
+}
+
+@media (max-width: 991.98px) {
+  .problem-page__topbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .problem-page__actions {
+    justify-content: flex-end;
+  }
+
+  .problem-page__body {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .problem-page__statement-scroll {
+    padding-right: 0;
+    overflow: visible;
+  }
+
+  .problem-page__editor {
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.12);
+  }
+}
+
+@media (max-width: 575.98px) {
+  .problem-page__topbar {
+    padding: 1.25rem;
+  }
+
+  .problem-page__body {
+    padding: 1.25rem;
+  }
+
+  .problem-page__tablist {
+    gap: 0.35rem;
+  }
+
+  .problem-page__tab {
+    padding: 0.45rem 0.75rem;
+  }
+}

--- a/src/app/modules/problems/pages/problem/problem.component.ts
+++ b/src/app/modules/problems/pages/problem/problem.component.ts
@@ -10,16 +10,12 @@ import { NgbNavModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { ProblemDescriptionComponent } from '@problems/pages/problem/problem-description/problem-description.component';
 import { ProblemAttemptsComponent } from '@problems/pages/problem/problem-attempts/problem-attempts.component';
 import { ProblemHacksComponent } from '@problems/pages/problem/problem-hacks/problem-hacks.component';
-import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { CodeEditorModule } from '@shared/components/code-editor/code-editor.module';
 import { ProblemSidebarComponent } from '@problems/pages/problem/problem-sidebar/problem-sidebar.component';
 import { TourModule } from '@shared/third-part-modules/tour/tour.module';
 import { NgSelectModule } from '@shared/third-part-modules/ng-select/ng-select.module';
 import { MonacoEditorComponent } from '@shared/third-part-modules/monaco-editor/monaco-editor.component';
 import { BasePageComponent } from '@core/common/classes/base-page.component';
-import { SidebarService } from '@shared/ui/sidebar/sidebar.service';
-import { ContentHeaderModule } from '@shared/ui/components/content-header/content-header.module';
-import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 
 import { ProblemSubmitCardComponent } from '@problems/components/problem-submit-card/problem-submit-card.component';
 import { take } from 'rxjs/operators';
@@ -32,18 +28,15 @@ import { ResourceByIdPipe } from '@shared/pipes/resource-by-id.pipe';
   standalone: true,
   imports: [
     CoreCommonModule,
-    ContentHeaderModule,
     NgbNavModule,
     ProblemDescriptionComponent,
     ProblemAttemptsComponent,
     ProblemHacksComponent,
-    MonacoEditorModule,
     CodeEditorModule,
     ProblemSidebarComponent,
     TourModule,
     NgSelectModule,
     MonacoEditorComponent,
-    KepCardComponent,
 
     ProblemSubmitCardComponent,
     NgbTooltipModule,
@@ -62,7 +55,6 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
   constructor(
     public service: ProblemsApiService,
     public api: ApiService,
-    protected coreSidebarService: SidebarService,
   ) {
     super();
   }
@@ -81,7 +73,6 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
         problemId: this.problem.id
       });
       this.checkInput = this.problem.checkInputSource;
-      this.loadContentHeader();
     });
   }
 
@@ -95,26 +86,6 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
   }
 
   beforeChangeCurrentUser(currentUser: AuthUser) {}
-
-  getContentHeader() {
-    return this.contentHeader = {
-      headerTitle: this.problem.title,
-      breadcrumb: {
-        type: '',
-        links: [
-          {
-            name: 'Problems',
-            isLink: true,
-            link: '/practice/problems',
-          },
-          {
-            name: this.problem.id + '',
-            isLink: false,
-          },
-        ]
-      }
-    };
-  }
 
   activeIdChange(index: number) {
     if (index === 1) {
@@ -136,12 +107,7 @@ export class ProblemComponent extends BasePageComponent implements OnInit {
     );
   }
 
-  codeEditorSidebarToggle() {
-    this.coreSidebarService.getSidebarRegistry('codeEditorSidebar').toggleOpen();
-  }
-
   onSubmit() {
-    console.log(4142);
     this.activeId = 2;
     this.submitEvent.next(null);
   }

--- a/src/app/modules/problems/problems.routing.ts
+++ b/src/app/modules/problems/problems.routing.ts
@@ -2,6 +2,7 @@ import { Route } from '@angular/router';
 import { ProblemResolver } from "@problems/problems.resolver";
 import { ProblemGuard } from "@problems/problems.guard";
 import { AuthGuard } from "@auth";
+import { ProblemLayoutComponent } from "@core/layouts/problem-layout/problem-layout.component";
 
 export default [
   {
@@ -22,36 +23,42 @@ export default [
   // },
   {
     path: 'problem/:id',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/attempts',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
-  },
-  {
-    path: 'problem/:id/hacks',
-    loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
-    data: {
-      title: 'Problems.Problem',
-    },
-    resolve: {
-      problem: ProblemResolver,
-    },
-    canActivate: [ProblemGuard],
+    component: ProblemLayoutComponent,
+    children: [
+      {
+        path: '',
+        loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: {
+          title: 'Problems.Problem',
+        },
+        resolve: {
+          problem: ProblemResolver,
+        },
+        canActivate: [ProblemGuard],
+      },
+      {
+        path: 'attempts',
+        loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: {
+          title: 'Problems.Problem',
+        },
+        resolve: {
+          problem: ProblemResolver,
+        },
+        canActivate: [ProblemGuard],
+      },
+      {
+        path: 'hacks',
+        loadComponent: () => import('./pages/problem/problem.component').then(c => c.ProblemComponent),
+        data: {
+          title: 'Problems.Problem',
+        },
+        resolve: {
+          problem: ProblemResolver,
+        },
+        canActivate: [ProblemGuard],
+      },
+    ],
   },
   // {
   //   path: 'problem/:id/og-image',

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.html
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.html
@@ -1,278 +1,303 @@
-<sidebar [hideOnEsc]="true" [name]="sidebarName" class="code-editor-sidebar">
-  <a
-    (click)="toggleSidebar()"
-    class="btn-toggle d-flex align-items-center justify-content-center">
-    <i [data-feather]="'terminal'"></i>
-  </a>
-
-  <ng-scrollbar>
-    <kep-card (keydown)="onKeyDown($event)" customClass="full-height position-relative">
-      <div class="card-header">
-        <div class="card-title">
-          {{ 'CodeEditor.Editor' | translate }}
-        </div>
-
-        <div class="d-flex justify-content-between">
-          <button (click)="toggleSidebar()" aria-label="Close" class="btn-close" type="button"></button>
-        </div>
+<ng-template #editorCard>
+  <kep-card (keydown)="onKeyDown($event)" customClass="full-height position-relative code-editor-card">
+    <div class="card-header d-flex align-items-center justify-content-between">
+      <div class="card-title mb-0">
+        {{ 'CodeEditor.Editor' | translate }}
       </div>
-      <hr class="mt-0 mb-50">
-      <div [formGroup]="editorForm" class="card-body">
-        <div class="row">
-          <div class="col-lg-8 col-md-7 col-12">
-            <div
-              [ngbTooltip]="editorForm.controls.code.errors | errorMessage"
-              [style.height.%]="100"
-              container="body"
-              tooltipClass="tooltip-danger"
-            >
-              <monaco-editor
-                [formControl]="editorForm.controls.code"
-                [height]="480"
-                [lang]="editorForm.controls.lang.value">
-              </monaco-editor>
-            </div>
+      @if (!isInlineLayout) {
+        <button (click)="toggleSidebar()" aria-label="Close" class="btn-close" type="button"></button>
+      }
+    </div>
+    <hr class="mt-0 mb-50">
+    <div [formGroup]="editorForm" class="card-body code-editor-card__body">
+      <div class="row g-3">
+        <div class="col-xl-8 col-lg-7 col-12">
+          <div
+            class="code-editor-card__editor-wrapper"
+            [ngbTooltip]="editorForm.controls.code.errors | errorMessage"
+            container="body"
+            tooltipClass="tooltip-danger"
+          >
+            <monaco-editor
+              class="code-editor-card__editor"
+              [formControl]="editorForm.controls.code"
+              [height]="editorHeight"
+              [lang]="editorForm.controls.lang.value">
+            </monaco-editor>
+          </div>
+        </div>
+
+        <div class="col-xl-4 col-lg-5 d-none d-lg-block">
+          <div class="mb-1">
+            <label class="fw-medium">{{ 'Language' | translate }}: </label>
+            <ng-select
+              (change)="langChange($event)"
+              [clearable]="false"
+              [formControl]="editorForm.controls.lang">
+              @for (availableLanguage of availableLanguages; track availableLanguage) {
+                <ng-option [value]="availableLanguage.lang">
+                  {{ availableLanguage.langFull || availableLanguage.lang }}
+                </ng-option>
+              }
+            </ng-select>
           </div>
 
-          <div class="col-lg-4 col-md-5 d-none d-md-block">
+          @if (sampleTests.length > 0) {
             <div class="mb-1">
-              <label class="fw-medium">{{ 'Language' | translate }}: </label>
+              <label class="fw-medium">{{ 'CodeEditor.SampleTest' | translate }}: </label>
               <ng-select
-                (change)="langChange($event)"
+                (change)="onSampleTestChange()"
                 [clearable]="false"
-                [formControl]="editorForm.controls.lang">
-                @for (availableLanguage of availableLanguages; track availableLanguage) {
-                  <ng-option
-                    [value]="availableLanguage.lang">
-                    {{ availableLanguage.langFull || availableLanguage.lang }}
+                formControlName="testCaseNumber"
+              >
+                @for (sampleTest of sampleTests; track sampleTest; let i = $index) {
+                  <ng-option value="{{ i + 1 }}">
+                    {{ i + 1 }}
                   </ng-option>
                 }
               </ng-select>
             </div>
+          }
 
-            @if (sampleTests.length > 0) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.SampleTest' | translate }}: </label>
-                <ng-select
-                  (change)="onSampleTestChange()"
-                  [clearable]="false"
-                  formControlName="testCaseNumber"
-                >
-                  @for (sampleTest of sampleTests; track sampleTest; let i = $index) {
-                    <ng-option
-                      value="{{ i + 1 }}">
-                      {{ i + 1 }}
-                    </ng-option>
-                  }
-                </ng-select>
-              </div>
-            }
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Input' | translate }}:</label>
+              <textarea
+                [ngbTooltip]="editorForm.controls.input.errors | errorMessage"
+                class="form-control"
+                formControlName="input"
+                rows="3"
+                tooltipClass="tooltip-danger"
+              ></textarea>
+            </div>
+          }
 
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Input' | translate }}:</label>
-                <textarea
-                  [ngbTooltip]="editorForm.controls.input.errors | errorMessage"
-                  class="form-control"
-                  formControlName="input"
-                  placeholder=""
-                  rows="3"
-                  tooltipClass="tooltip-danger"
-                ></textarea>
-              </div>
-            }
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Output' | translate }}:</label>
+              <textarea
+                class="form-control"
+                formControlName="output"
+                rows="2"
+              ></textarea>
+            </div>
+          }
 
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Output' | translate }}:</label>
-                <textarea
-                  class="form-control"
-                  formControlName="output"
-                  rows="2"
-                ></textarea>
-              </div>
-            }
-
-            @if (!isSelectedLangText()) {
-              <div class="mb-1">
-                <label class="fw-medium">{{ 'CodeEditor.Answer' | translate }}:</label>
-                <textarea
-                  class="form-control"
-                  formControlName="answer"
-                  rows="2"
-                ></textarea>
-              </div>
-            }
-          </div>
+          @if (!isSelectedLangText()) {
+            <div class="mb-1">
+              <label class="fw-medium">{{ 'CodeEditor.Answer' | translate }}:</label>
+              <textarea
+                class="form-control"
+                formControlName="answer"
+                rows="2"
+              ></textarea>
+            </div>
+          }
         </div>
       </div>
+    </div>
 
-      <div class="card-footer d-none d-md-flex justify-content-between">
-        @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
-          <kepcoin-spend-swal
-            (success)="checkSamplesPurchaseSuccess()"
-            [customContent]="true"
-            [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
-            [value]="100"
-          >
-            <div new-feature class="position-relative">
-              <button class="btn btn-glow btn-dark bg-dark">
-                {{ 'CodeEditor.CheckSamples' | translate }}
-                <i data-feather="shopping-cart"></i>
-              </button>
-            </div>
-          </kepcoin-spend-swal>
-        } @else {
+    <div class="card-footer d-none d-lg-flex justify-content-between align-items-center">
+      @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
+        <kepcoin-spend-swal
+          (success)="checkSamplesPurchaseSuccess()"
+          [customContent]="true"
+          [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
+          [value]="100"
+        >
+          <div new-feature class="position-relative">
+            <button class="btn btn-glow btn-dark bg-dark">
+              {{ 'CodeEditor.CheckSamples' | translate }}
+              <i data-feather="shopping-cart"></i>
+            </button>
+          </div>
+        </kepcoin-spend-swal>
+      } @else {
+        <button
+          (click)="checkSamples()"
+          class="btn btn-glow btn-dark bg-dark me-1"
+          type="button">
+          @if (isCheckSamples) {
+            <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
+          }
+          @if (!isCheckSamples) {
+            <span><i data-feather="terminal"></i></span>
+          }
+          {{ 'CodeEditor.CheckSamples' | translate }}
+        </button>
+      }
+      <div class="d-flex flex-wrap gap-2">
+        @if (!isSelectedLangText()) {
           <button
-            (click)="checkSamples()"
-            ngbTooltip="Alt+Z"
-            class="btn btn-glow btn-dark bg-dark me-1"
+            (click)="run()"
+            class="btn btn-glow btn-dark bg-dark"
             type="button">
-            @if (isCheckSamples) {
+            @if (isRunning) {
               <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
             }
-            @if (!isCheckSamples) {
+            @if (!isRunning) {
               <span><i data-feather="terminal"></i></span>
             }
-            {{ 'CodeEditor.CheckSamples' | translate }}
+            {{ 'CodeEditor.Run' | translate }}
           </button>
         }
-        <div class="d-flex">
-          @if (!isSelectedLangText()) {
-            <button
-              ngbTooltip="Alt+X"
-              (click)="run()"
-              class="btn btn-glow btn-dark bg-dark me-1"
-              type="button">
-              @if (isRunning) {
-                <span aria-hidden="true" class="spinner-border spinner-border-sm" role="status"></span>
+
+        @if (answerForInputEnabled) {
+          <kepcoin-spend-swal
+            (success)="answerForInput($event)"
+            [customContent]="true"
+            [purchaseUrl]="'problems/' + problem?.id + '/answer-for-input/'"
+            [requestBody]="{input_data: editorForm.get('input').value}"
+            [value]="1"
+          >
+            <button class="btn btn-glow btn-dark bg-dark" type="button">
+              @if (isAnswerForInput) {
+                <span class="spinner-border spinner-border-sm" role="status"></span>
               }
-              @if (!isRunning) {
-                <span><i data-feather="terminal"></i></span>
+              @if (!isAnswerForInput) {
+                <span><i data-feather="check-square"></i></span>
               }
-              {{ 'CodeEditor.Run' | translate }}
+              {{ 'CodeEditor.AnswerForInput' | translate }}
             </button>
-          }
+          </kepcoin-spend-swal>
+        }
 
-          @if (answerForInputEnabled) {
-            <kepcoin-spend-swal
-              (success)="answerForInput($event)"
-              [customContent]="true"
-              [purchaseUrl]="'problems/' + problem?.id + '/answer-for-input/'"
-              [requestBody]="{input_data: editorForm.get('input').value}"
-              [value]="1"
-            >
-              <button class="btn btn-glow btn-dark bg-dark me-1" type="button">
-                @if (isAnswerForInput) {
-                  <span
-                    class="spinner-border spinner-border-sm"
-                    role="status">
-                  </span>
-                }
-                @if (!isAnswerForInput) {
-                  <span>
-                    <i data-feather="check-square"></i>
-                  </span>
-                }
-                {{ 'CodeEditor.AnswerForInput' | translate }}
-              </button>
-            </kepcoin-spend-swal>
-          }
-
-          @if (submitUrl) {
-            <button
-              ngbTooltip="Alt+Enter"
-              (click)="submit()"
-              [disabled]="!editorForm.valid"
-              class="btn btn-glow btn-dark bg-dark"
-              type="submit">
-              <i data-feather="send"></i>
-              {{ 'CodeEditor.Submit' | translate }}
-            </button>
-          }
-        </div>
-      </div>
-
-      <div class="card-footer d-md-none d-block text-end">
         @if (submitUrl) {
           <button
-            ngbTooltip="Alt+Enter"
             (click)="submit()"
             [disabled]="!editorForm.valid"
-            class="btn btn-glow btn-dark bg-dark"
+            class="btn btn-glow btn-primary"
             type="submit">
             <i data-feather="send"></i>
             {{ 'CodeEditor.Submit' | translate }}
           </button>
         }
       </div>
-    </kep-card>
-  </ng-scrollbar>
-</sidebar>
+    </div>
 
-<sidebar [hideOnEsc]="true" [name]="checkSamplesResultSidebarName" class="check-samples-result">
-  <ng-scrollbar autoWidthDisabled="false">
-    <div (keydown)="onKeyDown($event)" class="card results-card full-height position-relative">
-      @if (isCheckSamples) {
-        <div class="card-body" [style.height.px]="200">
-          <spinner [name]="checkSamplesResultSidebarName"></spinner>
-        </div>
+    <div class="card-footer d-lg-none d-flex flex-wrap gap-2 justify-content-end">
+      @if (authService.currentUserValue?.permissions?.canUseCheckSamples === false) {
+        <kepcoin-spend-swal
+          (success)="checkSamplesPurchaseSuccess()"
+          [customContent]="true"
+          [purchaseUrl]="'problems/' + problem?.id + '/purchase-check-samples/'"
+          [value]="100"
+        >
+          <button class="btn btn-dark" type="button">
+            {{ 'CodeEditor.CheckSamples' | translate }}
+          </button>
+        </kepcoin-spend-swal>
       } @else {
-        <div class="card-header">
-          <div class="card-title">
-            {{ 'Result' | translate }}
-          </div>
-        </div>
-        <hr class="mt-0 mb-0">
-        <div class="card-body">
-          <!--          <ngb-accordion [closeOthers]="false" [destroyOnHide]="false">-->
-          <!--            @for (result of checkSamplesResult; track result.input){-->
-          <!--              <ngb-panel [cardClass]="'collapse-margin'" [id]="'result' + $index">-->
-          <!--                <ng-template ngbPanelTitle>-->
-          <!--                  <div class="fw-semibold d-flex justify-content-between">-->
-          <!--                    <span>TC #{{ $index + 1 }}</span>-->
-          <!--                    <span [class]="{-->
-          <!--                      'text-success': result.verdict == Verdicts.Accepted,-->
-          <!--                      'text-danger': result.verdict != Verdicts.Accepted,-->
-          <!--                    }">{{ result.verdict | verdictShortTitle }}</span>-->
-          <!--                  </div>-->
-          <!--                </ng-template>-->
-          <!--                <ng-template ngbPanelContent>-->
-          <!--                  @if (result.input) {-->
-          <!--                    <div class="meta">-->
-          <!--                      <div class="fw-medium">Input:</div>-->
-          <!--                      <div>{{ result.input }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
+        <button (click)="checkSamples()" class="btn btn-dark" type="button">
+          {{ 'CodeEditor.CheckSamples' | translate }}
+        </button>
+      }
 
-          <!--                  @if (result.answer) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Answer:</div>-->
-          <!--                      <div>{{ result.answer }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
+      @if (!isSelectedLangText()) {
+        <button (click)="run()" class="btn btn-outline-dark" type="button">
+          {{ 'CodeEditor.Run' | translate }}
+        </button>
+      }
 
-          <!--                  @if (result.output) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Output:</div>-->
-          <!--                      <div>{{ result.output }}</div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-
-          <!--                  @if (result.error) {-->
-          <!--                    <div>-->
-          <!--                      <div class="fw-medium">Error:</div>-->
-          <!--                      <div><pre>{{ result.error }}</pre></div>-->
-          <!--                    </div>-->
-          <!--                  }-->
-          <!--                </ng-template>-->
-          <!--              </ngb-panel>-->
-          <!--            }-->
-          <!--          </ngb-accordion>-->
-        </div>
+      @if (submitUrl) {
+        <button
+          (click)="submit()"
+          [disabled]="!editorForm.valid"
+          class="btn btn-primary"
+          type="submit">
+          {{ 'CodeEditor.Submit' | translate }}
+        </button>
       }
     </div>
+  </kep-card>
+</ng-template>
+
+<ng-template #editorWrapper>
+  <ng-scrollbar class="code-editor-scroll">
+    <ng-container *ngTemplateOutlet="editorCard"></ng-container>
   </ng-scrollbar>
-</sidebar>
+</ng-template>
+
+<ng-template #resultCard>
+  <ng-scrollbar autoWidthDisabled="false" class="code-editor-result-scroll">
+    <div (keydown)="onKeyDown($event)" class="card results-card full-height position-relative">
+      <div class="card-header d-flex align-items-center justify-content-between">
+        <div class="card-title mb-0">
+          {{ 'Result' | translate }}
+        </div>
+        <button class="btn-close" type="button" aria-label="Close" (click)="closeResultSidebar()"></button>
+      </div>
+      <hr class="mt-0 mb-0">
+      <div class="card-body">
+        @if (isCheckSamples) {
+          <div class="d-flex align-items-center justify-content-center" [style.minHeight.px]="160">
+            <spinner [name]="checkSamplesResultSidebarName"></spinner>
+          </div>
+        } @else {
+          <!-- additional result rendering can be placed here -->
+          <div class="text-muted small">
+            @if (checkSamplesResult.length === 0) {
+              {{ 'CodeEditor.NoResultsYet' | translate }}
+            } @else {
+              @for (result of checkSamplesResult; track result.input; let i = $index) {
+                <div class="mb-2">
+                  <div class="fw-semibold d-flex justify-content-between">
+                    <span>TC #{{ i + 1 }}</span>
+                    <span [class]="{
+                      'text-success': result.verdict == Verdicts.Accepted,
+                      'text-danger': result.verdict != Verdicts.Accepted
+                    }">{{ result.verdict | verdictShortTitle }}</span>
+                  </div>
+                  @if (result.input) {
+                    <div class="mt-25">
+                      <div class="fw-medium">{{ 'CodeEditor.Input' | translate }}</div>
+                      <pre class="bg-light border rounded p-50 mb-0">{{ result.input }}</pre>
+                    </div>
+                  }
+                  @if (result.output) {
+                    <div class="mt-25">
+                      <div class="fw-medium">{{ 'CodeEditor.Output' | translate }}</div>
+                      <pre class="bg-light border rounded p-50 mb-0">{{ result.output }}</pre>
+                    </div>
+                  }
+                  @if (result.answer) {
+                    <div class="mt-25">
+                      <div class="fw-medium">{{ 'CodeEditor.Answer' | translate }}</div>
+                      <pre class="bg-light border rounded p-50 mb-0">{{ result.answer }}</pre>
+                    </div>
+                  }
+                </div>
+              }
+            }
+          </div>
+        }
+      </div>
+    </div>
+  </ng-scrollbar>
+</ng-template>
+
+@if (!isInlineLayout) {
+  <sidebar [hideOnEsc]="true" [name]="sidebarName" class="code-editor-sidebar">
+    <a
+      (click)="toggleSidebar()"
+      class="btn-toggle d-flex align-items-center justify-content-center">
+      <i [data-feather]="'terminal'"></i>
+    </a>
+    <ng-container *ngTemplateOutlet="editorWrapper"></ng-container>
+  </sidebar>
+
+  <sidebar [hideOnEsc]="true" [name]="checkSamplesResultSidebarName" class="check-samples-result">
+    <ng-container *ngTemplateOutlet="resultCard"></ng-container>
+  </sidebar>
+} @else {
+  <div class="code-editor-inline" [class.code-editor-inline--with-result]="resultSidebarIsOpened">
+    <div class="code-editor-inline__main">
+      <ng-container *ngTemplateOutlet="editorWrapper"></ng-container>
+    </div>
+    <div class="code-editor-inline__result" *ngIf="resultSidebarIsOpened">
+      <ng-container *ngTemplateOutlet="resultCard"></ng-container>
+    </div>
+  </div>
+}
 
 <ng-select-css></ng-select-css>

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.scss
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.scss
@@ -123,3 +123,107 @@
     }
   }
 }
+
+.code-editor-card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  border-radius: 1.25rem;
+
+  @include dark-layout {
+    background-color: rgba(16, 23, 41, 0.95) !important;
+  }
+
+  .card-header {
+    padding: 1.25rem 1.5rem !important;
+  }
+
+  .card-body {
+    padding: 0 1.5rem 1.5rem 1.5rem !important;
+  }
+
+  .card-footer {
+    padding: 1rem 1.5rem 1.25rem !important;
+  }
+}
+
+.code-editor-card__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.code-editor-card__editor-wrapper {
+  height: 100%;
+  border-radius: 1rem;
+  overflow: hidden;
+  background: rgba(40, 120, 255, 0.08);
+  backdrop-filter: blur(6px);
+
+  @include dark-layout {
+    background: rgba(40, 120, 255, 0.18);
+  }
+}
+
+.code-editor-card__editor {
+  width: 100%;
+  height: 100%;
+}
+
+.code-editor-scroll,
+.code-editor-result-scroll {
+  height: 100%;
+
+  .ng-scroll-viewport,
+  .ng-scroll-content {
+    height: 100%;
+  }
+}
+
+.code-editor-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  height: 100%;
+  min-height: 0;
+}
+
+.code-editor-inline__main {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.code-editor-inline__main .code-editor-scroll {
+  flex: 1;
+}
+
+.code-editor-inline__result {
+  flex: 0 0 auto;
+}
+
+.code-editor-inline__result .results-card {
+  border-radius: 1.25rem;
+  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.12);
+
+  @include dark-layout {
+    background: rgba(16, 23, 41, 0.95);
+  }
+}
+
+.code-editor-inline--with-result {
+  gap: 1.25rem;
+}
+
+@include media-breakpoint-down(lg) {
+  .code-editor-card .card-body {
+    padding-right: 1rem !important;
+    padding-left: 1rem !important;
+  }
+
+  .code-editor-card .card-footer {
+    padding-right: 1rem !important;
+    padding-left: 1rem !important;
+  }
+}

--- a/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.ts
+++ b/src/app/shared/components/code-editor/code-editor-modal/code-editor-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Language, TranslateService } from '@ngx-translate/core';
 import { LanguageService } from 'app/modules/problems/services/language.service';
@@ -32,7 +32,7 @@ interface CheckSamplesResultOne {
   encapsulation: ViewEncapsulation.None,
   standalone: false,
 })
-export class CodeEditorModalComponent implements OnInit {
+export class CodeEditorModalComponent implements OnInit, OnChanges {
 
   @Input() submitUrl: string;
   @Input() submitParams: any = {};
@@ -42,6 +42,7 @@ export class CodeEditorModalComponent implements OnInit {
   @Input() answerForInputEnabled = false;
   @Input() availableLanguages: Array<AvailableLanguage> = [];
   @Input() problem: Problem;
+  @Input() layout: 'sidebar' | 'inline' = 'sidebar';
   @Output() submittedEvent = new EventEmitter<null>();
 
   public canSubmit = true;
@@ -66,6 +67,7 @@ export class CodeEditorModalComponent implements OnInit {
 
   public checkSamplesResult: Array<CheckSamplesResultOne> = [];
   protected readonly Verdicts = Verdicts;
+  public inlineResultVisible = false;
 
   constructor(
     public api: ApiService,
@@ -83,17 +85,36 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   get sidebarIsOpened() {
-    return this.coreSidebarService.getSidebarRegistry(this.sidebarName).isOpened;
+    if (this.isInlineLayout) {
+      return true;
+    }
+    const sidebar = this.coreSidebarService.getSidebarRegistry(this.sidebarName);
+    return sidebar?.isOpened ?? false;
   }
 
   get resultSidebarIsOpened() {
-    return this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName).isOpened;
+    if (this.isInlineLayout) {
+      return this.inlineResultVisible;
+    }
+    const sidebar = this.coreSidebarService.getSidebarRegistry(this.checkSamplesResultSidebarName);
+    return sidebar?.isOpened ?? false;
+  }
+
+  get isInlineLayout() {
+    return this.layout === 'inline';
+  }
+
+  get editorHeight() {
+    return this.isInlineLayout ? '100%' : 480;
   }
 
   ngOnInit(): void {
     this.langService.getLanguage().subscribe(
       (lang: string) => {
         this.editorForm.get('lang').setValue(lang);
+        if (this.isInlineLayout) {
+          this.init();
+        }
       }
     );
 
@@ -148,9 +169,21 @@ export class CodeEditorModalComponent implements OnInit {
     );
   }
 
+  ngOnChanges(changes: SimpleChanges): void {
+    if (this.isInlineLayout && (changes['availableLanguages'] || changes['layout'])) {
+      this.init();
+    }
+  }
+
   init() {
-    const editorLang = this.editorForm.get('lang').value as AttemptLangs;
-    console.log(editorLang)
+    if (!this.availableLanguages?.length) {
+      return;
+    }
+    let editorLang = this.editorForm.get('lang').value as AttemptLangs;
+    if (!editorLang) {
+      editorLang = this.langService.getLanguageValue();
+      this.editorForm.get('lang').setValue(editorLang);
+    }
     const code = this.templateCodeService.get(this.uniqueName, editorLang)
       || findAvailableLang(this.availableLanguages, editorLang)?.codeTemplate
       || this.availableLanguages[0].codeTemplate;
@@ -215,7 +248,9 @@ export class CodeEditorModalComponent implements OnInit {
       return;
     }
 
-    this.toggleSidebar();
+    if (!this.isInlineLayout) {
+      this.toggleSidebar();
+    }
     this.canSubmit = false;
     const data = {
       sourceCode: this.editorForm.get('code').value,
@@ -238,6 +273,9 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   toggleSidebar(): void {
+    if (this.isInlineLayout) {
+      return;
+    }
     if (!this.sidebarIsOpened) {
       this.openSidebar();
     } else {
@@ -246,6 +284,10 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   openSidebar() {
+    if (this.isInlineLayout) {
+      this.init();
+      return;
+    }
     if (this.sidebarIsOpened) {
       return;
     }
@@ -254,6 +296,10 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   closeSidebar() {
+    if (this.isInlineLayout) {
+      this.closeResultSidebar();
+      return;
+    }
     if (!this.sidebarIsOpened) {
       return;
     }
@@ -262,6 +308,10 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   openResultSidebar() {
+    if (this.isInlineLayout) {
+      this.inlineResultVisible = true;
+      return;
+    }
     if (this.resultSidebarIsOpened) {
       return;
     }
@@ -269,6 +319,10 @@ export class CodeEditorModalComponent implements OnInit {
   }
 
   closeResultSidebar() {
+    if (this.isInlineLayout) {
+      this.inlineResultVisible = false;
+      return;
+    }
     if (!this.resultSidebarIsOpened) {
       return;
     }

--- a/src/app/shared/third-part-modules/monaco-editor/monaco-editor.component.ts
+++ b/src/app/shared/third-part-modules/monaco-editor/monaco-editor.component.ts
@@ -20,7 +20,7 @@ import { AppStateService } from "@core/services/app-state.service";
 @Component({
   selector: 'monaco-editor',
   template: `
-    <ngx-monaco-editor [style.height.px]="height" [options]="options" [(ngModel)]="value"></ngx-monaco-editor>`,
+    <ngx-monaco-editor [style.height]="heightStyle" [options]="options" [(ngModel)]="value"></ngx-monaco-editor>`,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,
@@ -38,7 +38,7 @@ export class MonacoEditorComponent implements ControlValueAccessor, OnInit, OnCh
   @ViewChild(EditorComponent) editorComponent: EditorComponent;
 
   @Input() lang: AttemptLangs;
-  @Input() height = 300;
+  @Input() height: number | string = 300;
   @Input() tabSize = 4;
 
   public options = {
@@ -58,6 +58,10 @@ export class MonacoEditorComponent implements ControlValueAccessor, OnInit, OnCh
     protected languageService: LanguageService,
     protected appStateService: AppStateService,
   ) {
+  }
+
+  get heightStyle(): string {
+    return typeof this.height === 'number' ? `${this.height}px` : this.height;
   }
 
   ngOnInit() {


### PR DESCRIPTION
## Summary
- add a dedicated problem layout component and route wiring for problem detail views
- rebuild the problem page with a two-column LeetCode-style interface and refreshed styling
- extend the shared code editor to support inline usage and update monaco height handling plus translations

## Testing
- npm install --legacy-peer-deps
- npm run lint *(fails: lint target not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68ec0989f4dc832f9a7cd37249fed1fc