### PR TITLE
feat(arena): use kep-card wrapper and add translation

### DIFF
--- a/src/app/i18n/en.ts
+++ b/src/app/i18n/en.ts
@@ -163,6 +163,7 @@ export const localeEn = {
   Losses: 'Losses',
   TournamentFinish: 'Tournament is over',
   TournamentStarts: 'Tournament starts',
+  TournamentEnds: 'Tournament ends',
   Rated: 'Rated',
   Now: 'Now',
   AverageRating: 'Average rating',

--- a/src/app/i18n/ru.ts
+++ b/src/app/i18n/ru.ts
@@ -163,6 +163,7 @@ export const localeRu = {
   Losses: 'Проигрыши',
   TournamentFinish: 'Турнир завершен',
   TournamentStarts: 'Турнир начнется',
+  TournamentEnds: 'Турнир закончится',
   Rated: 'Рейтинговый',
   Now: 'Сейчас',
   AverageRating: 'Средний рейтинг',

--- a/src/app/i18n/uz.ts
+++ b/src/app/i18n/uz.ts
@@ -163,6 +163,7 @@ export const localeUz = {
   Losses: 'Magʻlubiyatlar',
   TournamentFinish: 'Turnir yakunlandi',
   TournamentStarts: 'Turnir boshlanadi',
+  TournamentEnds: 'Turnir yakunlanadi',
   Rated: 'Reytingli',
   MaxRating: 'Eng yuqori reyting',
   Now: 'Hozir',

--- a/src/app/modules/arena/components/arena-card/arena-card.component.html
+++ b/src/app/modules/arena/components/arena-card/arena-card.component.html
@@ -1,4 +1,4 @@
-<div class="card">
+<kep-card>
   <div class="card-header">
     <div class="d-flex justify-content-between">
       <logo [size]="32"/>
@@ -53,4 +53,4 @@
       }
     </div>
   </div>
-</div>
+</kep-card>

--- a/src/app/modules/arena/components/arena-card/arena-card.component.ts
+++ b/src/app/modules/arena/components/arena-card/arena-card.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, Input, ViewEncapsulation } from '@angular/core';
 import { Arena } from '@arena/arena.models';
 import { TranslateModule } from '@ngx-translate/core';
 import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 import { DatePipe } from '@angular/common';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { ArenaService } from '@arena/arena.service';
@@ -13,6 +14,7 @@ import { LogoComponent } from "@shared/components/logo/logo.component";
   imports: [
     TranslateModule,
     KepIconComponent,
+    KepCardComponent,
     DatePipe,
     NgbTooltipModule,
     LogoComponent

--- a/src/app/modules/arena/pages/arena-tournament/arena-chapters/arena-chapters.component.html
+++ b/src/app/modules/arena/pages/arena-tournament/arena-chapters/arena-chapters.component.html
@@ -1,4 +1,4 @@
-<div class="card bg-arena">
+<kep-card customClass="bg-arena">
   <div class="card-header d-block text-center">
     <div class="card-title">
       <kep-icon name="chapters"/>
@@ -17,4 +17,4 @@
       >
     }
   </div>
-</div>
+</kep-card>

--- a/src/app/modules/arena/pages/arena-tournament/arena-chapters/arena-chapters.component.ts
+++ b/src/app/modules/arena/pages/arena-tournament/arena-chapters/arena-chapters.component.ts
@@ -3,6 +3,7 @@ import { Arena } from '@arena/arena.models';
 import { TranslateModule } from '@ngx-translate/core';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 
 @Component({
   selector: 'arena-chapters',
@@ -10,7 +11,8 @@ import { KepIconComponent } from '@shared/components/kep-icon/kep-icon.component
   imports: [
     TranslateModule,
     NgbTooltipModule,
-    KepIconComponent
+    KepIconComponent,
+    KepCardComponent
   ],
   templateUrl: './arena-chapters.component.html',
   styleUrl: './arena-chapters.component.scss'

--- a/src/app/modules/arena/pages/arena-tournament/arena-countdown/arena-countdown.component.html
+++ b/src/app/modules/arena/pages/arena-tournament/arena-countdown/arena-countdown.component.html
@@ -1,4 +1,4 @@
-<div class="card bg-arena">
+<kep-card customClass="bg-arena">
   <div class="card-body">
     <h4 class="mb-2 text-center">
       @if (arena.status == ArenaStatus.NotStarted) {
@@ -27,4 +27,4 @@
       </ng-template>
     </ngx-countdown>
   </div>
-</div>
+</kep-card>

--- a/src/app/modules/arena/pages/arena-tournament/arena-countdown/arena-countdown.component.ts
+++ b/src/app/modules/arena/pages/arena-tournament/arena-countdown/arena-countdown.component.ts
@@ -2,13 +2,15 @@ import { Component, Input, OnInit } from '@angular/core';
 import { CountdownComponent } from '@shared/third-part-modules/countdown/countdown.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { Arena, ArenaStatus } from '@arena/arena.models';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 
 @Component({
   selector: 'arena-countdown',
   standalone: true,
   imports: [
     CountdownComponent,
-    TranslateModule
+    TranslateModule,
+    KepCardComponent
   ],
   templateUrl: './arena-countdown.component.html',
   styleUrl: './arena-countdown.component.scss'

--- a/src/app/modules/arena/pages/arena-tournament/arena-info/arena-info.component.html
+++ b/src/app/modules/arena/pages/arena-tournament/arena-info/arena-info.component.html
@@ -1,4 +1,4 @@
-<div class="card bg-arena">
+<kep-card customClass="bg-arena">
   <div class="card-header d-flex justify-content-center align-items-center">
     <div class="card-title d-flex align-items-center">
       <kep-icon name="arena" type="duotone" size="large-1"/>
@@ -36,4 +36,4 @@
       }
     </div>
   }
-</div>
+</kep-card>

--- a/src/app/modules/arena/pages/arena-tournament/arena-info/arena-info.component.ts
+++ b/src/app/modules/arena/pages/arena-tournament/arena-info/arena-info.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, Input } from '@angular/core';
 import { Arena, ArenaStatus } from '@arena/arena.models';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { CoreCommonModule } from '@core/common.module';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 import { ArenaService } from '@arena/arena.service';
 
 @Component({
@@ -9,7 +10,8 @@ import { ArenaService } from '@arena/arena.service';
   standalone: true,
   imports: [
     NgbTooltipModule,
-    CoreCommonModule
+    CoreCommonModule,
+    KepCardComponent
   ],
   templateUrl: './arena-info.component.html',
   styleUrl: './arena-info.component.scss'

--- a/src/app/modules/arena/pages/arena-tournament/arena-statistics/arena-statistics.component.html
+++ b/src/app/modules/arena/pages/arena-tournament/arena-statistics/arena-statistics.component.html
@@ -1,4 +1,4 @@
-<div class="card bg-arena">
+<kep-card customClass="bg-arena">
   @if (isLoading) {
     <div [style.height.px]="165">
       <spinner color="var(--bs-warning)"/>
@@ -24,4 +24,4 @@
       </div>
     </div>
   }
-</div>
+</kep-card>

--- a/src/app/modules/arena/pages/arena-tournament/arena-statistics/arena-statistics.component.ts
+++ b/src/app/modules/arena/pages/arena-tournament/arena-statistics/arena-statistics.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, Input } from '@angular/core';
 import { Arena, ArenaStatistics } from '@arena/arena.models';
 import { CoreCommonModule } from '@core/common.module';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 import { BaseLoadComponent } from '@core/common';
 import { Observable } from 'rxjs';
 import { ArenaService } from '@arena/arena.service';
@@ -11,7 +12,8 @@ import { ArenaService } from '@arena/arena.service';
   standalone: true,
   imports: [
     CoreCommonModule,
-    NgbTooltipModule
+    NgbTooltipModule,
+    KepCardComponent
   ],
   templateUrl: './arena-statistics.component.html',
   styleUrl: './arena-statistics.component.scss'

--- a/src/app/modules/arena/pages/arena-tournament/arena-winners/arena-winners.component.html
+++ b/src/app/modules/arena/pages/arena-tournament/arena-winners/arena-winners.component.html
@@ -1,4 +1,4 @@
-<div class="card bg-arena">
+<kep-card customClass="bg-arena">
   @if (isLoading) {
     <div [style.height.px]="410">
       <spinner color="var(--bs-warning)"/>
@@ -21,4 +21,4 @@
       </div>
     </div>
   }
-</div>
+</kep-card>

--- a/src/app/modules/arena/pages/arena-tournament/arena-winners/arena-winners.component.ts
+++ b/src/app/modules/arena/pages/arena-tournament/arena-winners/arena-winners.component.ts
@@ -8,6 +8,7 @@ import { ArenaService } from '@arena/arena.service';
 import { BaseLoadComponent } from '@core/common';
 import { Observable } from 'rxjs';
 import { SpinnerComponent } from '@shared/components/spinner/spinner.component';
+import { KepCardComponent } from '@shared/components/kep-card/kep-card.component';
 import { map } from 'rxjs/operators';
 
 @Component({
@@ -15,7 +16,8 @@ import { map } from 'rxjs/operators';
   standalone: true,
   imports: [
     ArenaPlayerStatisticsComponent,
-    SpinnerComponent
+    SpinnerComponent,
+    KepCardComponent
   ],
   templateUrl: './arena-winners.component.html',
   styleUrl: './arena-winners.component.scss',


### PR DESCRIPTION
## Summary
- wrap arena module templates with the shared `<kep-card>` component and update their module imports
- add the missing `TournamentEnds` translation to the English, Russian, and Uzbek locale files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb40316474832f93b4fd99f7169024