### PR TITLE
Ensure arena tournament view triggers manual change detection

### DIFF
--- a/src/app/modules/arena/pages/arena-tournament/arena-info/arena-info.component.ts
+++ b/src/app/modules/arena/pages/arena-tournament/arena-info/arena-info.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Input } from '@angular/core';
+import { ChangeDetectorRef, Component, inject, Input } from '@angular/core';
 import { Arena, ArenaStatus } from '@arena/arena.models';
 import { NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { CoreCommonModule } from '@core/common.module';
@@ -22,11 +22,14 @@ export class ArenaInfoComponent {
   protected readonly ArenaStatus = ArenaStatus;
 
   private service = inject(ArenaService);
+  private cdr = inject(ChangeDetectorRef);
 
   register() {
     this.service.arenaRegistration(this.arena.id).subscribe(() => {
       this.arena.isRegistrated = true;
       this.arena.pause = true;
+      this.cdr.markForCheck();
+      this.cdr.detectChanges();
     });
   }
 }

--- a/src/app/modules/arena/pages/arena-tournament/arena-tournament.component.ts
+++ b/src/app/modules/arena/pages/arena-tournament/arena-tournament.component.ts
@@ -67,6 +67,8 @@ export class ArenaTournamentComponent extends BaseComponent implements OnInit {
     this.route.data.subscribe(({arena}) => {
       this.arena = arena;
       this.titleService.updateTitle(this.route, {arenaTitle: arena.title});
+      this.cdr.markForCheck();
+      this.cdr.detectChanges();
       if (this.arena.status === ArenaStatus.Already) {
         this._intervalId = setInterval(
           () => {
@@ -89,12 +91,16 @@ export class ArenaTournamentComponent extends BaseComponent implements OnInit {
 
   updateRemainingTime() {
     this.remainingTime = new Date(this.arena.finishTime).valueOf() - Date.now();
+    this.cdr.markForCheck();
+    this.cdr.detectChanges();
   }
 
   loadArenaPlayerStatistics(arenaPlayerUsername: string) {
     this.service.getArenaPlayerStatistics(this.arena.id, arenaPlayerUsername).subscribe(
       (result: any) => {
         this.arenaPlayerStatistics = toArenaPlayerStatistics(result);
+        this.cdr.markForCheck();
+        this.cdr.detectChanges();
       }
     );
   }
@@ -115,12 +121,16 @@ export class ArenaTournamentComponent extends BaseComponent implements OnInit {
   arenaPause() {
     this.service.arenaPause(this.arena.id).subscribe(() => {
       this.arena.pause = true;
+      this.cdr.markForCheck();
+      this.cdr.detectChanges();
     });
   }
 
   arenaStart() {
     this.service.arenaStart(this.arena.id).subscribe(() => {
       this.arena.pause = false;
+      this.cdr.markForCheck();
+      this.cdr.detectChanges();
     });
   }
 


### PR DESCRIPTION
## Summary
- trigger change detection after loading arena data and player statistics on the tournament page
- update the arena info registration handler to request a view refresh after state changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb4c9e72a8832fbfa25af4cdcb2c83